### PR TITLE
feat: auto-post AP journal entries on bill/payment confirm

### DIFF
--- a/app/Actions/AccountingPosting/PostApPaymentJournalAction.php
+++ b/app/Actions/AccountingPosting/PostApPaymentJournalAction.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Actions\AccountingPosting;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\ApPayment;
+use App\Models\JournalEntry;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class PostApPaymentJournalAction
+{
+    public const AP_CONTROL_ACCOUNT_CODE = '21100';
+
+    public function __construct(
+        private CreateJournalEntryAction $createJournalEntry,
+        private ResolveControlAccountAction $resolveControlAccount,
+    ) {}
+
+    public function execute(ApPayment $apPayment): ?JournalEntry
+    {
+        if ($apPayment->journal_entry_id !== null) {
+            /** @var JournalEntry|null $existing */
+            $existing = $apPayment->journalEntry()->first();
+
+            return $existing;
+        }
+
+        if ($apPayment->status !== 'confirmed') {
+            return null;
+        }
+
+        return DB::transaction(function () use ($apPayment): JournalEntry {
+            $amount = round((float) $apPayment->total_amount, 2);
+
+            if ($amount <= 0) {
+                throw ValidationException::withMessages([
+                    'total_amount' => 'Cannot post a payment with non-positive total amount.',
+                ]);
+            }
+
+            $apAccount = $this->resolveControlAccount->execute(self::AP_CONTROL_ACCOUNT_CODE);
+
+            $journalEntry = $this->createJournalEntry->execute([
+                'entry_date' => $apPayment->payment_date->format('Y-m-d'),
+                'reference' => $apPayment->payment_number,
+                'description' => "AP Payment {$apPayment->payment_number}",
+                'status' => 'posted',
+                'journal_type' => 'system',
+                'source_type' => ApPayment::class,
+                'source_id' => $apPayment->id,
+                'lines' => [
+                    [
+                        'account_id' => $apAccount->id,
+                        'debit' => $amount,
+                        'credit' => 0,
+                        'memo' => "Payment {$apPayment->payment_number}",
+                    ],
+                    [
+                        'account_id' => (int) $apPayment->bank_account_id,
+                        'debit' => 0,
+                        'credit' => $amount,
+                        'memo' => "Payment {$apPayment->payment_number}",
+                    ],
+                ],
+            ]);
+
+            $apPayment->forceFill([
+                'journal_entry_id' => $journalEntry->id,
+            ])->save();
+
+            return $journalEntry;
+        });
+    }
+}

--- a/app/Actions/AccountingPosting/PostSupplierBillJournalAction.php
+++ b/app/Actions/AccountingPosting/PostSupplierBillJournalAction.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Actions\AccountingPosting;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\JournalEntry;
+use App\Models\SupplierBill;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class PostSupplierBillJournalAction
+{
+    public const AP_CONTROL_ACCOUNT_CODE = '21100';
+
+    public function __construct(
+        private CreateJournalEntryAction $createJournalEntry,
+        private ResolveControlAccountAction $resolveControlAccount,
+    ) {}
+
+    public function execute(SupplierBill $supplierBill): ?JournalEntry
+    {
+        if ($supplierBill->journal_entry_id !== null) {
+            /** @var JournalEntry|null $existing */
+            $existing = $supplierBill->journalEntry()->first();
+
+            return $existing;
+        }
+
+        if ($supplierBill->status !== 'confirmed') {
+            return null;
+        }
+
+        return DB::transaction(function () use ($supplierBill): JournalEntry {
+            $supplierBill->loadMissing('items');
+
+            if ($supplierBill->items->isEmpty()) {
+                throw ValidationException::withMessages([
+                    'items' => 'Cannot post a supplier bill with no items.',
+                ]);
+            }
+
+            $apAccount = $this->resolveControlAccount->execute(self::AP_CONTROL_ACCOUNT_CODE);
+
+            $debitTotal = 0.0;
+            $debitLines = [];
+            $expenseGrouped = [];
+
+            foreach ($supplierBill->items as $item) {
+                $accountId = (int) $item->account_id;
+                $expenseGrouped[$accountId] = ($expenseGrouped[$accountId] ?? 0.0) + (float) $item->line_total;
+            }
+
+            foreach ($expenseGrouped as $accountId => $amount) {
+                if ($amount <= 0) {
+                    continue;
+                }
+
+                $debitLines[] = [
+                    'account_id' => $accountId,
+                    'debit' => round($amount, 2),
+                    'credit' => 0,
+                    'memo' => "Bill {$supplierBill->bill_number}",
+                ];
+                $debitTotal += $amount;
+            }
+
+            $debitTotal = round($debitTotal, 2);
+
+            $creditLine = [
+                'account_id' => $apAccount->id,
+                'debit' => 0,
+                'credit' => $debitTotal,
+                'memo' => "Bill {$supplierBill->bill_number}",
+            ];
+
+            $journalEntry = $this->createJournalEntry->execute([
+                'entry_date' => $supplierBill->bill_date->format('Y-m-d'),
+                'reference' => $supplierBill->bill_number,
+                'description' => "Supplier Bill {$supplierBill->bill_number}",
+                'status' => 'posted',
+                'journal_type' => 'system',
+                'source_type' => SupplierBill::class,
+                'source_id' => $supplierBill->id,
+                'lines' => array_merge($debitLines, [$creditLine]),
+            ]);
+
+            $supplierBill->forceFill([
+                'journal_entry_id' => $journalEntry->id,
+            ])->save();
+
+            return $journalEntry;
+        });
+    }
+}

--- a/app/Actions/AccountingPosting/ResolveControlAccountAction.php
+++ b/app/Actions/AccountingPosting/ResolveControlAccountAction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Actions\AccountingPosting;
+
+use App\Models\Account;
+use App\Models\CoaVersion;
+use Illuminate\Validation\ValidationException;
+
+class ResolveControlAccountAction
+{
+    public function execute(string $accountCode): Account
+    {
+        $coaVersion = CoaVersion::where('status', 'active')->first();
+
+        if ($coaVersion === null) {
+            throw ValidationException::withMessages([
+                'coa_version' => 'No active COA version found. Seed or activate a COA version before posting.',
+            ]);
+        }
+
+        $account = Account::where('coa_version_id', $coaVersion->id)
+            ->where('code', $accountCode)
+            ->where('is_active', true)
+            ->first();
+
+        if ($account === null) {
+            throw ValidationException::withMessages([
+                'account' => "Control account with code '{$accountCode}' was not found in active COA version.",
+            ]);
+        }
+
+        return $account;
+    }
+}

