### PR TITLE
feat: implement Financial Reports module (Modul 18)

### DIFF
--- a/app/Actions/ReportConfigurations/ExportReportConfigurationsAction.php
+++ b/app/Actions/ReportConfigurations/ExportReportConfigurationsAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions\ReportConfigurations;
+
+use App\Actions\Concerns\ConfiguredTransactionExportAction;
+use App\Exports\ReportConfigurationExport;
+
+class ExportReportConfigurationsAction extends ConfiguredTransactionExportAction
+{
+    protected function filenamePrefix(): string
+    {
+        return 'report_configurations';
+    }
+
+    protected function makeExport(array $filters): object
+    {
+        return new ReportConfigurationExport($filters);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function filterDefaults(): array
+    {
+        return [
+            'search' => null,
+            'report_type' => null,
+            'is_active' => null,
+            'sort_by' => null,
+            'sort_direction' => null,
+        ];
+    }
+}

--- a/app/Actions/ReportConfigurations/GetReportConfigurationByTypeAction.php
+++ b/app/Actions/ReportConfigurations/GetReportConfigurationByTypeAction.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Actions\ReportConfigurations;
+
+use App\Models\ReportConfiguration;
+
+class GetReportConfigurationByTypeAction
+{
+    /**
+     * @return array{id: int, code: string, name: string, description: ?string, report_type: string, sections: array<int, array<string, mixed>>}|null
+     */
+    public function execute(string $reportType): ?array
+    {
+        /** @var ReportConfiguration|null $config */
+        $config = ReportConfiguration::query()
+            ->active()
+            ->ofType($reportType)
+            ->with([
+                'sections' => fn ($query) => $query->where('is_active', true)->orderBy('sort_order'),
+            ])
+            ->orderBy('id')
+            ->first();
+
+        if ($config === null) {
+            return null;
+        }
+
+        return [
+            'id' => $config->id,
+            'code' => $config->code,
+            'name' => $config->name,
+            'description' => $config->description,
+            'report_type' => $config->report_type,
+            'sections' => $config->sections->map(fn ($section): array => [
+                'id' => $section->id,
+                'parent_id' => $section->parent_id,
+                'code' => $section->code,
+                'name' => $section->name,
+                'sort_order' => $section->sort_order,
+                'section_type' => $section->section_type,
+                'account_type_filter' => $section->account_type_filter,
+                'account_sub_type_filter' => $section->account_sub_type_filter,
+                'sign_convention' => $section->sign_convention,
+                'formula' => $section->formula,
+            ])->values()->all(),
+        ];
+    }
+}

--- a/app/Actions/ReportConfigurations/IndexReportConfigurationsAction.php
+++ b/app/Actions/ReportConfigurations/IndexReportConfigurationsAction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\ReportConfigurations;
+
+use App\Actions\Concerns\InteractsWithIndexRequest;
+use App\Domain\ReportConfigurations\ReportConfigurationFilterService;
+use App\Http\Requests\ReportConfigurations\IndexReportConfigurationRequest;
+use App\Models\ReportConfiguration;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class IndexReportConfigurationsAction
+{
+    use InteractsWithIndexRequest;
+
+    public function __construct(private ReportConfigurationFilterService $filterService) {}
+
+    public function execute(IndexReportConfigurationRequest $request): LengthAwarePaginator
+    {
+        $query = ReportConfiguration::query()->with(['creator', 'sections']);
+
+        return $this->handleIndexRequest(
+            $request,
+            $query,
+            $this->filterService,
+            ['code', 'name', 'description'],
+            ['report_type', 'is_active'],
+            'name',
+            ['code', 'name', 'report_type', 'is_active', 'created_at'],
+        );
+    }
+}

--- a/app/Domain/ReportConfigurations/ReportConfigurationFilterService.php
+++ b/app/Domain/ReportConfigurations/ReportConfigurationFilterService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\ReportConfigurations;
+
+use App\Domain\Concerns\BaseFilterService;
+use Illuminate\Database\Eloquent\Builder;
+
+class ReportConfigurationFilterService
+{
+    use BaseFilterService;
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    public function applyAdvancedFilters(Builder $query, array $filters): void
+    {
+        $this->applyConfiguredFilters(
+            $query,
+            $filters,
+            [
+                'report_type' => 'report_type',
+                'is_active' => 'is_active',
+            ],
+        );
+    }
+}

--- a/app/Exports/ReportConfigurationExport.php
+++ b/app/Exports/ReportConfigurationExport.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Exports;
+
+use App\Exports\Concerns\InteractsWithExportFilters;
+use App\Models\ReportConfiguration;
+use Illuminate\Database\Eloquent\Builder;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithStyles;
+
+class ReportConfigurationExport implements FromQuery, ShouldAutoSize, WithHeadings, WithMapping, WithStyles
+{
+    use InteractsWithExportFilters;
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    public function __construct(protected array $filters = []) {}
+
+    public function query(): Builder
+    {
+        $query = ReportConfiguration::query()->with(['creator', 'sections']);
+
+        $this->applyConfiguredFilters(
+            $query,
+            $this->filters,
+            ['code', 'name', 'description'],
+            [
+                'report_type' => 'report_type',
+                'is_active' => 'is_active',
+            ],
+        );
+
+        return $query->orderBy('name');
+    }
+
+    public function headings(): array
+    {
+        return $this->exportHeadings($this->columns());
+    }
+
+    public function map($item): array
+    {
+        return $this->mapExportRow($item, $this->columns());
+    }
+
+    /**
+     * @return array<string, callable(mixed): mixed>
+     */
+    protected function columns(): array
+    {
+        return [
+            'ID' => fn (ReportConfiguration $item): mixed => $item->id,
+            'Code' => fn (ReportConfiguration $item): mixed => $item->code,
+            'Name' => fn (ReportConfiguration $item): mixed => $item->name,
+            'Report Type' => fn (ReportConfiguration $item): mixed => $item->report_type,
+            'Description' => fn (ReportConfiguration $item): mixed => $item->description,
+            'Sections' => fn (ReportConfiguration $item): mixed => $item->sections->count(),
+            'Active' => fn (ReportConfiguration $item): mixed => $item->is_active ? 'Yes' : 'No',
+            'Created By' => fn (ReportConfiguration $item): mixed => $this->relatedAttribute($item, 'creator', 'name'),
+            'Created At' => fn (ReportConfiguration $item): mixed => $this->formatIso8601($item->created_at),
+        ];
+    }
+}

--- a/app/Http/Controllers/ReportConfigurationController.php
+++ b/app/Http/Controllers/ReportConfigurationController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\ReportConfigurations\ExportReportConfigurationsAction;
+use App\Actions\ReportConfigurations\IndexReportConfigurationsAction;
+use App\Http\Controllers\Concerns\StoresItemsInTransaction;
+use App\Http\Requests\ReportConfigurations\ExportReportConfigurationRequest;
+use App\Http\Requests\ReportConfigurations\IndexReportConfigurationRequest;
+use App\Http\Requests\ReportConfigurations\StoreReportConfigurationRequest;
+use App\Http\Requests\ReportConfigurations\UpdateReportConfigurationRequest;
+use App\Http\Resources\ReportConfigurations\ReportConfigurationCollection;
+use App\Http\Resources\ReportConfigurations\ReportConfigurationResource;
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Http\JsonResponse;
+
+class ReportConfigurationController extends Controller
+{
+    use StoresItemsInTransaction;
+
+    public function index(IndexReportConfigurationRequest $request, IndexReportConfigurationsAction $action): JsonResponse
+    {
+        return (new ReportConfigurationCollection($action->execute($request)))->response();
+    }
+
+    public function store(StoreReportConfigurationRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $sections = $data['sections'] ?? [];
+        unset($data['sections']);
+        $data['created_by'] = auth()->id();
+
+        $config = $this->storeWithSyncedItems(
+            $data,
+            $sections,
+            fn (array $attributes): ReportConfiguration => ReportConfiguration::create($attributes),
+            fn (ReportConfiguration $config): null => null,
+            fn (ReportConfiguration $config, array $items): null => $this->syncSections($config, $items),
+        );
+
+        return (new ReportConfigurationResource($config->load(['creator', 'sections'])))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(ReportConfiguration $reportConfiguration): JsonResponse
+    {
+        return (new ReportConfigurationResource($reportConfiguration->load(['creator', 'sections'])))->response();
+    }
+
+    public function update(UpdateReportConfigurationRequest $request, ReportConfiguration $reportConfiguration): JsonResponse
+    {
+        $data = $request->validated();
+        $sections = $data['sections'] ?? null;
+        unset($data['sections']);
+
+        $this->updateWithSyncedItems(
+            $reportConfiguration,
+            $data,
+            $sections,
+            fn (array $attributes): array => $attributes,
+            fn (ReportConfiguration $config, array $items): null => $this->syncSections($config, $items),
+        );
+
+        return (new ReportConfigurationResource($reportConfiguration->refresh()->load(['creator', 'sections'])))->response();
+    }
+
+    public function destroy(ReportConfiguration $reportConfiguration): JsonResponse
+    {
+        return $this->destroyModel($reportConfiguration);
+    }
+
+    public function export(ExportReportConfigurationRequest $request, ExportReportConfigurationsAction $action): JsonResponse
+    {
+        return $action->execute($request);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    private function syncSections(ReportConfiguration $config, array $items): null
+    {
+        $config->sections()->delete();
+
+        $codeToId = [];
+
+        foreach ($items as $index => $item) {
+            $attributes = [
+                'code' => $item['code'],
+                'name' => $item['name'],
+                'sort_order' => $item['sort_order'] ?? ($index + 1) * 10,
+                'section_type' => $item['section_type'],
+                'account_type_filter' => $item['account_type_filter'] ?? null,
+                'account_sub_type_filter' => $item['account_sub_type_filter'] ?? null,
+                'sign_convention' => $item['sign_convention'] ?? ReportSection::SIGN_NORMAL,
+                'formula' => $item['formula'] ?? null,
+                'is_active' => $item['is_active'] ?? true,
+                'parent_id' => null,
+            ];
+
+            $parentCode = $item['parent_code'] ?? null;
+            if ($parentCode !== null && isset($codeToId[$parentCode])) {
+                $attributes['parent_id'] = $codeToId[$parentCode];
+            }
+
+            /** @var ReportSection $section */
+            $section = $config->sections()->create($attributes);
+            $codeToId[$item['code']] = $section->id;
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\ReportConfigurations\GetReportConfigurationByTypeAction;
 use App\Http\Controllers\Concerns\InteractsWithFinancialReportRequest;
+use App\Models\ReportConfiguration;
 use App\Services\FinancialReportService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -12,7 +14,8 @@ class ReportController extends Controller
     use InteractsWithFinancialReportRequest;
 
     public function __construct(
-        protected FinancialReportService $reportService
+        protected FinancialReportService $reportService,
+        protected GetReportConfigurationByTypeAction $configurationResolver,
     ) {}
 
     public function trialBalance(Request $request): JsonResponse
@@ -28,6 +31,7 @@ class ReportController extends Controller
             'fiscalYears' => $fiscalYears,
             'selectedYearId' => (int) $selectedYearId,
             'report' => $report,
+            'configuration' => $this->configurationResolver->execute(ReportConfiguration::TYPE_TRIAL_BALANCE),
         ]);
     }
 
@@ -52,6 +56,7 @@ class ReportController extends Controller
             'selectedYearId' => (int) $selectedYearId,
             'comparisonYearId' => $comparisonYearId ? (int) $comparisonYearId : null,
             'report' => $report,
+            'configuration' => $this->configurationResolver->execute(ReportConfiguration::TYPE_BALANCE_SHEET),
         ]);
     }
 
@@ -76,6 +81,7 @@ class ReportController extends Controller
             'selectedYearId' => (int) $selectedYearId,
             'comparisonYearId' => $comparisonYearId ? (int) $comparisonYearId : null,
             'report' => $report,
+            'configuration' => $this->configurationResolver->execute(ReportConfiguration::TYPE_INCOME_STATEMENT),
         ]);
     }
 
@@ -92,6 +98,7 @@ class ReportController extends Controller
             'fiscalYears' => $fiscalYears,
             'selectedYearId' => (int) $selectedYearId,
             'report' => $report,
+            'configuration' => $this->configurationResolver->execute(ReportConfiguration::TYPE_CASH_FLOW),
         ]);
     }
 

--- a/app/Http/Requests/ReportConfigurations/ExportReportConfigurationRequest.php
+++ b/app/Http/Requests/ReportConfigurations/ExportReportConfigurationRequest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Requests\ReportConfigurations;
+
+class ExportReportConfigurationRequest extends IndexReportConfigurationRequest
+{
+    // Intentionally empty. Behavior is inherited from the base class.
+}

--- a/app/Http/Requests/ReportConfigurations/IndexReportConfigurationRequest.php
+++ b/app/Http/Requests/ReportConfigurations/IndexReportConfigurationRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\ReportConfigurations;
+
+use App\Http\Requests\BaseListingRequest;
+use App\Models\ReportConfiguration;
+use Illuminate\Validation\Rule;
+
+class IndexReportConfigurationRequest extends BaseListingRequest
+{
+    public function rules(): array
+    {
+        return array_merge(
+            $this->searchRules(),
+            [
+                'report_type' => ['nullable', Rule::in(ReportConfiguration::TYPES)],
+                'is_active' => ['nullable', 'boolean'],
+            ],
+            $this->listingSortRules('code,name,report_type,is_active,created_at'),
+            $this->paginationRules(),
+        );
+    }
+}

--- a/app/Http/Requests/ReportConfigurations/StoreReportConfigurationRequest.php
+++ b/app/Http/Requests/ReportConfigurations/StoreReportConfigurationRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\ReportConfigurations;
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreReportConfigurationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('report_configurations', 'code')->ignore($this->route('report_configuration')),
+            ],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'report_type' => ['required', Rule::in(ReportConfiguration::TYPES)],
+            'layout_config' => ['nullable', 'array'],
+            'is_active' => ['boolean'],
+            'sections' => ['nullable', 'array'],
+            'sections.*.code' => ['required_with:sections', 'string', 'max:255'],
+            'sections.*.name' => ['required_with:sections', 'string', 'max:255'],
+            'sections.*.sort_order' => ['nullable', 'integer', 'min:0'],
+            'sections.*.section_type' => ['required_with:sections', Rule::in(ReportSection::SECTION_TYPES)],
+            'sections.*.account_type_filter' => ['nullable', 'string', 'max:30'],
+            'sections.*.account_sub_type_filter' => ['nullable', 'string', 'max:50'],
+            'sections.*.sign_convention' => ['nullable', Rule::in(ReportSection::SIGN_CONVENTIONS)],
+            'sections.*.formula' => ['nullable', 'string', 'max:255'],
+            'sections.*.is_active' => ['boolean'],
+            'sections.*.parent_code' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/ReportConfigurations/UpdateReportConfigurationRequest.php
+++ b/app/Http/Requests/ReportConfigurations/UpdateReportConfigurationRequest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Requests\ReportConfigurations;
+
+class UpdateReportConfigurationRequest extends StoreReportConfigurationRequest
+{
+    // Intentionally empty. Behavior is inherited from the base class.
+}

--- a/app/Http/Resources/ReportConfigurations/ReportConfigurationCollection.php
+++ b/app/Http/Resources/ReportConfigurations/ReportConfigurationCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\ReportConfigurations;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ReportConfigurationCollection extends ResourceCollection
+{
+    public $collects = ReportConfigurationResource::class;
+
+    public function toArray(Request $request): array
+    {
+        return ['data' => $this->collection];
+    }
+}

--- a/app/Http/Resources/ReportConfigurations/ReportConfigurationResource.php
+++ b/app/Http/Resources/ReportConfigurations/ReportConfigurationResource.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Resources\ReportConfigurations;
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @property ReportConfiguration $resource */
+class ReportConfigurationResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'code' => $this->resource->code,
+            'name' => $this->resource->name,
+            'description' => $this->resource->description,
+            'report_type' => $this->resource->report_type,
+            'layout_config' => $this->resource->layout_config,
+            'is_active' => $this->resource->is_active,
+            'sections' => $this->whenLoaded('sections', fn () => $this->resource->sections
+                ->map(fn (ReportSection $section): array => [
+                    'id' => $section->id,
+                    'parent_id' => $section->parent_id,
+                    'code' => $section->code,
+                    'name' => $section->name,
+                    'sort_order' => $section->sort_order,
+                    'section_type' => $section->section_type,
+                    'account_type_filter' => $section->account_type_filter,
+                    'account_sub_type_filter' => $section->account_sub_type_filter,
+                    'sign_convention' => $section->sign_convention,
+                    'formula' => $section->formula,
+                    'is_active' => $section->is_active,
+                ])->values()->all()),
+            'created_by' => $this->whenLoaded('creator', fn () => [
+                'id' => $this->resource->created_by,
+                'name' => $this->resource->creator?->name,
+            ]),
+            'created_at' => $this->resource->created_at?->toIso8601String(),
+            'updated_at' => $this->resource->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/ReportConfiguration.php
+++ b/app/Models/ReportConfiguration.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $code
+ * @property string $name
+ * @property string|null $description
+ * @property string $report_type
+ * @property array<string, mixed>|null $layout_config
+ * @property bool $is_active
+ * @property int|null $created_by
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\User|null $creator
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\ReportSection> $sections
+ * @property-read int|null $sections_count
+ *
+ * @method static \Database\Factories\ReportConfigurationFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ReportConfiguration active()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ReportConfiguration ofType(string $type)
+ *
+ * @mixin \Eloquent
+ */
+class ReportConfiguration extends Model
+{
+    /** @use HasFactory<\Database\Factories\ReportConfigurationFactory> */
+    use HasFactory;
+
+    public const TYPE_BALANCE_SHEET = 'balance_sheet';
+
+    public const TYPE_INCOME_STATEMENT = 'income_statement';
+
+    public const TYPE_CASH_FLOW = 'cash_flow';
+
+    public const TYPE_TRIAL_BALANCE = 'trial_balance';
+
+    public const TYPE_CUSTOM = 'custom';
+
+    public const TYPES = [
+        self::TYPE_BALANCE_SHEET,
+        self::TYPE_INCOME_STATEMENT,
+        self::TYPE_CASH_FLOW,
+        self::TYPE_TRIAL_BALANCE,
+        self::TYPE_CUSTOM,
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'code',
+        'name',
+        'description',
+        'report_type',
+        'layout_config',
+        'is_active',
+        'created_by',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'layout_config' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function sections(): HasMany
+    {
+        return $this->hasMany(ReportSection::class)->orderBy('sort_order');
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function scopeOfType($query, string $type)
+    {
+        return $query->where('report_type', $type);
+    }
+}

--- a/app/Models/ReportSection.php
+++ b/app/Models/ReportSection.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $report_configuration_id
+ * @property int|null $parent_id
+ * @property string $code
+ * @property string $name
+ * @property int $sort_order
+ * @property string $section_type
+ * @property string|null $account_type_filter
+ * @property string|null $account_sub_type_filter
+ * @property string $sign_convention
+ * @property string|null $formula
+ * @property bool $is_active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\ReportConfiguration $reportConfiguration
+ * @property-read \App\Models\ReportSection|null $parent
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\ReportSection> $children
+ * @property-read int|null $children_count
+ *
+ * @method static \Database\Factories\ReportSectionFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ReportSection active()
+ *
+ * @mixin \Eloquent
+ */
+class ReportSection extends Model
+{
+    /** @use HasFactory<\Database\Factories\ReportSectionFactory> */
+    use HasFactory;
+
+    public const TYPE_HEADER = 'header';
+
+    public const TYPE_DETAIL = 'detail';
+
+    public const TYPE_SUBTOTAL = 'subtotal';
+
+    public const TYPE_TOTAL = 'total';
+
+    public const TYPE_SEPARATOR = 'separator';
+
+    public const SECTION_TYPES = [
+        self::TYPE_HEADER,
+        self::TYPE_DETAIL,
+        self::TYPE_SUBTOTAL,
+        self::TYPE_TOTAL,
+        self::TYPE_SEPARATOR,
+    ];
+
+    public const SIGN_NORMAL = 'normal';
+
+    public const SIGN_REVERSED = 'reversed';
+
+    public const SIGN_CONVENTIONS = [
+        self::SIGN_NORMAL,
+        self::SIGN_REVERSED,
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'report_configuration_id',
+        'parent_id',
+        'code',
+        'name',
+        'sort_order',
+        'section_type',
+        'account_type_filter',
+        'account_sub_type_filter',
+        'sign_convention',
+        'formula',
+        'is_active',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'sort_order' => 'integer',
+        'is_active' => 'boolean',
+    ];
+
+    public function reportConfiguration(): BelongsTo
+    {
+        return $this->belongsTo(ReportConfiguration::class);
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id')->orderBy('sort_order');
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/database/factories/ReportConfigurationFactory.php
+++ b/database/factories/ReportConfigurationFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ReportConfiguration;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ReportConfiguration>
+ */
+class ReportConfigurationFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $type = $this->faker->randomElement(ReportConfiguration::TYPES);
+        $slug = str_replace('_', '-', $type) . '-' . $this->faker->unique()->numberBetween(1000, 999999);
+
+        return [
+            'code' => $slug,
+            'name' => $this->faker->sentence(3),
+            'description' => $this->faker->optional()->sentence(),
+            'report_type' => $type,
+            'layout_config' => null,
+            'is_active' => true,
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(['is_active' => false]);
+    }
+
+    public function ofType(string $type): static
+    {
+        return $this->state(['report_type' => $type]);
+    }
+}

--- a/database/factories/ReportSectionFactory.php
+++ b/database/factories/ReportSectionFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ReportSection>
+ */
+class ReportSectionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'report_configuration_id' => ReportConfiguration::factory(),
+            'parent_id' => null,
+            'code' => $this->faker->unique()->slug(2),
+            'name' => $this->faker->words(3, true),
+            'sort_order' => $this->faker->numberBetween(0, 100),
+            'section_type' => $this->faker->randomElement(ReportSection::SECTION_TYPES),
+            'account_type_filter' => null,
+            'account_sub_type_filter' => null,
+            'sign_convention' => ReportSection::SIGN_NORMAL,
+            'formula' => null,
+            'is_active' => true,
+        ];
+    }
+
+    public function header(): static
+    {
+        return $this->state(['section_type' => ReportSection::TYPE_HEADER]);
+    }
+
+    public function detail(string $type, ?string $subType = null): static
+    {
+        return $this->state([
+            'section_type' => ReportSection::TYPE_DETAIL,
+            'account_type_filter' => $type,
+            'account_sub_type_filter' => $subType,
+        ]);
+    }
+
+    public function subtotal(): static
+    {
+        return $this->state(['section_type' => ReportSection::TYPE_SUBTOTAL]);
+    }
+
+    public function total(): static
+    {
+        return $this->state(['section_type' => ReportSection::TYPE_TOTAL]);
+    }
+
+    public function reversed(): static
+    {
+        return $this->state(['sign_convention' => ReportSection::SIGN_REVERSED]);
+    }
+}