--- a/app/Actions/JournalEntries/CreateJournalEntryAction.php
+++ b/app/Actions/JournalEntries/CreateJournalEntryAction.php
@@ -5,19 +5,45 @@ namespace App\Actions\JournalEntries;
 use App\Models\FiscalYear;
 use App\Models\JournalEntry;
 use Exception;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class CreateJournalEntryAction
 {
+    /**
+     * Create a journal entry with its lines.
+     *
+     * Optional keys (all backward compatible):
+     * - status: 'draft'|'posted' (default 'draft'). When 'posted', posted_by/posted_at are
+     *   filled and the entry is balance-verified before saving.
+     * - journal_type: e.g. 'general', 'adjusting', 'closing', 'recurring', 'system'.
+     * - source_type, source_id: morph reference to the originating document.
+     */
     public function execute(array $data): JournalEntry
     {
         $attempts = 0;
         $maxAttempts = 3;
 
+        $status = $data['status'] ?? 'draft';
+
+        if ($status === 'posted') {
+            $totalDebit = 0.0;
+            $totalCredit = 0.0;
+            foreach ($data['lines'] as $line) {
+                $totalDebit += (float) ($line['debit'] ?? 0);
+                $totalCredit += (float) ($line['credit'] ?? 0);
+            }
+            if (bccomp((string) $totalDebit, (string) $totalCredit, 2) !== 0) {
+                throw ValidationException::withMessages([
+                    'lines' => 'Journal entry is not balanced (debit must equal credit).',
+                ]);
+            }
+        }
+
         while ($attempts < $maxAttempts) {
             try {
-                return DB::transaction(function () use ($data) {
+                return DB::transaction(function () use ($data, $status) {
                     $entryDate = $data['entry_date'];
 
                     $fiscalYear = FiscalYear::where('start_date', '<=', $entryDate)
@@ -55,15 +81,27 @@ class CreateJournalEntryAction
 
                     $entryNumber = 'JV-' . $fiscalYear->name . '-' . str_pad((string) $count, 5, '0', STR_PAD_LEFT);
 
-                    $journalEntry = JournalEntry::create([
+                    $userId = Auth::id();
+
+                    $attributes = [
                         'fiscal_year_id' => $fiscalYear->id,
                         'entry_number' => $entryNumber,
                         'entry_date' => $data['entry_date'],
                         'reference' => $data['reference'] ?? null,
                         'description' => $data['description'],
-                        'status' => 'draft', // Default to draft
-                        'created_by' => auth()->id(),
-                    ]);
+                        'status' => $status,
+                        'journal_type' => $data['journal_type'] ?? 'general',
+                        'source_type' => $data['source_type'] ?? null,
+                        'source_id' => $data['source_id'] ?? null,
+                        'created_by' => $userId,
+                    ];
+
+                    if ($status === 'posted') {
+                        $attributes['posted_by'] = $userId;
+                        $attributes['posted_at'] = now();
+                    }
+
+                    $journalEntry = JournalEntry::create($attributes);
 
                     foreach ($data['lines'] as $lineData) {
                         $journalEntry->lines()->create([

--- a/app/Http/Controllers/ApPaymentController.php
+++ b/app/Http/Controllers/ApPaymentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\AccountingPosting\PostApPaymentJournalAction;
 use App\Actions\ApPayments\ExportApPaymentsAction;
 use App\Actions\ApPayments\IndexApPaymentsAction;
 use App\Actions\ApPayments\SyncApPaymentAllocationsAction;
@@ -64,13 +65,16 @@ class ApPaymentController extends Controller
     public function update(
         UpdateApPaymentRequest $request,
         ApPayment $apPayment,
-        SyncApPaymentAllocationsAction $syncAllocations
+        SyncApPaymentAllocationsAction $syncAllocations,
+        PostApPaymentJournalAction $postJournal
     ): JsonResponse {
         $validated = $request->validated();
         $allocations = $validated['allocations'] ?? null;
         unset($validated['allocations']);
 
-        if (($validated['status'] ?? null) === 'confirmed' && $apPayment->confirmed_at === null) {
+        $isNewlyConfirmed = ($validated['status'] ?? null) === 'confirmed' && $apPayment->confirmed_at === null;
+
+        if ($isNewlyConfirmed) {
             $validated['confirmed_by'] = Auth::id();
             $validated['confirmed_at'] = now()->toIso8601String();
         }
@@ -89,6 +93,10 @@ class ApPaymentController extends Controller
                 $syncAllocations->execute($apPayment, $allocations);
             },
         );
+
+        if ($isNewlyConfirmed) {
+            $postJournal->execute($apPayment->refresh());
+        }
 
         return (new ApPaymentResource($this->loadResourceRelations($apPayment)))->response();
     }

--- a/app/Http/Controllers/SupplierBillController.php
+++ b/app/Http/Controllers/SupplierBillController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\AccountingPosting\PostSupplierBillJournalAction;
 use App\Actions\SupplierBills\ExportSupplierBillsAction;
 use App\Actions\SupplierBills\IndexSupplierBillsAction;
 use App\Actions\SupplierBills\SyncSupplierBillItemsAction;
@@ -61,13 +62,16 @@ class SupplierBillController extends Controller
     public function update(
         UpdateSupplierBillRequest $request,
         SupplierBill $supplierBill,
-        SyncSupplierBillItemsAction $syncItems
+        SyncSupplierBillItemsAction $syncItems,
+        PostSupplierBillJournalAction $postJournal
     ): JsonResponse {
         $validated = $request->validated();
         $items = $validated['items'] ?? null;
         unset($validated['items']);
 
-        if (($validated['status'] ?? null) === 'confirmed' && $supplierBill->confirmed_at === null) {
+        $isNewlyConfirmed = ($validated['status'] ?? null) === 'confirmed' && $supplierBill->confirmed_at === null;
+
+        if ($isNewlyConfirmed) {
             $validated['confirmed_by'] = Auth::id();
             $validated['confirmed_at'] = now()->toIso8601String();
         }
@@ -81,6 +85,10 @@ class SupplierBillController extends Controller
                 $syncItems->execute($supplierBill, $items);
             },
         );
+
+        if ($isNewlyConfirmed) {
+            $postJournal->execute($supplierBill->refresh());
+        }
 
         return (new SupplierBillResource($this->loadResourceRelations($supplierBill)))->response();
     }

--- a/docs/database/IMPLEMENTATION_STATUS.md
+++ b/docs/database/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status — Database Modules
 
-> **Last updated:** 2026-05-13
+> **Last updated:** 2026-05-15
 >
 > **Purpose:** Referensi cepat untuk AI agent dan developer tentang status implementasi setiap modul database. Dokumen ini adalah satu-satunya sumber kebenaran untuk status implementasi — jangan duplikasi informasi ini di file desain individual.
 
@@ -31,7 +31,7 @@
 | 15 | Accounts Payable | `15_accounts_payable_design.md` | ✅ Implemented | PR #10 |
 | 16 | Accounts Receivable | `16_accounts_receivable_design.md` | ✅ Implemented | PR #11 |
 | 17 | General Ledger (Extended) | `17_general_ledger_design.md` | ✅ Implemented | PR #12 |
-| 18 | Financial Reports | `18_financial_reports_design.md` | 🚧 In Progress | `feature/financial-reports` |
+| 18 | Financial Reports | `18_financial_reports_design.md` | ✅ Implemented | PR #13 |
 
 ---
 
@@ -239,22 +239,24 @@
 
 ---
 
-### 🚧 Financial Reports
+### ✅ Financial Reports
 
 **Design doc:** `18_financial_reports_design.md`
 
-| Layer | Status |
-|-------|--------|
-| Migration | 🚧 In Progress (branch `feature/financial-reports`) |
-| Model | 🚧 In Progress |
-| Controller | 🚧 In Progress |
-| Frontend | 🚧 In Progress |
-| Factory | 🚧 In Progress |
-| Tests | 🚧 In Progress |
+| Layer | Status | Files |
+|-------|--------|-------|
+| Migration | ✅ | `2026_05_13_000100_create_report_configurations_table.php`, `2026_05_13_000200_create_report_sections_table.php` |
+| Model | ✅ | `ReportConfiguration`, `ReportSection` |
+| Controller | ✅ | `ReportConfigurationController`, `ReportController` (extended with `configuration` payload) |
+| Frontend | ✅ | `pages/report-configurations/`, `components/report-configurations/` (Columns, Filters, Form with `useFieldArray`, ViewModal) |
+| Factory | ✅ | `ReportConfigurationFactory`, `ReportSectionFactory` |
+| Tests | ✅ | 36 Pest financial-reports, 12 Pest reports, 7 E2E `report-configurations` |
+| Seeder | ✅ | `ReportConfigurationSeeder` (4 default configs: balance_sheet 15, income_statement 16, cash_flow 13, trial_balance 2 sections) |
 
-**Tables to create:** `report_configurations`, `report_sections`
+**Dependencies:** GL Extended (✅), AP (✅), AR (✅) — all prerequisites merged (PR #10, #11, #12, #13).
 
-**Dependencies:** GL Extended (✅), AP (✅), AR (✅) — all prerequisites merged (PR #10, #11, #12).
+**Known gaps vs design:**
+- Layout binding to actual GL/AP/AR balances dilakukan via existing `ReportController` actions; konfigurasi saat ini fokus pada struktur sections (ordering, sign_convention, formula). Render engine yang membaca formula expression untuk komputasi advanced belum diimplementasi (current behavior: section metadata + balance lookup by account code).
 
 ---
 
@@ -315,20 +317,13 @@ Dependencies: COA (✅), AP (✅ Fase 1A), AR (✅ Fase 1B)
 Design doc: `17_general_ledger_design.md`
 Note: Sebagian fitur GL dasar (journal entries, posting) sudah ada di COA module. Fase ini menambahkan fitur lanjutan.
 
-### Fase 3 — Financial Reports (18)
+### Fase 3 — Financial Reports (18) — ✅ COMPLETE
 
-Harus menunggu GL Extended selesai karena laporan keuangan membutuhkan data dari semua modul akuntansi.
+Implemented in PR #13 (`feature/financial-reports`). 42 files / +2453 / −42, 36 Pest financial-reports tests, 12 Pest reports tests, 7 E2E `report-configurations` tests.
 
-| Step | Scope | Skill | Estimasi |
-|------|-------|-------|----------|
-| 1 | Migration: `report_configurations`, `report_sections` | `database-migration` | 15m |
-| 2 | Models + Backend | `feature-non-crud` | 2h |
-| 3 | Frontend: Report pages (balance sheet, income statement, cash flow, dll) | `feature-non-crud` | 4h |
-| 4 | Tests | `testing-strategy` | 2h |
-
-Dependencies: GL Extended (Fase 2), AP (Fase 1A), AR (Fase 1B)
+Dependencies: GL Extended (✅ Fase 2), AP (✅ Fase 1A), AR (✅ Fase 1B)
 Design doc: `18_financial_reports_design.md`
-Note: Partial implementation sudah ada (`ReportController`, `pages/reports/`). Fase ini memperluas dengan konfigurasi report dan section yang dinamis.
+Note: Tabel `report_configurations` dan `report_sections` dengan hierarchical `parent_id`, enum `section_type` (header/detail/subtotal/total/separator), dan enum `sign_convention` (normal/reversed). `ReportController` diperluas dengan key `configuration` (additive, non-breaking).
 
 ### Fase 4 — Integration & Remaining Gaps
 
@@ -378,6 +373,8 @@ Task-task ini bisa dikerjakan kapan saja, tidak harus menunggu Fase 1-3.
 
 | Date | Milestone |
 |------|-----------|
+| 2026-05-15 | Financial Reports module complete (PR #13) |
+| 2026-05-13 | General Ledger Extended module complete (PR #12) |
 | 2026-05-11 | Accounts Receivable module complete (PR #11) |
 | 2026-05-10 | Accounts Payable module complete (PR #10) |
 | 2026-05-02 | Products V1→V2 migration complete (Fase 1-8) |

--- a/task.changelog.md
+++ b/task.changelog.md
@@ -1,6 +1,6 @@
 # Changelog Tugas
 
-Terakhir diperbarui: 2026-04-28
+Terakhir diperbarui: 2026-05-15
 
 File ini menyimpan catatan perubahan produk dan fitur.
 Baca `task.md` untuk status handoff aktif dan `task.handoff-archive.md` untuk riwayat checkpoint E2E lama.
@@ -40,6 +40,23 @@ Catatan penamaan: heading modul memakai pola `Nama Modul di Kode (Label Bisnis)`
 ### Modul Asset Movement (Mutasi Aset)
 
 - [ ] Dokumen: tambah upload dokumen movement
+
+### Modul Financial Reports (Laporan Keuangan)
+
+- [x] Refactor config-driven: tabel `report_configurations` dan `report_sections` (hierarchical `parent_id`, enum `section_type`, enum `sign_convention`, optional `formula`).
+- [x] Seeder default untuk 4 laporan built-in: Balance Sheet (15 sections), Income Statement (16), Cash Flow (13), Trial Balance (2).
+- [x] Admin UI Report Configuration di `/report-configurations` dengan nested section editor (`useFieldArray`).
+- [x] API `GET /api/reports/{balance-sheet,income-statement,cash-flow,trial-balance}` menambahkan key `configuration` (additive, non-breaking) tanpa mengubah struktur `report` lama.
+- [x] Menu seeder menambahkan entri "Report Configuration" di grup Accounting; Permission seeder menambahkan `report_configuration` + CRUD children.
+- [x] Cakupan tes: 36 Pest financial-reports, 12 Pest reports, 7 E2E Playwright report-configurations.
+
+### Modul Accounts Payable (Hutang Usaha)
+
+- [x] Auto-posting jurnal saat Supplier Bill di-confirm: Debit akun per-item (grouped by `account_id`), Credit Accounts Payable (`code=21100`).
+- [x] Auto-posting jurnal saat AP Payment di-confirm: Debit Accounts Payable, Credit `bank_account_id`.
+- [x] Idempoten — re-confirm atau update setelah confirmed tidak menduplikasi jurnal.
+- [x] `JournalEntry.source_type/source_id` di-set ke dokumen sumber (`App\Models\SupplierBill` / `App\Models\ApPayment`) untuk audit trail.
+- [x] Cakupan tes: 13 Pest ap-journal-posting (action-level + controller PUT integration), regresi clean pada supplier-bills, ap-payments, journal-entries, dan asset-depreciation-runs.
 
 ## Dokumen Terkait
 

--- a/task.md
+++ b/task.md
@@ -1,6 +1,6 @@
-# AI Handoff: Financial Reports (Modul 18) — Config-Driven Refactor
+# AI Handoff: AP Journal Auto-Posting (Pending Decision #2 part 1)
 
-Last updated: 2026-05-13 UTC
+Last updated: 2026-05-15 UTC
 
 ## Document Roles
 
@@ -10,73 +10,66 @@ Last updated: 2026-05-13 UTC
 
 ## Current Objective
 
-- **Financial Reports (Modul 18)** — Config-driven report system with Report Configuration CRUD. Local implementation complete. Ready to push branch + open PR.
+- Ship AP journal auto-posting (Modul 15 §4 / Modul 17 §6 integration). Branch ready; commit + push + PR pending.
 
 ## Current Milestone
 
-- PR #12 (GL Extended) merged to main as `f3252285`.
-- Branch `feature/financial-reports` — all waves complete locally:
-  - ✅ Wave 1: Migrations (`report_configurations`, `report_sections`) + Models + 16 unit tests
-  - ✅ Wave 2: `ReportConfigurationSeeder` seeds 4 defaults (balance_sheet 15 sections, income_statement 16, cash_flow 13, trial_balance 2)
-  - ✅ Wave 3: Report Configuration CRUD backend (Controller, Action, FilterService, Requests, Resource, Export) + 14 feature tests
-  - ✅ Wave 4: `ReportController` extended with `configuration` payload (via `GetReportConfigurationByTypeAction`) — additive, non-breaking + 6 new tests
-  - ✅ Wave 5: Frontend CRUD (entity config, Columns, Filters, Form with `useFieldArray` for sections, ViewModal, page) + Menu + Permission seeder entries
-  - ✅ Wave 6: E2E Playwright (7 specs passed) + Quality gate (PHPStan 0 errors, TS clean, ESLint clean)
+- ✅ **Modul 18 (Financial Reports)** — merged via PR #13 as `82b7989e`.
+- 🚧 **AP journal auto-posting** — branch `feature/ap-journal-auto-posting`. All code + tests + style verifications green locally. Ready to commit + push + open PR.
 
 ## Current State
 
-- Branch: `feature/financial-reports`
-- Commits: pending (not yet committed)
-- HEAD parent: `f3252285` (merged main)
-- PHPStan: 0 errors (full project 1023 files)
-- TypeScript: clean (`npm run types`)
-- ESLint: clean (`npm run lint --fix`)
-- Pest `--group=financial-reports`: 36 passed (103 assertions)
-- Pest `--group=reports`: 12 passed (79 assertions)
-- E2E `tests/e2e/report-configurations/`: 7 passed (33.7s)
+- Branch: `feature/ap-journal-auto-posting`
+- Parent: `82b7989e` (main)
+- Commits: pending
+- PHPStan: 0 errors (full project)
+- Pest groups: ap-journal-posting (13/13), supplier-bills (8/8), ap-payments (12/12), journal-entries (29/29), asset-depreciation-runs (12/12), goods-receipts (22/22), purchase-orders (17/17), ar-receipts (8/8), customer-invoices (8/8), recurring-journals (16/16), reports (12/12), accounts (34/34) — all green.
+- Duster: applied (CS Fixer + Pint pass).
 
 ## Active Constraints
 
 - Use Sail for every runtime command.
+- Auto-posting is additive + non-breaking; existing tests that triggered `status='confirmed'` were updated to seed the COA control account (`code=21100`).
 
 ## Latest Session Delta
 
-- Merged PR #12 (GL Extended) — no code changes, just CI retrigger after autofix commit (`8b608724`).
-- Implemented Modul 18 config-driven refactor (full scope per user choice):
-  - Config tables `report_configurations`, `report_sections` with hierarchical `parent_id`, `section_type` enum (header/detail/subtotal/total/separator), `sign_convention` enum (normal/reversed), optional `formula`.
-  - Seeder preloads design-doc defaults for 4 built-in reports.
-  - Admin UI at `/report-configurations` with nested section editor (`useFieldArray`).
-  - `GET /api/reports/{balance-sheet,income-statement,cash-flow,trial-balance}` responses now include `configuration: { id, code, name, report_type, sections: [...] }` key. Existing `report` payload unchanged → frontend pages keep working.
-  - Menu seeder adds "Report Configuration" entry under Accounting. Permission seeder adds `report_configuration` + CRUD children.
+- Added 3 new actions in `app/Actions/AccountingPosting/`:
+  - `ResolveControlAccountAction` — looks up an account by code in the active CoaVersion.
+  - `PostSupplierBillJournalAction` — on bill confirm: Debit per-item `account_id` (grouped by account), Credit AP control (`code=21100`). Idempotent via `journal_entry_id` short-circuit.
+  - `PostApPaymentJournalAction` — on payment confirm: Debit AP control, Credit `bank_account_id`. Idempotent.
+- Extended `CreateJournalEntryAction::execute()` (additive): accepts optional `status` (`draft`|`posted`), `journal_type`, `source_type`, `source_id`. When `status='posted'`, balance is verified and `posted_by/posted_at` are stamped. Existing callers (depreciation, JournalEntryController) unchanged.
+- Wired hooks in `SupplierBillController::update()` and `ApPaymentController::update()` — only fires when status transitions from non-confirmed to `confirmed` (uses `confirmed_at === null` guard).
+- Pest coverage:
+  - Action-level: balance, idempotency, no-op when not confirmed, validation errors (no items, no active COA, non-positive payment).
+  - Controller-level: PUT endpoint posts journal on confirm; second PUT does NOT double-post.
+- Updated existing controller tests `update modifies supplier bill and items` + `update modifies ap payment` to seed FiscalYear + active CoaVersion + AP control account + bank account before triggering confirm.
 
 ## Validated Commands and Outcomes
 
-- `./vendor/bin/sail bin phpstan analyze` — 0 errors
-- `./vendor/bin/sail npm run types` — clean
-- `./vendor/bin/sail npm run lint` — clean
-- `./vendor/bin/sail test --group=financial-reports` — 36 passed (103 assertions)
-- `./vendor/bin/sail test --group=reports` — 12 passed (79 assertions)
-- `./vendor/bin/sail npm run test:e2e -- tests/e2e/report-configurations/` — 7 passed
-- `./vendor/bin/sail artisan migrate:fresh --seed` — all seeders green
+- `./vendor/bin/sail bin phpstan analyze` — 0 errors.
+- `./vendor/bin/sail test --group=ap-journal-posting` — 13 passed (47 assertions).
+- `./vendor/bin/sail test --group=supplier-bills` — 8 passed (42 assertions).
+- `./vendor/bin/sail test --group=ap-payments` — 12 passed (58 assertions).
+- `./vendor/bin/sail test --group=journal-entries` — 29 passed (194 assertions).
+- `./vendor/bin/sail test --group=asset-depreciation-runs` — 12 passed (no regression on the other CreateJournalEntryAction caller).
+- `./vendor/bin/sail bin duster fix` — clean.
 
 ## Open Risks / Blockers
 
-- None. Ready to commit + push + open PR.
-- Note: `sail bin duster fix` was invoked once but exceeded the 5m bash timeout. Not a blocker — PHPStan/TS/ESLint/Pest all pass, and CI duster step will auto-fix on push if anything slipped.
+- None. Test DB is clean, all groups green, PHPStan clean.
 
 ## Recommended Next Steps
 
-1. Stage and commit all 29 changed files in one atomic commit: `feat: implement Financial Reports module (Modul 18)`.
-2. Push branch `feature/financial-reports` to origin.
-3. Open PR against `main` titled `feat: implement Financial Reports module (Modul 18)` referencing `docs/database/18_financial_reports_design.md`.
-4. Wait for CI. After autofix (if any), retrigger via empty commit per existing convention.
-5. On green CI → merge.
+1. Stage + commit all changes in one atomic commit: `feat: auto-post AP journal entries on bill/payment confirm (Pending Decision #2 partial)`.
+2. Push branch `feature/ap-journal-auto-posting`. Open PR against `main`.
+3. Monitor CI (expect autofix retrigger pattern as usual). Merge when green.
+4. Start AR journal auto-posting branch (`feature/ar-journal-auto-posting`) using the same pattern: PostCustomerInvoiceJournalAction (Debit AR, Credit Revenue) + PostArReceiptJournalAction (Debit Bank, Credit AR).
 
 ## Continuation Prompt
 
 ```
-Read task.md. Modul 18 (Financial Reports) implementation complete on branch feature/financial-reports.
-Commit all changes with message "feat: implement Financial Reports module (Modul 18)",
-push to origin, open PR against main. Monitor CI (expect autofix retrigger pattern),
-then merge when green.
+Read task.md. Branch feature/ap-journal-auto-posting on parent 82b7989e (main).
+AP auto-posting (SupplierBill + ApPayment) implemented + tested. Commit "feat: auto-post AP
+journal entries on bill/payment confirm", push, open PR, monitor CI, merge.
+After merge, start feature/ar-journal-auto-posting using the same pattern.
 ```

--- a/tests/Feature/AccountingPosting/ApJournalPostingTest.php
+++ b/tests/Feature/AccountingPosting/ApJournalPostingTest.php
@@ -1,0 +1,427 @@
+<?php
+
+use App\Actions\AccountingPosting\PostApPaymentJournalAction;
+use App\Actions\AccountingPosting\PostSupplierBillJournalAction;
+use App\Models\Account;
+use App\Models\ApPayment;
+use App\Models\CoaVersion;
+use App\Models\FiscalYear;
+use App\Models\JournalEntry;
+use App\Models\SupplierBill;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\putJson;
+
+uses(RefreshDatabase::class)->group('ap-journal-posting');
+
+function makePostingFiscalYear(): FiscalYear
+{
+    return FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+}
+
+function makePostingChartOfAccounts(): array
+{
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+
+    $apAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '21100',
+        'name' => 'Accounts Payable',
+        'type' => 'liability',
+        'normal_balance' => 'credit',
+        'is_active' => true,
+    ]);
+
+    $expenseAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '52000',
+        'name' => 'Operating Expense',
+        'type' => 'expense',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
+    $bankAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11110',
+        'name' => 'Cash in Bank',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
+    return [
+        'coa_version' => $coaVersion,
+        'ap' => $apAccount,
+        'expense' => $expenseAccount,
+        'bank' => $bankAccount,
+    ];
+}
+
+test('PostSupplierBillJournalAction creates a balanced posted journal entry', function () {
+    $fiscalYear = makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $supplierBill = SupplierBill::factory()->confirmed()->create([
+        'fiscal_year_id' => $fiscalYear->id,
+        'bill_number' => 'BILL-2026-000001',
+        'bill_date' => '2026-03-15',
+        'subtotal' => 1000000,
+        'tax_amount' => 110000,
+        'discount_amount' => 0,
+        'grand_total' => 1110000,
+        'amount_paid' => 0,
+        'amount_due' => 1110000,
+    ]);
+
+    $supplierBill->items()->create([
+        'account_id' => $accounts['expense']->id,
+        'description' => 'Service fee',
+        'quantity' => 1,
+        'unit_price' => 1000000,
+        'discount_percent' => 0,
+        'tax_percent' => 11,
+        'line_total' => 1110000,
+    ]);
+
+    $action = app(PostSupplierBillJournalAction::class);
+
+    $journalEntry = $action->execute($supplierBill->fresh());
+
+    expect($journalEntry)->not->toBeNull()
+        ->and($journalEntry->status)->toBe('posted')
+        ->and($journalEntry->journal_type)->toBe('system')
+        ->and($journalEntry->source_type)->toBe(SupplierBill::class)
+        ->and($journalEntry->source_id)->toBe($supplierBill->id)
+        ->and((float) $journalEntry->total_debit)->toBe(1110000.0)
+        ->and((float) $journalEntry->total_credit)->toBe(1110000.0);
+
+    assertDatabaseHas('supplier_bills', [
+        'id' => $supplierBill->id,
+        'journal_entry_id' => $journalEntry->id,
+    ]);
+
+    $apLine = $journalEntry->lines()->where('account_id', $accounts['ap']->id)->first();
+    expect((float) $apLine->credit)->toBe(1110000.0)
+        ->and((float) $apLine->debit)->toBe(0.0);
+
+    $expenseLine = $journalEntry->lines()->where('account_id', $accounts['expense']->id)->first();
+    expect((float) $expenseLine->debit)->toBe(1110000.0)
+        ->and((float) $expenseLine->credit)->toBe(0.0);
+});
+
+test('PostSupplierBillJournalAction is idempotent and returns existing entry', function () {
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $supplierBill = SupplierBill::factory()->confirmed()->create([
+        'bill_date' => '2026-03-15',
+        'grand_total' => 500000,
+        'amount_due' => 500000,
+    ]);
+    $supplierBill->items()->create([
+        'account_id' => $accounts['expense']->id,
+        'description' => 'Item',
+        'quantity' => 1,
+        'unit_price' => 500000,
+        'discount_percent' => 0,
+        'tax_percent' => 0,
+        'line_total' => 500000,
+    ]);
+
+    $action = app(PostSupplierBillJournalAction::class);
+
+    $first = $action->execute($supplierBill->fresh());
+    $second = $action->execute($supplierBill->fresh());
+
+    expect($second->id)->toBe($first->id);
+    expect(JournalEntry::count())->toBe(1);
+});
+
+test('PostSupplierBillJournalAction returns null when bill is not confirmed', function () {
+    makePostingFiscalYear();
+    makePostingChartOfAccounts();
+
+    $supplierBill = SupplierBill::factory()->create(['status' => 'draft']);
+
+    $action = app(PostSupplierBillJournalAction::class);
+
+    expect($action->execute($supplierBill))->toBeNull();
+    expect(JournalEntry::count())->toBe(0);
+});
+
+test('PostSupplierBillJournalAction throws when no items exist', function () {
+    makePostingFiscalYear();
+    makePostingChartOfAccounts();
+
+    $supplierBill = SupplierBill::factory()->confirmed()->create(['bill_date' => '2026-03-15']);
+
+    $action = app(PostSupplierBillJournalAction::class);
+
+    expect(fn () => $action->execute($supplierBill->fresh()))
+        ->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('PostSupplierBillJournalAction throws when no active COA version exists', function () {
+    makePostingFiscalYear();
+
+    $supplierBill = SupplierBill::factory()->confirmed()->create(['bill_date' => '2026-03-15']);
+    $orphanAccount = Account::factory()->create();
+    $supplierBill->items()->create([
+        'account_id' => $orphanAccount->id,
+        'description' => 'Item',
+        'quantity' => 1,
+        'unit_price' => 100000,
+        'discount_percent' => 0,
+        'tax_percent' => 0,
+        'line_total' => 100000,
+    ]);
+
+    $action = app(PostSupplierBillJournalAction::class);
+
+    expect(fn () => $action->execute($supplierBill->fresh()))
+        ->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('PostApPaymentJournalAction creates a balanced posted journal entry', function () {
+    $fiscalYear = makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $apPayment = ApPayment::factory()->confirmed()->create([
+        'fiscal_year_id' => $fiscalYear->id,
+        'payment_number' => 'PAY-2026-000001',
+        'payment_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 1110000,
+    ]);
+
+    $action = app(PostApPaymentJournalAction::class);
+
+    $journalEntry = $action->execute($apPayment->fresh());
+
+    expect($journalEntry)->not->toBeNull()
+        ->and($journalEntry->status)->toBe('posted')
+        ->and($journalEntry->journal_type)->toBe('system')
+        ->and($journalEntry->source_type)->toBe(ApPayment::class)
+        ->and($journalEntry->source_id)->toBe($apPayment->id);
+
+    assertDatabaseHas('ap_payments', [
+        'id' => $apPayment->id,
+        'journal_entry_id' => $journalEntry->id,
+    ]);
+
+    $apLine = $journalEntry->lines()->where('account_id', $accounts['ap']->id)->first();
+    expect((float) $apLine->debit)->toBe(1110000.0)
+        ->and((float) $apLine->credit)->toBe(0.0);
+
+    $bankLine = $journalEntry->lines()->where('account_id', $accounts['bank']->id)->first();
+    expect((float) $bankLine->credit)->toBe(1110000.0)
+        ->and((float) $bankLine->debit)->toBe(0.0);
+});
+
+test('PostApPaymentJournalAction is idempotent', function () {
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $apPayment = ApPayment::factory()->confirmed()->create([
+        'payment_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 500000,
+    ]);
+
+    $action = app(PostApPaymentJournalAction::class);
+
+    $first = $action->execute($apPayment->fresh());
+    $second = $action->execute($apPayment->fresh());
+
+    expect($second->id)->toBe($first->id);
+    expect(JournalEntry::count())->toBe(1);
+});
+
+test('PostApPaymentJournalAction returns null when payment is not confirmed', function () {
+    makePostingFiscalYear();
+    makePostingChartOfAccounts();
+
+    $apPayment = ApPayment::factory()->create(['status' => 'draft']);
+
+    $action = app(PostApPaymentJournalAction::class);
+
+    expect($action->execute($apPayment))->toBeNull();
+    expect(JournalEntry::count())->toBe(0);
+});
+
+test('PostApPaymentJournalAction throws on non-positive total amount', function () {
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $apPayment = ApPayment::factory()->confirmed()->create([
+        'payment_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 0,
+    ]);
+
+    $action = app(PostApPaymentJournalAction::class);
+
+    expect(fn () => $action->execute($apPayment->fresh()))
+        ->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('SupplierBillController update triggers journal posting on confirm transition', function () {
+    $user = createTestUserWithPermissions([
+        'supplier_bill',
+        'supplier_bill.create',
+        'supplier_bill.edit',
+        'supplier_bill.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $supplierBill = SupplierBill::factory()->create([
+        'status' => 'draft',
+        'bill_date' => '2026-03-15',
+        'subtotal' => 800000,
+        'tax_amount' => 0,
+        'discount_amount' => 0,
+        'grand_total' => 800000,
+        'amount_paid' => 0,
+        'amount_due' => 800000,
+    ]);
+
+    $payload = [
+        'status' => 'confirmed',
+        'items' => [
+            [
+                'account_id' => $accounts['expense']->id,
+                'description' => 'Service',
+                'quantity' => 1,
+                'unit_price' => 800000,
+                'discount_percent' => 0,
+                'tax_percent' => 0,
+            ],
+        ],
+    ];
+
+    putJson("/api/supplier-bills/{$supplierBill->id}", $payload)
+        ->assertOk()
+        ->assertJsonPath('data.status', 'confirmed');
+
+    $supplierBill->refresh();
+    expect($supplierBill->journal_entry_id)->not->toBeNull();
+
+    assertDatabaseHas('journal_entries', [
+        'id' => $supplierBill->journal_entry_id,
+        'status' => 'posted',
+        'journal_type' => 'system',
+        'source_type' => SupplierBill::class,
+        'source_id' => $supplierBill->id,
+    ]);
+});
+
+test('SupplierBillController update does not double-post on subsequent saves', function () {
+    $user = createTestUserWithPermissions([
+        'supplier_bill',
+        'supplier_bill.create',
+        'supplier_bill.edit',
+        'supplier_bill.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $supplierBill = SupplierBill::factory()->create([
+        'status' => 'draft',
+        'bill_date' => '2026-03-15',
+        'grand_total' => 500000,
+        'amount_due' => 500000,
+    ]);
+
+    $items = [[
+        'account_id' => $accounts['expense']->id,
+        'description' => 'Service',
+        'quantity' => 1,
+        'unit_price' => 500000,
+        'discount_percent' => 0,
+        'tax_percent' => 0,
+    ]];
+
+    putJson("/api/supplier-bills/{$supplierBill->id}", [
+        'status' => 'confirmed',
+        'items' => $items,
+    ])->assertOk();
+
+    putJson("/api/supplier-bills/{$supplierBill->id}", [
+        'notes' => 'edited after confirm',
+    ])->assertOk();
+
+    expect(JournalEntry::where('source_type', SupplierBill::class)->count())->toBe(1);
+});
+
+test('ApPaymentController update triggers journal posting on confirm transition', function () {
+    $user = createTestUserWithPermissions([
+        'ap_payment',
+        'ap_payment.create',
+        'ap_payment.edit',
+        'ap_payment.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $apPayment = ApPayment::factory()->create([
+        'status' => 'draft',
+        'payment_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 750000,
+    ]);
+
+    putJson("/api/ap-payments/{$apPayment->id}", [
+        'status' => 'confirmed',
+    ])->assertOk()->assertJsonPath('data.status', 'confirmed');
+
+    $apPayment->refresh();
+    expect($apPayment->journal_entry_id)->not->toBeNull();
+
+    assertDatabaseHas('journal_entries', [
+        'id' => $apPayment->journal_entry_id,
+        'status' => 'posted',
+        'journal_type' => 'system',
+        'source_type' => ApPayment::class,
+        'source_id' => $apPayment->id,
+    ]);
+});
+
+test('ApPaymentController update does not double-post on subsequent saves', function () {
+    $user = createTestUserWithPermissions([
+        'ap_payment',
+        'ap_payment.create',
+        'ap_payment.edit',
+        'ap_payment.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makePostingFiscalYear();
+    $accounts = makePostingChartOfAccounts();
+
+    $apPayment = ApPayment::factory()->create([
+        'status' => 'draft',
+        'payment_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 250000,
+    ]);
+
+    putJson("/api/ap-payments/{$apPayment->id}", ['status' => 'confirmed'])->assertOk();
+    putJson("/api/ap-payments/{$apPayment->id}", ['notes' => 'reconciled note'])->assertOk();
+
+    expect(JournalEntry::where('source_type', ApPayment::class)->count())->toBe(1);
+});

--- a/tests/Feature/ApPayments/ApPaymentControllerTest.php
+++ b/tests/Feature/ApPayments/ApPaymentControllerTest.php
@@ -3,6 +3,7 @@
 use App\Models\Account;
 use App\Models\ApPayment;
 use App\Models\Branch;
+use App\Models\CoaVersion;
 use App\Models\FiscalYear;
 use App\Models\Supplier;
 use App\Models\SupplierBill;
@@ -137,7 +138,34 @@ test('show returns ap payment detail', function () {
 });
 
 test('update modifies ap payment', function () {
-    $apPayment = ApPayment::factory()->create();
+    FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+    Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '21100',
+        'name' => 'Accounts Payable',
+        'type' => 'liability',
+        'normal_balance' => 'credit',
+        'is_active' => true,
+    ]);
+    $bankAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11110',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
+    $apPayment = ApPayment::factory()->create([
+        'payment_date' => '2026-03-15',
+        'bank_account_id' => $bankAccount->id,
+        'total_amount' => 500000,
+    ]);
 
     $payload = [
         'status' => 'confirmed',

--- a/tests/Feature/SupplierBills/SupplierBillControllerTest.php
+++ b/tests/Feature/SupplierBills/SupplierBillControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Account;
 use App\Models\Branch;
+use App\Models\CoaVersion;
 use App\Models\FiscalYear;
 use App\Models\Product;
 use App\Models\Supplier;
@@ -146,9 +147,33 @@ test('show returns supplier bill detail', function () {
 });
 
 test('update modifies supplier bill and items', function () {
-    $supplierBill = SupplierBill::factory()->create();
+    FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+    Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '21100',
+        'name' => 'Accounts Payable',
+        'type' => 'liability',
+        'normal_balance' => 'credit',
+        'is_active' => true,
+    ]);
+
+    $supplierBill = SupplierBill::factory()->create([
+        'bill_date' => '2026-03-01',
+    ]);
     $product = Product::factory()->create();
-    $account = Account::factory()->create();
+    $account = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '52000',
+        'type' => 'expense',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
 
     $payload = [
         'status' => 'confirmed',


### PR DESCRIPTION
## Summary

- Closes Pending Decision #2 (AP side) — supplier bills and AP payments now automatically create **posted** journal entries when confirmed.
- Implements `15_accounts_payable_design.md` §4 (Posting Jurnal) end-to-end via the controller-hook approach approved in handoff.
- Fully idempotent and additive — existing API contracts unchanged.

## What posts when

- `SupplierBill` confirm → **Debit** each item's `account_id` (grouped), **Credit** Accounts Payable control account (`code=21100`).
- `ApPayment` confirm → **Debit** Accounts Payable, **Credit** the payment's `bank_account_id`.

Each generated `JournalEntry` carries:
- `status='posted'`
- `journal_type='system'`
- `source_type` + `source_id` → back-reference to the originating document.

## Idempotency

Re-saving or re-confirming a previously-confirmed document never produces a duplicate journal — every action checks `journal_entry_id` first and returns the existing entry. Verified by dedicated tests (`does not double-post on subsequent saves`).

## New surface area

- `app/Actions/AccountingPosting/ResolveControlAccountAction.php` — looks up an account by `code` in the active `CoaVersion`.
- `app/Actions/AccountingPosting/PostSupplierBillJournalAction.php`
- `app/Actions/AccountingPosting/PostApPaymentJournalAction.php`

## Modified

- `app/Actions/JournalEntries/CreateJournalEntryAction.php` — additive: accepts optional `status`, `journal_type`, `source_type`, `source_id`. Balance verified when `status='posted'`. Existing callers (depreciation, JournalEntryController) unchanged.
- `app/Http/Controllers/SupplierBillController.php` and `ApPaymentController.php` — fire posting actions only on the `draft → confirmed` transition (guarded by `confirmed_at === null`).

## Tests (all green locally)

| Group | Result |
| --- | --- |
| `ap-journal-posting` (new) | 13 / 13 — 47 assertions |
| `supplier-bills` | 8 / 8 |
| `ap-payments` | 12 / 12 |
| `journal-entries` | 29 / 29 |
| `asset-depreciation-runs` | 12 / 12 (other `CreateJournalEntryAction` consumer — no regression) |
| `goods-receipts` | 22 / 22 |
| `purchase-orders` | 17 / 17 |
| `ar-receipts` | 8 / 8 |
| `customer-invoices` | 8 / 8 |
| `recurring-journals` | 16 / 16 |
| `reports` | 12 / 12 |
| `accounts` | 34 / 34 |

`./vendor/bin/sail bin phpstan analyze` — **0 errors** (full project).
`./vendor/bin/sail bin duster fix` — **clean**.

## Migration / data impact

None. Reuses the existing `journal_entries.journal_type / source_type / source_id` columns added in the GL Extended migration. No new tables, no data backfill — historical bills/payments stay untouched.

## Follow-up

After this lands, the same pattern will be applied to AR (`feature/ar-journal-auto-posting`): `PostCustomerInvoiceJournalAction` (Debit AR, Credit Revenue) + `PostArReceiptJournalAction` (Debit Bank, Credit AR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)