--- a/database/migrations/2026_05_13_000100_create_report_configurations_table.php
+++ b/database/migrations/2026_05_13_000100_create_report_configurations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('report_configurations', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('report_type', 30);
+            $table->json('layout_config')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index('report_type');
+            $table->index('is_active');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('report_configurations');
+    }
+};

--- a/database/migrations/2026_05_13_000200_create_report_sections_table.php
+++ b/database/migrations/2026_05_13_000200_create_report_sections_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('report_sections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('report_configuration_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('parent_id')->nullable()->constrained('report_sections')->nullOnDelete();
+            $table->string('code');
+            $table->string('name');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->string('section_type', 20);
+            $table->string('account_type_filter', 30)->nullable();
+            $table->string('account_sub_type_filter', 50)->nullable();
+            $table->string('sign_convention', 20)->default('normal');
+            $table->string('formula')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['report_configuration_id', 'code'], 'report_sections_config_code_unique');
+            $table->index(['report_configuration_id', 'sort_order']);
+            $table->index('parent_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('report_sections');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -168,6 +168,7 @@ class DatabaseSeeder extends Seeder
             StockMovementSampleDataSeeder::class,
             ArSampleDataSeeder::class,
             GlExtendedSampleDataSeeder::class,
+            ReportConfigurationSeeder::class,
         ]);
 
         // Assign all permissions to sample users for easy testing

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -99,6 +99,19 @@ class MenuSeeder extends Seeder
                         'url' => 'posting-journals',
                         'child' => [],
                     ],
+                    [
+                        'name' => 'report_configuration',
+                        'display_name' => 'Report Configuration',
+                        'permissions' => [
+                            'report_configuration',
+                            'report_configuration.create',
+                            'report_configuration.edit',
+                            'report_configuration.delete',
+                        ],
+                        'icon' => 'Settings',
+                        'url' => 'report-configurations',
+                        'child' => [],
+                    ],
                 ],
             ],
             [

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -341,6 +341,27 @@ class PermissionSeeder extends Seeder
                 'child' => [],
             ],
             [
+                'name' => 'report_configuration',
+                'display_name' => 'Report Configuration',
+                'child' => [
+                    [
+                        'name' => 'report_configuration.create',
+                        'display_name' => 'Create Report Configuration',
+                        'child' => [],
+                    ],
+                    [
+                        'name' => 'report_configuration.edit',
+                        'display_name' => 'Edit Report Configuration',
+                        'child' => [],
+                    ],
+                    [
+                        'name' => 'report_configuration.delete',
+                        'display_name' => 'Delete Report Configuration',
+                        'child' => [],
+                    ],
+                ],
+            ],
+            [
                 'name' => 'asset',
                 'display_name' => 'Asset',
                 'child' => [

--- a/database/seeders/ReportConfigurationSeeder.php
+++ b/database/seeders/ReportConfigurationSeeder.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Database\Seeder;
+
+class ReportConfigurationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->seedBalanceSheet();
+        $this->seedIncomeStatement();
+        $this->seedCashFlow();
+        $this->seedTrialBalance();
+    }
+
+    private function seedBalanceSheet(): void
+    {
+        $config = ReportConfiguration::updateOrCreate(
+            ['code' => 'balance_sheet'],
+            [
+                'name' => 'Balance Sheet',
+                'description' => 'Posisi keuangan perusahaan pada titik waktu tertentu (Aset = Liabilitas + Ekuitas).',
+                'report_type' => ReportConfiguration::TYPE_BALANCE_SHEET,
+                'is_active' => true,
+            ]
+        );
+
+        $sections = [
+            ['assets_header', 'ASET', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['current_assets', 'Aset Lancar', ReportSection::TYPE_DETAIL, 'asset', 'current_asset', null, null],
+            ['fixed_assets', 'Aset Tetap', ReportSection::TYPE_DETAIL, 'asset', 'fixed_asset', null, null],
+            ['other_assets', 'Aset Lainnya', ReportSection::TYPE_DETAIL, 'asset', 'other_asset', null, null],
+            ['total_assets', 'TOTAL ASET', ReportSection::TYPE_TOTAL, 'asset', null, null, null],
+
+            ['liabilities_header', 'KEWAJIBAN', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['current_liabilities', 'Kewajiban Lancar', ReportSection::TYPE_DETAIL, 'liability', 'current_liability', null, null],
+            ['long_term_liabilities', 'Kewajiban Jangka Panjang', ReportSection::TYPE_DETAIL, 'liability', 'long_term_liability', null, null],
+            ['total_liabilities', 'TOTAL KEWAJIBAN', ReportSection::TYPE_TOTAL, 'liability', null, null, null],
+
+            ['equity_header', 'EKUITAS', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['paid_in_capital', 'Modal Disetor', ReportSection::TYPE_DETAIL, 'equity', 'paid_in_capital', null, null],
+            ['retained_earnings', 'Laba Ditahan', ReportSection::TYPE_DETAIL, 'equity', 'retained_earnings', null, null],
+            ['current_year_earnings', 'Laba Bersih Tahun Berjalan', ReportSection::TYPE_DETAIL, null, null, null, '{revenue} - {expense}'],
+            ['total_equity', 'TOTAL EKUITAS', ReportSection::TYPE_TOTAL, 'equity', null, null, null],
+
+            ['total_liab_equity', 'TOTAL KEWAJIBAN + EKUITAS', ReportSection::TYPE_TOTAL, null, null, null, '{total_liabilities} + {total_equity}'],
+        ];
+
+        $this->seedSections($config, $sections);
+    }
+
+    private function seedIncomeStatement(): void
+    {
+        $config = ReportConfiguration::updateOrCreate(
+            ['code' => 'income_statement'],
+            [
+                'name' => 'Income Statement',
+                'description' => 'Kinerja keuangan selama periode tertentu (Pendapatan - Beban = Laba/Rugi).',
+                'report_type' => ReportConfiguration::TYPE_INCOME_STATEMENT,
+                'is_active' => true,
+            ]
+        );
+
+        $sections = [
+            ['revenue_header', 'PENDAPATAN', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['operating_revenue', 'Pendapatan Operasional', ReportSection::TYPE_DETAIL, 'revenue', 'operating_revenue', null, null],
+            ['non_operating_revenue', 'Pendapatan Lain-lain', ReportSection::TYPE_DETAIL, 'revenue', 'non_operating_revenue', null, null],
+            ['total_revenue', 'TOTAL PENDAPATAN', ReportSection::TYPE_SUBTOTAL, 'revenue', null, null, null],
+
+            ['cogs_header', 'HARGA POKOK PENJUALAN', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['cost_of_goods_sold', 'Harga Pokok Penjualan', ReportSection::TYPE_DETAIL, 'expense', 'cost_of_goods_sold', null, null],
+            ['gross_profit', 'LABA KOTOR', ReportSection::TYPE_SUBTOTAL, null, null, null, '{total_revenue} - {cost_of_goods_sold}'],
+
+            ['operating_expense_header', 'BEBAN OPERASIONAL', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['operating_expense', 'Beban Operasional', ReportSection::TYPE_DETAIL, 'expense', 'operating_expense', null, null],
+            ['depreciation_expense', 'Beban Penyusutan', ReportSection::TYPE_DETAIL, 'expense', 'depreciation_expense', null, null],
+            ['operating_income', 'LABA OPERASIONAL', ReportSection::TYPE_SUBTOTAL, null, null, null, '{gross_profit} - {operating_expense} - {depreciation_expense}'],
+
+            ['non_operating_expense_header', 'BEBAN LAIN-LAIN', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['non_operating_expense', 'Beban Lain-lain', ReportSection::TYPE_DETAIL, 'expense', 'non_operating_expense', null, null],
+            ['income_before_tax', 'LABA SEBELUM PAJAK', ReportSection::TYPE_SUBTOTAL, null, null, null, '{operating_income} - {non_operating_expense}'],
+
+            ['tax_expense', 'Beban Pajak', ReportSection::TYPE_DETAIL, 'expense', 'tax_expense', null, null],
+            ['net_income', 'LABA BERSIH', ReportSection::TYPE_TOTAL, null, null, null, '{income_before_tax} - {tax_expense}'],
+        ];
+
+        $this->seedSections($config, $sections);
+    }
+
+    private function seedCashFlow(): void
+    {
+        $config = ReportConfiguration::updateOrCreate(
+            ['code' => 'cash_flow'],
+            [
+                'name' => 'Cash Flow Statement',
+                'description' => 'Pergerakan kas masuk dan keluar (metode tidak langsung) selama periode tertentu.',
+                'report_type' => ReportConfiguration::TYPE_CASH_FLOW,
+                'is_active' => true,
+            ]
+        );
+
+        $sections = [
+            ['operating_header', 'ARUS KAS DARI AKTIVITAS OPERASIONAL', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['net_income_source', 'Laba Bersih', ReportSection::TYPE_DETAIL, null, null, null, '{net_income}'],
+            ['depreciation_addback', 'Penyusutan', ReportSection::TYPE_DETAIL, 'expense', 'depreciation_expense', ReportSection::SIGN_REVERSED, null],
+            ['working_capital_changes', 'Perubahan Modal Kerja', ReportSection::TYPE_DETAIL, null, null, null, null],
+            ['operating_cash_flow', 'Arus Kas Bersih dari Operasional', ReportSection::TYPE_SUBTOTAL, null, null, null, '{net_income_source} + {depreciation_addback} + {working_capital_changes}'],
+
+            ['investing_header', 'ARUS KAS DARI AKTIVITAS INVESTASI', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['fixed_asset_activity', 'Aktivitas Aset Tetap', ReportSection::TYPE_DETAIL, 'asset', 'fixed_asset', ReportSection::SIGN_REVERSED, null],
+            ['investing_cash_flow', 'Arus Kas Bersih dari Investasi', ReportSection::TYPE_SUBTOTAL, null, null, null, '{fixed_asset_activity}'],
+
+            ['financing_header', 'ARUS KAS DARI AKTIVITAS PENDANAAN', ReportSection::TYPE_HEADER, null, null, null, null],
+            ['long_term_debt_activity', 'Pinjaman Jangka Panjang', ReportSection::TYPE_DETAIL, 'liability', 'long_term_liability', null, null],
+            ['equity_activity', 'Modal Disetor', ReportSection::TYPE_DETAIL, 'equity', 'paid_in_capital', null, null],
+            ['financing_cash_flow', 'Arus Kas Bersih dari Pendanaan', ReportSection::TYPE_SUBTOTAL, null, null, null, '{long_term_debt_activity} + {equity_activity}'],
+
+            ['net_change', 'KENAIKAN/PENURUNAN KAS BERSIH', ReportSection::TYPE_TOTAL, null, null, null, '{operating_cash_flow} + {investing_cash_flow} + {financing_cash_flow}'],
+        ];
+
+        $this->seedSections($config, $sections);
+    }
+
+    private function seedTrialBalance(): void
+    {
+        $config = ReportConfiguration::updateOrCreate(
+            ['code' => 'trial_balance'],
+            [
+                'name' => 'Trial Balance',
+                'description' => 'Saldo semua akun untuk memastikan total debit = total kredit.',
+                'report_type' => ReportConfiguration::TYPE_TRIAL_BALANCE,
+                'is_active' => true,
+            ]
+        );
+
+        $sections = [
+            ['all_accounts', 'Semua Akun', ReportSection::TYPE_DETAIL, null, null, null, null],
+            ['total_debit_credit', 'TOTAL', ReportSection::TYPE_TOTAL, null, null, null, null],
+        ];
+
+        $this->seedSections($config, $sections);
+    }
+
+    /**
+     * @param  array<int, array{0: string, 1: string, 2: string, 3: ?string, 4: ?string, 5: ?string, 6: ?string}>  $sections
+     */
+    private function seedSections(ReportConfiguration $config, array $sections): void
+    {
+        foreach ($sections as $order => [$code, $name, $type, $accountType, $subType, $sign, $formula]) {
+            ReportSection::updateOrCreate(
+                [
+                    'report_configuration_id' => $config->id,
+                    'code' => $code,
+                ],
+                [
+                    'name' => $name,
+                    'sort_order' => ($order + 1) * 10,
+                    'section_type' => $type,
+                    'account_type_filter' => $accountType,
+                    'account_sub_type_filter' => $subType,
+                    'sign_convention' => $sign ?? ReportSection::SIGN_NORMAL,
+                    'formula' => $formula,
+                    'is_active' => true,
+                ]
+            );
+        }
+    }
+}

--- a/docs/database/IMPLEMENTATION_STATUS.md
+++ b/docs/database/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status — Database Modules
 
-> **Last updated:** 2026-05-02
+> **Last updated:** 2026-05-13
 >
 > **Purpose:** Referensi cepat untuk AI agent dan developer tentang status implementasi setiap modul database. Dokumen ini adalah satu-satunya sumber kebenaran untuk status implementasi — jangan duplikasi informasi ini di file desain individual.
 
@@ -30,8 +30,8 @@
 | 14 | Inventory (Warehouse/Transfer/Opname) | `14_inventory_design.md` | ✅ Implemented | |
 | 15 | Accounts Payable | `15_accounts_payable_design.md` | ✅ Implemented | PR #10 |
 | 16 | Accounts Receivable | `16_accounts_receivable_design.md` | ✅ Implemented | PR #11 |
-| 17 | General Ledger (Extended) | `17_general_ledger_design.md` | ✅ Implemented | PR pending |
-| 18 | Financial Reports | `18_financial_reports_design.md` | 📐 Designed Only | |
+| 17 | General Ledger (Extended) | `17_general_ledger_design.md` | ✅ Implemented | PR #12 |
+| 18 | Financial Reports | `18_financial_reports_design.md` | 🚧 In Progress | `feature/financial-reports` |
 
 ---
 
@@ -239,22 +239,22 @@
 
 ---
 
-### 📐 Financial Reports
+### 🚧 Financial Reports
 
 **Design doc:** `18_financial_reports_design.md`
 
 | Layer | Status |
 |-------|--------|
-| Migration | ❌ Not created |
-| Model | ❌ Not created |
-| Controller | 🔨 Partial (`ReportController` exists but scope unclear) |
-| Frontend | 🔨 Partial (`pages/reports/` exists) |
-| Factory | ❌ Not created |
-| Tests | ❌ Not created |
+| Migration | 🚧 In Progress (branch `feature/financial-reports`) |
+| Model | 🚧 In Progress |
+| Controller | 🚧 In Progress |
+| Frontend | 🚧 In Progress |
+| Factory | 🚧 In Progress |
+| Tests | 🚧 In Progress |
 
 **Tables to create:** `report_configurations`, `report_sections`
 
-**Dependencies:** Requires GL Extended (📐), AP (✅), AR (✅)
+**Dependencies:** GL Extended (✅), AP (✅), AR (✅) — all prerequisites merged (PR #10, #11, #12).
 
 ---
 

--- a/resources/js/app-routes.tsx
+++ b/resources/js/app-routes.tsx
@@ -86,6 +86,9 @@ const BankReconciliations = lazy(
 );
 const PeriodClosings = lazy(() => import('./pages/period-closings/index'));
 const PostingJournals = lazy(() => import('./pages/posting-journals/index'));
+const ReportConfigurations = lazy(
+    () => import('./pages/report-configurations/index'),
+);
 
 // AR Module (Accounts Receivable)
 const CustomerInvoices = lazy(() => import('./pages/customer-invoices/index'));
@@ -554,6 +557,14 @@ export default function AppRoutes() {
                     element={
                         <P>
                             <PeriodClosings />
+                        </P>
+                    }
+                />
+                <Route
+                    path="/report-configurations"
+                    element={
+                        <P>
+                            <ReportConfigurations />
                         </P>
                     }
                 />

--- a/resources/js/components/report-configurations/ReportConfigurationColumns.tsx
+++ b/resources/js/components/report-configurations/ReportConfigurationColumns.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { type ReportConfiguration } from '@/types/report-configuration';
+import {
+    createActionsColumn,
+    createSelectColumn,
+    createSortingHeader,
+    createTextColumn,
+} from '@/utils/columns';
+import { formatDateByRegionalSettings } from '@/utils/date-format';
+import { type ColumnDef } from '@tanstack/react-table';
+
+const reportTypeLabels: Record<string, string> = {
+    balance_sheet: 'Balance Sheet',
+    income_statement: 'Income Statement',
+    cash_flow: 'Cash Flow',
+    trial_balance: 'Trial Balance',
+    custom: 'Custom',
+};
+
+export const reportConfigurationColumns: ColumnDef<ReportConfiguration>[] = [
+    createSelectColumn<ReportConfiguration>(),
+    createTextColumn<ReportConfiguration>({
+        accessorKey: 'code',
+        label: 'Code',
+        enableSorting: true,
+    }),
+    createTextColumn<ReportConfiguration>({
+        accessorKey: 'name',
+        label: 'Name',
+        enableSorting: true,
+    }),
+    {
+        accessorKey: 'report_type',
+        ...createSortingHeader('Report Type'),
+        cell: ({ row }) => {
+            const value = row.getValue('report_type') as string;
+            return reportTypeLabels[value] ?? value;
+        },
+    },
+    {
+        accessorKey: 'sections',
+        header: 'Sections',
+        cell: ({ row }) => {
+            const sections = row.original.sections ?? [];
+            return <span>{sections.length}</span>;
+        },
+    },
+    {
+        accessorKey: 'is_active',
+        ...createSortingHeader('Status'),
+        cell: ({ row }) => (
+            <Badge
+                variant={row.getValue('is_active') ? 'default' : 'secondary'}
+            >
+                {row.getValue('is_active') ? 'Active' : 'Inactive'}
+            </Badge>
+        ),
+    },
+    {
+        accessorKey: 'created_at',
+        ...createSortingHeader('Created At'),
+        cell: ({ row }) =>
+            formatDateByRegionalSettings(row.getValue('created_at') as string),
+    },
+    createActionsColumn<ReportConfiguration>(),
+];

--- a/resources/js/components/report-configurations/ReportConfigurationFilters.tsx
+++ b/resources/js/components/report-configurations/ReportConfigurationFilters.tsx
@@ -1,0 +1,40 @@
+import {
+    createSelectFilterField,
+    createTextFilterField,
+    type FieldDescriptor,
+} from '@/components/common/filters';
+
+const reportTypeOptions = [
+    { value: 'balance_sheet', label: 'Balance Sheet' },
+    { value: 'income_statement', label: 'Income Statement' },
+    { value: 'cash_flow', label: 'Cash Flow' },
+    { value: 'trial_balance', label: 'Trial Balance' },
+    { value: 'custom', label: 'Custom' },
+];
+
+const activeStatusOptions = [
+    { value: '1', label: 'Active' },
+    { value: '0', label: 'Inactive' },
+];
+
+export function createReportConfigurationFilterFields(): FieldDescriptor[] {
+    return [
+        createTextFilterField(
+            'search',
+            'Search',
+            'Search code, name, description...',
+        ),
+        createSelectFilterField(
+            'report_type',
+            'Report Type',
+            reportTypeOptions,
+            'Select Report Type',
+        ),
+        createSelectFilterField(
+            'is_active',
+            'Status',
+            activeStatusOptions,
+            'Select Status',
+        ),
+    ];
+}

--- a/resources/js/components/report-configurations/ReportConfigurationForm.tsx
+++ b/resources/js/components/report-configurations/ReportConfigurationForm.tsx
@@ -1,0 +1,414 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Plus, Trash } from 'lucide-react';
+import { memo, useEffect, useMemo } from 'react';
+import { useFieldArray, useForm, type UseFormReturn } from 'react-hook-form';
+import * as z from 'zod';
+
+import EntityForm from '@/components/common/EntityForm';
+import { InputField } from '@/components/common/InputField';
+import SelectField from '@/components/common/SelectField';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { type ReportConfiguration } from '@/types/report-configuration';
+
+const reportSectionSchema = z.object({
+    id: z.number().optional(),
+    code: z.string().min(1, { message: 'Section code is required.' }),
+    name: z.string().min(1, { message: 'Section name is required.' }),
+    sort_order: z.coerce.number().int().min(0).default(0),
+    section_type: z.enum([
+        'header',
+        'detail',
+        'subtotal',
+        'total',
+        'separator',
+    ]),
+    account_type_filter: z.string().optional().nullable(),
+    account_sub_type_filter: z.string().optional().nullable(),
+    sign_convention: z.enum(['normal', 'reversed']).default('normal'),
+    formula: z.string().optional().nullable(),
+    is_active: z.boolean().default(true),
+    parent_code: z.string().optional().nullable(),
+});
+
+const reportConfigurationFormSchema = z.object({
+    code: z.string().min(1, { message: 'Code is required.' }).max(255),
+    name: z.string().min(1, { message: 'Name is required.' }).max(255),
+    description: z.string().optional().nullable(),
+    report_type: z.enum([
+        'balance_sheet',
+        'income_statement',
+        'cash_flow',
+        'trial_balance',
+        'custom',
+    ]),
+    is_active: z.boolean().default(true),
+    sections: z.array(reportSectionSchema).default([]),
+});
+
+type ReportConfigurationFormData = z.infer<
+    typeof reportConfigurationFormSchema
+>;
+
+interface ReportConfigurationFormProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    entity?: ReportConfiguration | null;
+    onSubmit: (data: ReportConfigurationFormData) => void;
+    isLoading?: boolean;
+}
+
+const reportTypeOptions = [
+    { value: 'balance_sheet', label: 'Balance Sheet' },
+    { value: 'income_statement', label: 'Income Statement' },
+    { value: 'cash_flow', label: 'Cash Flow' },
+    { value: 'trial_balance', label: 'Trial Balance' },
+    { value: 'custom', label: 'Custom' },
+];
+
+const sectionTypeOptions = [
+    { value: 'header', label: 'Header' },
+    { value: 'detail', label: 'Detail' },
+    { value: 'subtotal', label: 'Subtotal' },
+    { value: 'total', label: 'Total' },
+    { value: 'separator', label: 'Separator' },
+];
+
+const signConventionOptions = [
+    { value: 'normal', label: 'Normal' },
+    { value: 'reversed', label: 'Reversed' },
+];
+
+const getDefaults = (
+    entity?: ReportConfiguration | null,
+): ReportConfigurationFormData => {
+    if (!entity) {
+        return {
+            code: '',
+            name: '',
+            description: '',
+            report_type: 'balance_sheet',
+            is_active: true,
+            sections: [],
+        };
+    }
+
+    return {
+        code: entity.code,
+        name: entity.name,
+        description: entity.description ?? '',
+        report_type: entity.report_type,
+        is_active: entity.is_active,
+        sections: (entity.sections ?? []).map((section) => ({
+            id: section.id,
+            code: section.code,
+            name: section.name,
+            sort_order: section.sort_order ?? 0,
+            section_type: section.section_type,
+            account_type_filter: section.account_type_filter ?? '',
+            account_sub_type_filter: section.account_sub_type_filter ?? '',
+            sign_convention: section.sign_convention ?? 'normal',
+            formula: section.formula ?? '',
+            is_active: section.is_active,
+            parent_code: section.parent_code ?? '',
+        })),
+    };
+};
+
+export const ReportConfigurationForm = memo<ReportConfigurationFormProps>(
+    function ReportConfigurationForm({
+        open,
+        onOpenChange,
+        entity,
+        onSubmit,
+        isLoading = false,
+    }) {
+        const isEdit = !!entity;
+
+        const defaultValues = useMemo(() => getDefaults(entity), [entity]);
+
+        const form = useForm<z.input<typeof reportConfigurationFormSchema>>({
+            resolver: zodResolver(reportConfigurationFormSchema),
+            defaultValues,
+        });
+
+        const { fields, append, remove } = useFieldArray({
+            control: form.control,
+            name: 'sections',
+        });
+
+        useEffect(() => {
+            if (open) {
+                form.reset(defaultValues);
+            }
+        }, [open, defaultValues, form]);
+
+        const handleAddSection = () => {
+            append({
+                code: '',
+                name: '',
+                sort_order: (fields.length + 1) * 10,
+                section_type: 'detail',
+                account_type_filter: '',
+                account_sub_type_filter: '',
+                sign_convention: 'normal',
+                formula: '',
+                is_active: true,
+                parent_code: '',
+            });
+        };
+
+        return (
+            <EntityForm
+                form={form as UseFormReturn<ReportConfigurationFormData>}
+                open={open}
+                onOpenChange={onOpenChange}
+                title={
+                    isEdit
+                        ? 'Edit Report Configuration'
+                        : 'Add New Report Configuration'
+                }
+                onSubmit={onSubmit}
+                isLoading={isLoading}
+                className="sm:max-w-5xl"
+            >
+                <div className="min-h-0 flex-1 overflow-y-auto sm:pr-4">
+                    <div className="space-y-6 py-2">
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <InputField
+                                name="code"
+                                label="Code"
+                                placeholder="e.g. balance_sheet"
+                                required
+                            />
+                            <InputField
+                                name="name"
+                                label="Name"
+                                placeholder="Report name"
+                                required
+                            />
+                            <SelectField
+                                name="report_type"
+                                label="Report Type"
+                                options={reportTypeOptions}
+                                placeholder="Select report type"
+                            />
+                            <div className="flex items-center space-x-2 pt-6">
+                                <Checkbox
+                                    id="is_active"
+                                    checked={form.watch('is_active')}
+                                    onCheckedChange={(v) =>
+                                        form.setValue('is_active', !!v)
+                                    }
+                                />
+                                <Label htmlFor="is_active">Active</Label>
+                            </div>
+                            <div className="sm:col-span-2">
+                                <InputField
+                                    name="description"
+                                    label="Description"
+                                    placeholder="Optional description"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <div className="flex items-center justify-between">
+                                <h4 className="text-sm font-semibold">
+                                    Sections
+                                </h4>
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    onClick={handleAddSection}
+                                >
+                                    <Plus className="h-4 w-4" /> Add Section
+                                </Button>
+                            </div>
+
+                            <div className="rounded-md border">
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-[90px]">
+                                                Order
+                                            </TableHead>
+                                            <TableHead>Code</TableHead>
+                                            <TableHead>Name</TableHead>
+                                            <TableHead className="w-[120px]">
+                                                Type
+                                            </TableHead>
+                                            <TableHead className="w-[140px]">
+                                                Account Type
+                                            </TableHead>
+                                            <TableHead className="w-[160px]">
+                                                Sub Type
+                                            </TableHead>
+                                            <TableHead className="w-[110px]">
+                                                Sign
+                                            </TableHead>
+                                            <TableHead>Formula</TableHead>
+                                            <TableHead className="w-[120px]">
+                                                Parent Code
+                                            </TableHead>
+                                            <TableHead className="w-[60px]" />
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {fields.length === 0 ? (
+                                            <TableRow>
+                                                <TableCell
+                                                    colSpan={10}
+                                                    className="text-center text-muted-foreground"
+                                                >
+                                                    No sections defined. Click
+                                                    "Add Section" to start.
+                                                </TableCell>
+                                            </TableRow>
+                                        ) : (
+                                            fields.map((field, index) => (
+                                                <TableRow key={field.id}>
+                                                    <TableCell>
+                                                        <Input
+                                                            type="number"
+                                                            {...form.register(
+                                                                `sections.${index}.sort_order`,
+                                                                {
+                                                                    valueAsNumber:
+                                                                        true,
+                                                                },
+                                                            )}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Input
+                                                            {...form.register(
+                                                                `sections.${index}.code`,
+                                                            )}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Input
+                                                            {...form.register(
+                                                                `sections.${index}.name`,
+                                                            )}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <select
+                                                            className="w-full rounded-md border px-2 py-1 text-sm"
+                                                            {...form.register(
+                                                                `sections.${index}.section_type`,
+                                                            )}
+                                                        >
+                                                            {sectionTypeOptions.map(
+                                                                (opt) => (
+                                                                    <option
+                                                                        key={
+                                                                            opt.value
+                                                                        }
+                                                                        value={
+                                                                            opt.value
+                                                                        }
+                                                                    >
+                                                                        {
+                                                                            opt.label
+                                                                        }
+                                                                    </option>
+                                                                ),
+                                                            )}
+                                                        </select>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Input
+                                                            {...form.register(
+                                                                `sections.${index}.account_type_filter`,
+                                                            )}
+                                                            placeholder="asset"
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Input
+                                                            {...form.register(
+                                                                `sections.${index}.account_sub_type_filter`,
+                                                            )}
+                                                            placeholder="current_asset"
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <select
+                                                            className="w-full rounded-md border px-2 py-1 text-sm"
+                                                            {...form.register(
+                                                                `sections.${index}.sign_convention`,
+                                                            )}
+                                                        >
+                                                            {signConventionOptions.map(
+                                                                (opt) => (
+                                                                    <option
+                                                                        key={
+                                                                            opt.value
+                                                                        }
+                                                                        value={
+                                                                            opt.value
+                                                                        }
+                                                                    >
+                                                                        {
+                                                                            opt.label
+                                                                        }
+                                                                    </option>
+                                                                ),
+                                                            )}
+                                                        </select>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Input
+                                                            {...form.register(
+                                                                `sections.${index}.formula`,
+                                                            )}
+                                                            placeholder="{revenue} - {expense}"
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Input
+                                                            {...form.register(
+                                                                `sections.${index}.parent_code`,
+                                                            )}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() =>
+                                                                remove(index)
+                                                            }
+                                                        >
+                                                            <Trash className="h-4 w-4 text-destructive" />
+                                                        </Button>
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))
+                                        )}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </EntityForm>
+        );
+    },
+);

--- a/resources/js/components/report-configurations/ReportConfigurationForm.tsx
+++ b/resources/js/components/report-configurations/ReportConfigurationForm.tsx
@@ -286,8 +286,7 @@ export const ReportConfigurationForm = memo<ReportConfigurationFormProps>(
                                                             {...form.register(
                                                                 `sections.${index}.sort_order`,
                                                                 {
-                                                                    valueAsNumber:
-                                                                        true,
+                                                                    valueAsNumber: true,
                                                                 },
                                                             )}
                                                         />

--- a/resources/js/components/report-configurations/ReportConfigurationViewModal.tsx
+++ b/resources/js/components/report-configurations/ReportConfigurationViewModal.tsx
@@ -1,0 +1,177 @@
+import { memo } from 'react';
+
+import { ViewField } from '@/components/common/ViewField';
+import { ViewModalShell } from '@/components/common/ViewModalShell';
+import { Badge } from '@/components/ui/badge';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { type ReportConfiguration } from '@/types/report-configuration';
+
+interface ReportConfigurationViewModalProps {
+    item: ReportConfiguration | null;
+    open: boolean;
+    onClose: () => void;
+}
+
+const reportTypeLabels: Record<string, string> = {
+    balance_sheet: 'Balance Sheet',
+    income_statement: 'Income Statement',
+    cash_flow: 'Cash Flow',
+    trial_balance: 'Trial Balance',
+    custom: 'Custom',
+};
+
+const sectionTypeLabels: Record<string, string> = {
+    header: 'Header',
+    detail: 'Detail',
+    subtotal: 'Subtotal',
+    total: 'Total',
+    separator: 'Separator',
+};
+
+export const ReportConfigurationViewModal =
+    memo<ReportConfigurationViewModalProps>(
+        function ReportConfigurationViewModal({ item, open, onClose }) {
+            if (!item) return null;
+
+            return (
+                <ViewModalShell
+                    open={open}
+                    onClose={onClose}
+                    title="Report Configuration Details"
+                    description="View full configuration including sections"
+                    contentClassName="flex max-h-[90vh] max-w-[95vw] flex-col overflow-hidden sm:max-w-5xl"
+                >
+                    <div className="min-h-0 flex-1 overflow-y-auto sm:pr-4">
+                        <div className="space-y-6 py-2">
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                                <ViewField label="Code" value={item.code} />
+                                <ViewField label="Name" value={item.name} />
+                                <ViewField
+                                    label="Report Type"
+                                    value={
+                                        reportTypeLabels[item.report_type] ??
+                                        item.report_type
+                                    }
+                                />
+                                <ViewField
+                                    label="Status"
+                                    value={
+                                        <Badge
+                                            variant={
+                                                item.is_active
+                                                    ? 'default'
+                                                    : 'secondary'
+                                            }
+                                        >
+                                            {item.is_active
+                                                ? 'Active'
+                                                : 'Inactive'}
+                                        </Badge>
+                                    }
+                                />
+                                <div className="sm:col-span-2">
+                                    <ViewField
+                                        label="Description"
+                                        value={item.description || '-'}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="space-y-2">
+                                <h4 className="text-sm font-semibold">
+                                    Sections ({item.sections?.length ?? 0})
+                                </h4>
+                                <div className="rounded-md border">
+                                    <Table>
+                                        <TableHeader>
+                                            <TableRow>
+                                                <TableHead>Order</TableHead>
+                                                <TableHead>Code</TableHead>
+                                                <TableHead>Name</TableHead>
+                                                <TableHead>Type</TableHead>
+                                                <TableHead>
+                                                    Account Type
+                                                </TableHead>
+                                                <TableHead>Sub Type</TableHead>
+                                                <TableHead>Sign</TableHead>
+                                                <TableHead>Formula</TableHead>
+                                            </TableRow>
+                                        </TableHeader>
+                                        <TableBody>
+                                            {(item.sections ?? []).length ===
+                                            0 ? (
+                                                <TableRow>
+                                                    <TableCell
+                                                        colSpan={8}
+                                                        className="text-center text-muted-foreground"
+                                                    >
+                                                        No sections defined.
+                                                    </TableCell>
+                                                </TableRow>
+                                            ) : (
+                                                (item.sections ?? []).map(
+                                                    (section) => (
+                                                        <TableRow
+                                                            key={
+                                                                section.id ??
+                                                                section.code
+                                                            }
+                                                        >
+                                                            <TableCell>
+                                                                {
+                                                                    section.sort_order
+                                                                }
+                                                            </TableCell>
+                                                            <TableCell className="font-mono text-xs">
+                                                                {section.code}
+                                                            </TableCell>
+                                                            <TableCell>
+                                                                {section.name}
+                                                            </TableCell>
+                                                            <TableCell>
+                                                                <Badge variant="outline">
+                                                                    {sectionTypeLabels[
+                                                                        section
+                                                                            .section_type
+                                                                    ] ??
+                                                                        section.section_type}
+                                                                </Badge>
+                                                            </TableCell>
+                                                            <TableCell>
+                                                                {section.account_type_filter ||
+                                                                    '-'}
+                                                            </TableCell>
+                                                            <TableCell>
+                                                                {section.account_sub_type_filter ||
+                                                                    '-'}
+                                                            </TableCell>
+                                                            <TableCell>
+                                                                {
+                                                                    section.sign_convention
+                                                                }
+                                                            </TableCell>
+                                                            <TableCell className="font-mono text-xs">
+                                                                {section.formula ||
+                                                                    '-'}
+                                                            </TableCell>
+                                                        </TableRow>
+                                                    ),
+                                                )
+                                            )}
+                                        </TableBody>
+                                    </Table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ViewModalShell>
+            );
+        },
+    );

--- a/resources/js/pages/report-configurations/index.tsx
+++ b/resources/js/pages/report-configurations/index.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { createEntityCrudPage } from '@/components/common/EntityCrudPage';
+import { reportConfigurationConfig } from '@/utils/entityConfigs';
+
+export default createEntityCrudPage(reportConfigurationConfig);

--- a/resources/js/types/report-configuration.ts
+++ b/resources/js/types/report-configuration.ts
@@ -1,0 +1,47 @@
+export type ReportType =
+    | 'balance_sheet'
+    | 'income_statement'
+    | 'cash_flow'
+    | 'trial_balance'
+    | 'custom';
+
+export type SectionType =
+    | 'header'
+    | 'detail'
+    | 'subtotal'
+    | 'total'
+    | 'separator';
+
+export type SignConvention = 'normal' | 'reversed';
+
+export interface ReportSection {
+    id?: number;
+    parent_id?: number | null;
+    code: string;
+    name: string;
+    sort_order: number;
+    section_type: SectionType;
+    account_type_filter?: string | null;
+    account_sub_type_filter?: string | null;
+    sign_convention: SignConvention;
+    formula?: string | null;
+    is_active: boolean;
+    parent_code?: string | null;
+}
+
+export interface ReportConfiguration {
+    id: number;
+    code: string;
+    name: string;
+    description?: string | null;
+    report_type: ReportType;
+    layout_config?: Record<string, unknown> | null;
+    is_active: boolean;
+    sections: ReportSection[];
+    created_by?: {
+        id: number;
+        name: string;
+    } | null;
+    created_at: string;
+    updated_at: string;
+}

--- a/resources/js/utils/entityConfigs.ts
+++ b/resources/js/utils/entityConfigs.ts
@@ -1243,3 +1243,30 @@ export const periodClosingConfig = createComplexEntityConfig<PeriodClosing>({
     getDeleteMessage: () =>
         'This action cannot be undone. This will permanently delete this period closing.',
 });
+
+import { reportConfigurationColumns } from '@/components/report-configurations/ReportConfigurationColumns';
+import { createReportConfigurationFilterFields } from '@/components/report-configurations/ReportConfigurationFilters';
+import { ReportConfigurationForm } from '@/components/report-configurations/ReportConfigurationForm';
+import { ReportConfigurationViewModal } from '@/components/report-configurations/ReportConfigurationViewModal';
+import { type ReportConfiguration } from '@/types/report-configuration';
+
+export const reportConfigurationConfig =
+    createComplexEntityConfig<ReportConfiguration>({
+        entityName: 'Report Configuration',
+        entityNamePlural: 'Report Configurations',
+        apiEndpoint: '/api/report-configurations',
+        exportEndpoint: '/api/report-configurations/export',
+        queryKey: ['report-configurations'],
+        breadcrumbs: [
+            { title: 'Report Configurations', href: '/report-configurations' },
+        ],
+        initialFilters: { search: '', report_type: '', is_active: '' },
+        columns: reportConfigurationColumns,
+        filterFields: createReportConfigurationFilterFields(),
+        formComponent: ReportConfigurationForm,
+        formType: 'complex',
+        entityNameForSearch: 'report configuration',
+        viewModalComponent: ReportConfigurationViewModal,
+        getDeleteMessage: (item: { name?: string }) =>
+            `This action cannot be undone. This will permanently delete report configuration ${item.name}.`,
+    });

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,7 @@ Route::middleware('auth:sanctum')->group(function () {
     require __DIR__ . '/api/recurring-journals.php';
     require __DIR__ . '/api/purchase-orders.php';
     require __DIR__ . '/api/purchase-requests.php';
+    require __DIR__ . '/api/report-configurations.php';
     require __DIR__ . '/api/reports.php';
     require __DIR__ . '/api/stock-adjustments.php';
     require __DIR__ . '/api/stock-monitor.php';

--- a/routes/api/report-configurations.php
+++ b/routes/api/report-configurations.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Http\Controllers\ReportConfigurationController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth:sanctum'])->group(function () {
+    Route::get('report-configurations', [ReportConfigurationController::class, 'index']);
+    Route::get('report-configurations/{report_configuration}', [ReportConfigurationController::class, 'show']);
+    Route::post('report-configurations', [ReportConfigurationController::class, 'store']);
+    Route::put('report-configurations/{report_configuration}', [ReportConfigurationController::class, 'update']);
+    Route::delete('report-configurations/{report_configuration}', [ReportConfigurationController::class, 'destroy']);
+    Route::post('report-configurations/export', [ReportConfigurationController::class, 'export']);
+});

--- a/task.md
+++ b/task.md
@@ -1,4 +1,4 @@
-# AI Handoff: GL Extended — E2E Tests & Bug Fixes
+# AI Handoff: Financial Reports (Modul 18) — Config-Driven Refactor
 
 Last updated: 2026-05-13 UTC
 
@@ -10,23 +10,30 @@ Last updated: 2026-05-13 UTC
 
 ## Current Objective
 
-- **GL Extended (Modul 17)** — PR #12 open. All CI checks passed. Ready to merge.
+- **Financial Reports (Modul 18)** — Config-driven report system with Report Configuration CRUD. Local implementation complete. Ready to push branch + open PR.
 
 ## Current Milestone
 
-- **GL Extended**: ✅ Implementation complete. Sonar passed. E2E tests added. Bug fixes applied.
-- Full E2E suite: **466 passed, 0 failed** (42.0m)
-- PR #12 CI: Quality checks ✅, Test suite ✅, SonarCloud ✅
+- PR #12 (GL Extended) merged to main as `f3252285`.
+- Branch `feature/financial-reports` — all waves complete locally:
+  - ✅ Wave 1: Migrations (`report_configurations`, `report_sections`) + Models + 16 unit tests
+  - ✅ Wave 2: `ReportConfigurationSeeder` seeds 4 defaults (balance_sheet 15 sections, income_statement 16, cash_flow 13, trial_balance 2)
+  - ✅ Wave 3: Report Configuration CRUD backend (Controller, Action, FilterService, Requests, Resource, Export) + 14 feature tests
+  - ✅ Wave 4: `ReportController` extended with `configuration` payload (via `GetReportConfigurationByTypeAction`) — additive, non-breaking + 6 new tests
+  - ✅ Wave 5: Frontend CRUD (entity config, Columns, Filters, Form with `useFieldArray` for sections, ViewModal, page) + Menu + Permission seeder entries
+  - ✅ Wave 6: E2E Playwright (7 specs passed) + Quality gate (PHPStan 0 errors, TS clean, ESLint clean)
 
 ## Current State
 
-- Branch: `feature/general-ledger-extended`
-- PR: #12 (https://github.com/gmedia/erp/pull/12)
-- CI: All checks PASS, mergeable
-- PHPStan: 0 errors (3 pre-existing in PipelineSampleDataSeeder — nullsafe + offset)
-- TypeScript: clean
-- Pest: 54 tests, 155 assertions, all passing
-- E2E: 466 passed, 0 failed
+- Branch: `feature/financial-reports`
+- Commits: pending (not yet committed)
+- HEAD parent: `f3252285` (merged main)
+- PHPStan: 0 errors (full project 1023 files)
+- TypeScript: clean (`npm run types`)
+- ESLint: clean (`npm run lint --fix`)
+- Pest `--group=financial-reports`: 36 passed (103 assertions)
+- Pest `--group=reports`: 12 passed (79 assertions)
+- E2E `tests/e2e/report-configurations/`: 7 passed (33.7s)
 
 ## Active Constraints
 
@@ -34,37 +41,42 @@ Last updated: 2026-05-13 UTC
 
 ## Latest Session Delta
 
-- Added E2E tests for 5 GL Extended modules:
-  - `tests/e2e/recurring-journals/` (8 tests)
-  - `tests/e2e/bank-reconciliations/` (7 tests)
-  - `tests/e2e/period-closings/` (7 tests)
-  - `tests/e2e/general-ledger-report/` (1 test)
-  - `tests/e2e/trial-balance-report/` (1 test)
-- Fixed 27 pre-existing E2E failures:
-  - Supplier Bills 500: removed invalid `items.unit` eager load from `TransactionMappedIndexConfigurations.php`
-  - Entity State/Pipeline 17 failures: added `seedAssetLifecycle()` to `PipelineSampleDataSeeder.php`
-  - High-value asset registration 5 failures: fixed tests to handle confirmation dialog before API call
-  - Purchase Request sort 500: fixed `requester → requested_by` sort mapping
-- Increased shared test factory `waitForApiResponse` timeout from 15s to 30s
+- Merged PR #12 (GL Extended) — no code changes, just CI retrigger after autofix commit (`8b608724`).
+- Implemented Modul 18 config-driven refactor (full scope per user choice):
+  - Config tables `report_configurations`, `report_sections` with hierarchical `parent_id`, `section_type` enum (header/detail/subtotal/total/separator), `sign_convention` enum (normal/reversed), optional `formula`.
+  - Seeder preloads design-doc defaults for 4 built-in reports.
+  - Admin UI at `/report-configurations` with nested section editor (`useFieldArray`).
+  - `GET /api/reports/{balance-sheet,income-statement,cash-flow,trial-balance}` responses now include `configuration: { id, code, name, report_type, sections: [...] }` key. Existing `report` payload unchanged → frontend pages keep working.
+  - Menu seeder adds "Report Configuration" entry under Accounting. Permission seeder adds `report_configuration` + CRUD children.
 
 ## Validated Commands and Outcomes
 
-- `./vendor/bin/sail npm run test:e2e` — 466 passed, 0 failed (42.0m)
 - `./vendor/bin/sail bin phpstan analyze` — 0 errors
 - `./vendor/bin/sail npm run types` — clean
+- `./vendor/bin/sail npm run lint` — clean
+- `./vendor/bin/sail test --group=financial-reports` — 36 passed (103 assertions)
+- `./vendor/bin/sail test --group=reports` — 12 passed (79 assertions)
+- `./vendor/bin/sail npm run test:e2e -- tests/e2e/report-configurations/` — 7 passed
+- `./vendor/bin/sail artisan migrate:fresh --seed` — all seeders green
 
 ## Open Risks / Blockers
 
-- None. PR #12 ready to merge.
+- None. Ready to commit + push + open PR.
+- Note: `sail bin duster fix` was invoked once but exceeded the 5m bash timeout. Not a blocker — PHPStan/TS/ESLint/Pest all pass, and CI duster step will auto-fix on push if anything slipped.
 
 ## Recommended Next Steps
 
-1. Merge PR #12 to main.
-2. After merge → update `docs/database/IMPLEMENTATION_STATUS.md`, start Financial Reports (Modul 18) per `docs/database/18_financial_reports_design.md`.
+1. Stage and commit all 29 changed files in one atomic commit: `feat: implement Financial Reports module (Modul 18)`.
+2. Push branch `feature/financial-reports` to origin.
+3. Open PR against `main` titled `feat: implement Financial Reports module (Modul 18)` referencing `docs/database/18_financial_reports_design.md`.
+4. Wait for CI. After autofix (if any), retrigger via empty commit per existing convention.
+5. On green CI → merge.
 
 ## Continuation Prompt
 
 ```
-Read task.md. PR #12 (GL Extended) has all CI checks passing and full E2E suite green (466/466).
-Merge PR #12, then start Financial Reports (Modul 18) per docs/database/18_financial_reports_design.md.
+Read task.md. Modul 18 (Financial Reports) implementation complete on branch feature/financial-reports.
+Commit all changes with message "feat: implement Financial Reports module (Modul 18)",
+push to origin, open PR against main. Monitor CI (expect autofix retrigger pattern),
+then merge when green.
 ```

--- a/tests/Feature/ReportConfigurations/ReportConfigurationControllerTest.php
+++ b/tests/Feature/ReportConfigurations/ReportConfigurationControllerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
+
+uses(RefreshDatabase::class)->group('financial-reports');
+
+beforeEach(function () {
+    $this->user = createTestUserWithPermissions([]);
+    Sanctum::actingAs($this->user, ['*']);
+});
+
+function reportConfigurationPayload(array $overrides = []): array
+{
+    return array_merge([
+        'code' => 'custom_bs',
+        'name' => 'Custom Balance Sheet',
+        'description' => 'Customer-defined layout',
+        'report_type' => ReportConfiguration::TYPE_BALANCE_SHEET,
+        'is_active' => true,
+        'sections' => [
+            [
+                'code' => 'assets_header',
+                'name' => 'ASET',
+                'section_type' => ReportSection::TYPE_HEADER,
+                'sort_order' => 10,
+            ],
+            [
+                'code' => 'current_assets',
+                'name' => 'Aset Lancar',
+                'section_type' => ReportSection::TYPE_DETAIL,
+                'sort_order' => 20,
+                'account_type_filter' => 'asset',
+                'account_sub_type_filter' => 'current_asset',
+                'parent_code' => 'assets_header',
+            ],
+            [
+                'code' => 'total_assets',
+                'name' => 'TOTAL ASET',
+                'section_type' => ReportSection::TYPE_TOTAL,
+                'sort_order' => 30,
+                'account_type_filter' => 'asset',
+            ],
+        ],
+    ], $overrides);
+}
+
+test('it lists report configurations with pagination', function () {
+    ReportConfiguration::factory()->count(3)->create();
+
+    getJson('/api/report-configurations')
+        ->assertOk()
+        ->assertJsonStructure(['data' => [['id', 'code', 'name', 'report_type', 'is_active']], 'meta']);
+});
+
+test('it filters report configurations by report_type', function () {
+    ReportConfiguration::factory()->ofType(ReportConfiguration::TYPE_BALANCE_SHEET)->create();
+    ReportConfiguration::factory()->ofType(ReportConfiguration::TYPE_INCOME_STATEMENT)->create();
+
+    getJson('/api/report-configurations?report_type=balance_sheet')
+        ->assertOk()
+        ->assertJsonCount(1, 'data');
+});
+
+test('it searches report configurations by code or name', function () {
+    ReportConfiguration::factory()->create(['code' => 'bs_default', 'name' => 'Balance Sheet Default']);
+    ReportConfiguration::factory()->create(['code' => 'is_default', 'name' => 'Income Statement']);
+
+    getJson('/api/report-configurations?search=Balance')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.code', 'bs_default');
+});
+
+test('it creates a report configuration with sections', function () {
+    $response = postJson('/api/report-configurations', reportConfigurationPayload());
+
+    $response->assertCreated()
+        ->assertJsonStructure(['data' => ['id', 'code', 'sections' => [['id', 'code', 'parent_id']]]])
+        ->assertJsonPath('data.code', 'custom_bs');
+
+    assertDatabaseHas('report_configurations', ['code' => 'custom_bs']);
+    expect(ReportConfiguration::where('code', 'custom_bs')->first()->sections)->toHaveCount(3);
+});
+
+test('it resolves parent_code to parent_id when creating sections', function () {
+    postJson('/api/report-configurations', reportConfigurationPayload())->assertCreated();
+
+    $config = ReportConfiguration::where('code', 'custom_bs')->first();
+    $parent = $config->sections->firstWhere('code', 'assets_header');
+    $child = $config->sections->firstWhere('code', 'current_assets');
+
+    expect($child->parent_id)->toBe($parent->id);
+});
+
+test('it shows a report configuration with sections', function () {
+    $config = ReportConfiguration::factory()->create();
+    ReportSection::factory()->count(2)->create(['report_configuration_id' => $config->id]);
+
+    getJson("/api/report-configurations/{$config->id}")
+        ->assertOk()
+        ->assertJsonPath('data.id', $config->id)
+        ->assertJsonStructure(['data' => ['sections' => [['id', 'code', 'section_type']]]]);
+});
+
+test('it updates a report configuration and replaces sections', function () {
+    $config = ReportConfiguration::factory()->create(['code' => 'old_code']);
+    ReportSection::factory()->count(5)->create(['report_configuration_id' => $config->id]);
+
+    $payload = reportConfigurationPayload(['code' => 'old_code', 'name' => 'Updated Name']);
+
+    putJson("/api/report-configurations/{$config->id}", $payload)->assertOk();
+
+    assertDatabaseHas('report_configurations', ['id' => $config->id, 'name' => 'Updated Name']);
+    expect($config->refresh()->sections)->toHaveCount(3);
+});
+
+test('it deletes a report configuration and cascades sections', function () {
+    $config = ReportConfiguration::factory()->create();
+    ReportSection::factory()->count(2)->create(['report_configuration_id' => $config->id]);
+
+    deleteJson("/api/report-configurations/{$config->id}")->assertNoContent();
+
+    assertDatabaseMissing('report_configurations', ['id' => $config->id]);
+    assertDatabaseMissing('report_sections', ['report_configuration_id' => $config->id]);
+});
+
+test('it rejects duplicate codes', function () {
+    ReportConfiguration::factory()->create(['code' => 'bs_default']);
+
+    postJson('/api/report-configurations', reportConfigurationPayload(['code' => 'bs_default']))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('code');
+});
+
+test('it rejects invalid report_type', function () {
+    postJson('/api/report-configurations', reportConfigurationPayload(['report_type' => 'unknown_type']))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('report_type');
+});
+
+test('it rejects invalid section_type', function () {
+    $payload = reportConfigurationPayload();
+    $payload['sections'][0]['section_type'] = 'bogus';
+
+    postJson('/api/report-configurations', $payload)
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('sections.0.section_type');
+});
+
+test('it sorts by name by default', function () {
+    ReportConfiguration::factory()->create(['name' => 'Alpha']);
+    ReportConfiguration::factory()->create(['name' => 'Bravo']);
+
+    $response = getJson('/api/report-configurations?sort_by=name&sort_direction=asc')->assertOk();
+
+    expect($response->json('data.0.name'))->toBe('Alpha');
+});

--- a/tests/Feature/ReportConfigurations/ReportConfigurationExportTest.php
+++ b/tests/Feature/ReportConfigurations/ReportConfigurationExportTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\ReportConfiguration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+use Maatwebsite\Excel\Facades\Excel;
+
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class)->group('financial-reports');
+
+test('it exports report configurations to xlsx', function () {
+    Excel::fake();
+    Storage::fake('public');
+    Sanctum::actingAs(createTestUserWithPermissions([]), ['*']);
+    ReportConfiguration::factory()->count(2)->create();
+
+    $response = postJson('/api/report-configurations/export', [])->assertOk();
+
+    $response->assertJsonStructure(['url', 'filename']);
+    expect($response->json('filename'))->toEndWith('.xlsx');
+});
+
+test('it applies filters to export', function () {
+    Excel::fake();
+    Storage::fake('public');
+    Sanctum::actingAs(createTestUserWithPermissions([]), ['*']);
+    ReportConfiguration::factory()->ofType(ReportConfiguration::TYPE_BALANCE_SHEET)->create();
+    ReportConfiguration::factory()->ofType(ReportConfiguration::TYPE_INCOME_STATEMENT)->create();
+
+    postJson('/api/report-configurations/export', ['report_type' => 'balance_sheet'])
+        ->assertOk()
+        ->assertJsonStructure(['url', 'filename']);
+});

--- a/tests/Feature/Reports/FinancialReportConfigurationTest.php
+++ b/tests/Feature/Reports/FinancialReportConfigurationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\FiscalYear;
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Database\Seeders\ReportConfigurationSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class)->group('financial-reports');
+
+beforeEach(function () {
+    $this->user = createTestUserWithPermissions([
+        'trial_balance_report',
+        'balance_sheet_report',
+        'income_statement_report',
+        'cash_flow_report',
+    ]);
+    $this->seed(ReportConfigurationSeeder::class);
+    FiscalYear::create([
+        'name' => '2025',
+        'start_date' => '2025-01-01',
+        'end_date' => '2025-12-31',
+        'status' => 'open',
+    ]);
+    Sanctum::actingAs($this->user, ['*']);
+});
+
+test('balance sheet response includes DB-driven configuration payload', function () {
+    $this->getJson('/api/reports/balance-sheet')
+        ->assertStatus(200)
+        ->assertJsonPath('configuration.code', 'balance_sheet')
+        ->assertJsonPath('configuration.report_type', ReportConfiguration::TYPE_BALANCE_SHEET)
+        ->assertJsonStructure(['configuration' => ['sections' => [['code', 'name', 'section_type']]]]);
+});
+
+test('income statement response includes configuration with ordered sections', function () {
+    $response = $this->getJson('/api/reports/income-statement')->assertStatus(200);
+
+    $sections = $response->json('configuration.sections');
+    expect($sections[0]['sort_order'])->toBeLessThan($sections[1]['sort_order'])
+        ->and(collect($sections)->pluck('code'))->toContain('total_revenue', 'net_income');
+});
+
+test('cash flow response includes configuration with reversed sign section for depreciation', function () {
+    $response = $this->getJson('/api/reports/cash-flow')->assertStatus(200);
+
+    $sections = collect($response->json('configuration.sections'));
+    expect($sections->firstWhere('code', 'depreciation_addback')['sign_convention'])
+        ->toBe(ReportSection::SIGN_REVERSED);
+});
+
+test('trial balance response includes minimal configuration', function () {
+    $this->getJson('/api/reports/trial-balance')
+        ->assertStatus(200)
+        ->assertJsonPath('configuration.code', 'trial_balance');
+});
+
+test('configuration is null when report_configuration row is missing', function () {
+    ReportConfiguration::query()->delete();
+
+    $this->getJson('/api/reports/balance-sheet')
+        ->assertStatus(200)
+        ->assertJsonPath('configuration', null);
+});
+
+test('configuration skips inactive sections', function () {
+    $config = ReportConfiguration::where('code', 'balance_sheet')->firstOrFail();
+    $activeCount = $config->sections()->where('is_active', true)->count();
+    $config->sections()->limit(1)->update(['is_active' => false]);
+
+    $response = $this->getJson('/api/reports/balance-sheet')->assertStatus(200);
+
+    expect($response->json('configuration.sections'))->toHaveCount($activeCount - 1);
+});

--- a/tests/Unit/Models/ReportConfigurationTest.php
+++ b/tests/Unit/Models/ReportConfigurationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('financial-reports');
+
+test('it has correct fillable attributes', function () {
+    expect((new ReportConfiguration)->getFillable())->toBe([
+        'code',
+        'name',
+        'description',
+        'report_type',
+        'layout_config',
+        'is_active',
+        'created_by',
+    ]);
+});
+
+test('it casts layout_config to array and is_active to boolean', function () {
+    $config = ReportConfiguration::factory()->create([
+        'layout_config' => ['columns' => ['code', 'name']],
+        'is_active' => 1,
+    ]);
+
+    expect($config->layout_config)->toBe(['columns' => ['code', 'name']])
+        ->and($config->is_active)->toBeTrue();
+});
+
+test('it has a creator relation', function () {
+    expect((new ReportConfiguration)->creator())->toBeInstanceOf(BelongsTo::class);
+});
+
+test('it has many sections ordered by sort_order', function () {
+    expect((new ReportConfiguration)->sections())->toBeInstanceOf(HasMany::class);
+
+    $config = ReportConfiguration::factory()->create();
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'sort_order' => 20, 'code' => 's2']);
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'sort_order' => 10, 'code' => 's1']);
+
+    expect($config->sections()->pluck('code')->toArray())->toBe(['s1', 's2']);
+});
+
+test('active scope filters to active rows', function () {
+    ReportConfiguration::factory()->create(['is_active' => true]);
+    ReportConfiguration::factory()->inactive()->create();
+
+    expect(ReportConfiguration::active()->count())->toBe(1);
+});
+
+test('ofType scope filters by report_type', function () {
+    ReportConfiguration::factory()->ofType(ReportConfiguration::TYPE_BALANCE_SHEET)->create();
+    ReportConfiguration::factory()->ofType(ReportConfiguration::TYPE_INCOME_STATEMENT)->create();
+
+    expect(ReportConfiguration::ofType(ReportConfiguration::TYPE_BALANCE_SHEET)->count())->toBe(1);
+});
+
+test('code is unique', function () {
+    ReportConfiguration::factory()->create(['code' => 'balance_sheet']);
+
+    expect(fn () => ReportConfiguration::factory()->create(['code' => 'balance_sheet']))
+        ->toThrow(Illuminate\Database\QueryException::class);
+});
+
+test('deleting a configuration cascade deletes its sections', function () {
+    $config = ReportConfiguration::factory()->create();
+    ReportSection::factory()->count(3)->create(['report_configuration_id' => $config->id]);
+
+    $config->delete();
+
+    expect(ReportSection::where('report_configuration_id', $config->id)->count())->toBe(0);
+});

--- a/tests/Unit/Models/ReportSectionTest.php
+++ b/tests/Unit/Models/ReportSectionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\ReportConfiguration;
+use App\Models\ReportSection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('financial-reports');
+
+test('it has correct fillable attributes', function () {
+    expect((new ReportSection)->getFillable())->toBe([
+        'report_configuration_id',
+        'parent_id',
+        'code',
+        'name',
+        'sort_order',
+        'section_type',
+        'account_type_filter',
+        'account_sub_type_filter',
+        'sign_convention',
+        'formula',
+        'is_active',
+    ]);
+});
+
+test('it casts sort_order to integer and is_active to boolean', function () {
+    $section = ReportSection::factory()->create([
+        'sort_order' => '15',
+        'is_active' => 1,
+    ]);
+
+    expect($section->sort_order)->toBe(15)
+        ->and($section->is_active)->toBeTrue();
+});
+
+test('it has reportConfiguration, parent, and children relations', function () {
+    $section = new ReportSection;
+
+    expect($section->reportConfiguration())->toBeInstanceOf(BelongsTo::class)
+        ->and($section->parent())->toBeInstanceOf(BelongsTo::class)
+        ->and($section->children())->toBeInstanceOf(HasMany::class);
+});
+
+test('children are ordered by sort_order', function () {
+    $config = ReportConfiguration::factory()->create();
+    $parent = ReportSection::factory()->create(['report_configuration_id' => $config->id, 'code' => 'p']);
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'parent_id' => $parent->id, 'sort_order' => 20, 'code' => 'c2']);
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'parent_id' => $parent->id, 'sort_order' => 10, 'code' => 'c1']);
+
+    expect($parent->children()->pluck('code')->toArray())->toBe(['c1', 'c2']);
+});
+
+test('active scope filters to active rows', function () {
+    $config = ReportConfiguration::factory()->create();
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'is_active' => true, 'code' => 'a']);
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'is_active' => false, 'code' => 'b']);
+
+    expect(ReportSection::active()->count())->toBe(1);
+});
+
+test('code is unique per configuration', function () {
+    $config = ReportConfiguration::factory()->create();
+    ReportSection::factory()->create(['report_configuration_id' => $config->id, 'code' => 'current_assets']);
+
+    expect(fn () => ReportSection::factory()->create(['report_configuration_id' => $config->id, 'code' => 'current_assets']))
+        ->toThrow(Illuminate\Database\QueryException::class);
+});
+
+test('same code can exist across different configurations', function () {
+    $configA = ReportConfiguration::factory()->create();
+    $configB = ReportConfiguration::factory()->create();
+    ReportSection::factory()->create(['report_configuration_id' => $configA->id, 'code' => 'current_assets']);
+    ReportSection::factory()->create(['report_configuration_id' => $configB->id, 'code' => 'current_assets']);
+
+    expect(ReportSection::where('code', 'current_assets')->count())->toBe(2);
+});
+
+test('deleting a parent section nullifies its childrens parent_id', function () {
+    $config = ReportConfiguration::factory()->create();
+    $parent = ReportSection::factory()->create(['report_configuration_id' => $config->id, 'code' => 'parent']);
+    $child = ReportSection::factory()->create(['report_configuration_id' => $config->id, 'parent_id' => $parent->id, 'code' => 'child']);
+
+    $parent->delete();
+
+    expect($child->fresh()->parent_id)->toBeNull();
+});

--- a/tests/e2e/report-configurations/helpers.ts
+++ b/tests/e2e/report-configurations/helpers.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+import { searchAndWaitForApi } from '../helpers';
+
+export async function searchReportConfiguration(
+    page: Page,
+    query: string,
+): Promise<void> {
+    await searchAndWaitForApi(
+        page,
+        page.getByPlaceholder(/Search/i),
+        query,
+        '/api/report-configurations',
+    );
+}

--- a/tests/e2e/report-configurations/report-configuration.spec.ts
+++ b/tests/e2e/report-configurations/report-configuration.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+import { login } from '../helpers';
+import { searchReportConfiguration } from './helpers';
+
+test.describe('Report Configuration E2E Tests', () => {
+    test.beforeEach(async ({ page }) => {
+        await login(page, undefined, undefined, { requireDashboard: false });
+        await page.goto('/report-configurations');
+        await page.waitForResponse(
+            (r) =>
+                r.url().includes('/api/report-configurations') &&
+                r.status() < 400,
+            { timeout: 15000 },
+        );
+    });
+
+    test('can view Report Configurations list with seeded defaults', async ({
+        page,
+    }) => {
+        await expect(page.locator('table')).toBeVisible();
+        await expect(page.locator('tbody tr').first()).toBeVisible();
+        await expect(page.locator('tbody')).toContainText('Balance Sheet');
+    });
+
+    test('can search Report Configurations', async ({ page }) => {
+        await searchReportConfiguration(page, 'Balance');
+        await expect(page.locator('tbody')).toContainText('Balance Sheet');
+    });
+
+    test('can filter Report Configurations by report type', async ({
+        page,
+    }) => {
+        const filterButton = page.getByRole('button', { name: /filter/i });
+        await filterButton.click();
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+    });
+
+    test('can open actions menu and view modal', async ({ page }) => {
+        const row = page.locator('tbody tr').first();
+        await expect(row).toBeVisible();
+        await row.getByRole('button').last().click();
+
+        const viewItem = page.getByRole('menuitem', { name: /View/i });
+        await expect(viewItem).toBeVisible({ timeout: 5000 });
+        await viewItem.click();
+
+        const viewDialog = page.getByRole('dialog', {
+            name: /Report Configuration Details/i,
+        });
+        await expect(viewDialog).toBeVisible();
+        await expect(viewDialog).toContainText(/Sections/i);
+    });
+
+    test('can export Report Configurations', async ({ page }) => {
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('button', { name: /export/i }).click();
+        const download = await downloadPromise;
+        expect(download.suggestedFilename()).toBeTruthy();
+    });
+
+    test('datatable has correct checkbox behavior', async ({ page }) => {
+        const headerCheckboxes = page.locator('thead [data-testid="select-all"]');
+        await expect(headerCheckboxes).toHaveCount(1);
+        await expect(headerCheckboxes.first()).toBeVisible();
+
+        const row = page.locator('tbody tr').first();
+        const bodyCheckbox = row.locator('[data-testid="select-row"]').first();
+        await expect(bodyCheckbox).toBeVisible();
+    });
+
+    test('can sort Report Configurations by code and name', async ({ page }) => {
+        test.setTimeout(90000);
+        const sortableColumns = ['Code', 'Name'];
+
+        for (const column of sortableColumns) {
+            const sortButton = page
+                .locator('thead')
+                .getByRole('button', { name: column, exact: true });
+            await expect(sortButton).toBeVisible();
+            await sortButton.click();
+            await page.waitForTimeout(500);
+            await sortButton.click();
+            await page.waitForTimeout(500);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- **Config-driven financial reports**: added `report_configurations` + `report_sections` tables with hierarchical sections, `section_type` enum (header/detail/subtotal/total/separator), `sign_convention` (normal/reversed), and optional `formula` support per `docs/database/18_financial_reports_design.md`.
- **Seeder** preloads 4 default reports: balance_sheet (15 sections), income_statement (16), cash_flow (13), trial_balance (2).
- **Admin UI** at `/report-configurations` — full CRUD with nested section editor (`useFieldArray`), registered in MenuSeeder and PermissionSeeder.
- **Non-breaking extension**: `GET /api/reports/{balance-sheet,income-statement,cash-flow,trial-balance}` responses now include a `configuration: { id, code, name, report_type, sections: [...] }` key alongside the existing `report` payload, so frontend keeps working while new consumers can render section-driven layouts.

## Why

Modul 17 (GL Extended) landed in PR #12. This PR completes the accounting roadmap's final leg (Modul 18) by delivering the design doc's configuration layer without touching the existing `FinancialReportService` output contract.

## Test plan

- `./vendor/bin/sail test --group=financial-reports` — **36 passed** (103 assertions)
- `./vendor/bin/sail test --group=reports` — **12 passed** (79 assertions, pre-existing tests still green)
- `./vendor/bin/sail npm run test:e2e -- tests/e2e/report-configurations/` — **7 passed** (33.7s)
- `./vendor/bin/sail bin phpstan analyze` — **0 errors** (1023 files)
- `./vendor/bin/sail npm run types` — clean
- `./vendor/bin/sail npm run lint` — clean
- `./vendor/bin/sail artisan migrate:fresh --seed` — all seeders green

## Follow-ups (out of scope)

- Frontend balance-sheet/income-statement/cash-flow pages can be refactored in a follow-up to render section-driven output (the API already exposes it).
- No backwards-incompatible changes in this PR.