### PR TITLE
feat: auto-post AR journal entries on invoice sent / receipt confirm

### DIFF
--- a/app/Actions/AccountingPosting/PostArReceiptJournalAction.php
+++ b/app/Actions/AccountingPosting/PostArReceiptJournalAction.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Actions\AccountingPosting;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\ArReceipt;
+use App\Models\JournalEntry;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class PostArReceiptJournalAction
+{
+    public const AR_CONTROL_ACCOUNT_CODE = '11200';
+
+    public function __construct(
+        private CreateJournalEntryAction $createJournalEntry,
+        private ResolveControlAccountAction $resolveControlAccount,
+    ) {}
+
+    public function execute(ArReceipt $arReceipt): ?JournalEntry
+    {
+        if ($arReceipt->journal_entry_id !== null) {
+            /** @var JournalEntry|null $existing */
+            $existing = $arReceipt->journalEntry()->first();
+
+            return $existing;
+        }
+
+        if ($arReceipt->status !== 'confirmed') {
+            return null;
+        }
+
+        return DB::transaction(function () use ($arReceipt): JournalEntry {
+            $amount = round((float) $arReceipt->total_amount, 2);
+
+            if ($amount <= 0) {
+                throw ValidationException::withMessages([
+                    'total_amount' => 'Cannot post a receipt with non-positive total amount.',
+                ]);
+            }
+
+            $arAccount = $this->resolveControlAccount->execute(self::AR_CONTROL_ACCOUNT_CODE);
+
+            $journalEntry = $this->createJournalEntry->execute([
+                'entry_date' => $arReceipt->receipt_date->format('Y-m-d'),
+                'reference' => $arReceipt->receipt_number,
+                'description' => "AR Receipt {$arReceipt->receipt_number}",
+                'status' => 'posted',
+                'journal_type' => 'system',
+                'source_type' => ArReceipt::class,
+                'source_id' => $arReceipt->id,
+                'lines' => [
+                    [
+                        'account_id' => (int) $arReceipt->bank_account_id,
+                        'debit' => $amount,
+                        'credit' => 0,
+                        'memo' => "Receipt {$arReceipt->receipt_number}",
+                    ],
+                    [
+                        'account_id' => $arAccount->id,
+                        'debit' => 0,
+                        'credit' => $amount,
+                        'memo' => "Receipt {$arReceipt->receipt_number}",
+                    ],
+                ],
+            ]);
+
+            $arReceipt->forceFill([
+                'journal_entry_id' => $journalEntry->id,
+            ])->save();
+
+            return $journalEntry;
+        });
+    }
+}

--- a/app/Actions/AccountingPosting/PostCustomerInvoiceJournalAction.php
+++ b/app/Actions/AccountingPosting/PostCustomerInvoiceJournalAction.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Actions\AccountingPosting;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\CustomerInvoice;
+use App\Models\JournalEntry;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class PostCustomerInvoiceJournalAction
+{
+    public const AR_CONTROL_ACCOUNT_CODE = '11200';
+
+    public function __construct(
+        private CreateJournalEntryAction $createJournalEntry,
+        private ResolveControlAccountAction $resolveControlAccount,
+    ) {}
+
+    public function execute(CustomerInvoice $invoice): ?JournalEntry
+    {
+        if ($invoice->journal_entry_id !== null) {
+            /** @var JournalEntry|null $existing */
+            $existing = $invoice->journalEntry()->first();
+
+            return $existing;
+        }
+
+        if ($invoice->status !== 'sent') {
+            return null;
+        }
+
+        return DB::transaction(function () use ($invoice): JournalEntry {
+            $invoice->loadMissing('items');
+
+            if ($invoice->items->isEmpty()) {
+                throw ValidationException::withMessages([
+                    'items' => 'Cannot post a customer invoice with no items.',
+                ]);
+            }
+
+            $arAccount = $this->resolveControlAccount->execute(self::AR_CONTROL_ACCOUNT_CODE);
+
+            $creditTotal = 0.0;
+            $creditLines = [];
+            $revenueGrouped = [];
+
+            foreach ($invoice->items as $item) {
+                $accountId = (int) $item->account_id;
+                $revenueGrouped[$accountId] = ($revenueGrouped[$accountId] ?? 0.0) + (float) $item->line_total;
+            }
+
+            foreach ($revenueGrouped as $accountId => $amount) {
+                if ($amount <= 0) {
+                    continue;
+                }
+
+                $creditLines[] = [
+                    'account_id' => $accountId,
+                    'debit' => 0,
+                    'credit' => round($amount, 2),
+                    'memo' => "Invoice {$invoice->invoice_number}",
+                ];
+                $creditTotal += $amount;
+            }
+
+            $creditTotal = round($creditTotal, 2);
+
+            $debitLine = [
+                'account_id' => $arAccount->id,
+                'debit' => $creditTotal,
+                'credit' => 0,
+                'memo' => "Invoice {$invoice->invoice_number}",
+            ];
+
+            $journalEntry = $this->createJournalEntry->execute([
+                'entry_date' => $invoice->invoice_date->format('Y-m-d'),
+                'reference' => $invoice->invoice_number,
+                'description' => "Customer Invoice {$invoice->invoice_number}",
+                'status' => 'posted',
+                'journal_type' => 'system',
+                'source_type' => CustomerInvoice::class,
+                'source_id' => $invoice->id,
+                'lines' => array_merge([$debitLine], $creditLines),
+            ]);
+
+            $invoice->forceFill([
+                'journal_entry_id' => $journalEntry->id,
+            ])->save();
+
+            return $journalEntry;
+        });
+    }
+}

--- a/app/Http/Controllers/ArReceiptController.php
+++ b/app/Http/Controllers/ArReceiptController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\AccountingPosting\PostArReceiptJournalAction;
 use App\Actions\ArReceipts\ExportArReceiptsAction;
 use App\Actions\ArReceipts\IndexArReceiptsAction;
 use App\Actions\ArReceipts\SyncArReceiptAllocationsAction;
@@ -65,13 +66,16 @@ class ArReceiptController extends Controller
     public function update(
         UpdateArReceiptRequest $request,
         ArReceipt $arReceipt,
-        SyncArReceiptAllocationsAction $syncAllocations
+        SyncArReceiptAllocationsAction $syncAllocations,
+        PostArReceiptJournalAction $postJournal
     ): JsonResponse {
         $validated = $request->validated();
         $allocations = $validated['allocations'] ?? null;
         unset($validated['allocations']);
 
-        if (($validated['status'] ?? null) === 'confirmed' && $arReceipt->confirmed_at === null) {
+        $isNewlyConfirmed = ($validated['status'] ?? null) === 'confirmed' && $arReceipt->confirmed_at === null;
+
+        if ($isNewlyConfirmed) {
             $validated['confirmed_by'] = Auth::id();
             $validated['confirmed_at'] = now()->toIso8601String();
         }
@@ -87,6 +91,10 @@ class ArReceiptController extends Controller
                 $syncAllocations->execute($arReceipt, $allocations);
             },
         );
+
+        if ($isNewlyConfirmed) {
+            $postJournal->execute($arReceipt->refresh());
+        }
 
         return (new ArReceiptResource($this->loadResourceRelations($arReceipt)))->response();
     }

--- a/app/Http/Controllers/CustomerInvoiceController.php
+++ b/app/Http/Controllers/CustomerInvoiceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\AccountingPosting\PostCustomerInvoiceJournalAction;
 use App\Actions\CustomerInvoices\ExportCustomerInvoicesAction;
 use App\Actions\CustomerInvoices\IndexCustomerInvoicesAction;
 use App\Actions\CustomerInvoices\SyncCustomerInvoiceItemsAction;
@@ -63,13 +64,16 @@ class CustomerInvoiceController extends Controller
     public function update(
         UpdateCustomerInvoiceRequest $request,
         CustomerInvoice $customerInvoice,
-        SyncCustomerInvoiceItemsAction $syncItems
+        SyncCustomerInvoiceItemsAction $syncItems,
+        PostCustomerInvoiceJournalAction $postJournal
     ): JsonResponse {
         $validated = $request->validated();
         $items = $validated['items'] ?? null;
         unset($validated['items']);
 
-        if (($validated['status'] ?? null) === 'sent' && $customerInvoice->sent_at === null) {
+        $isNewlySent = ($validated['status'] ?? null) === 'sent' && $customerInvoice->sent_at === null;
+
+        if ($isNewlySent) {
             $validated['sent_by'] = Auth::id();
             $validated['sent_at'] = now()->toIso8601String();
         }
@@ -85,6 +89,10 @@ class CustomerInvoiceController extends Controller
                 $syncItems->execute($customerInvoice, $items);
             },
         );
+
+        if ($isNewlySent) {
+            $postJournal->execute($customerInvoice->refresh());
+        }
 
         return (new CustomerInvoiceResource($this->loadResourceRelations($customerInvoice)))->response();
     }

--- a/task.changelog.md
+++ b/task.changelog.md
@@ -58,6 +58,14 @@ Catatan penamaan: heading modul memakai pola `Nama Modul di Kode (Label Bisnis)`
 - [x] `JournalEntry.source_type/source_id` di-set ke dokumen sumber (`App\Models\SupplierBill` / `App\Models\ApPayment`) untuk audit trail.
 - [x] Cakupan tes: 13 Pest ap-journal-posting (action-level + controller PUT integration), regresi clean pada supplier-bills, ap-payments, journal-entries, dan asset-depreciation-runs.
 
+### Modul Accounts Receivable (Piutang Usaha)
+
+- [x] Auto-posting jurnal saat Customer Invoice transisi ke `sent`: Debit Accounts Receivable (`code=11200`), Credit akun revenue per-item (grouped by `account_id`).
+- [x] Auto-posting jurnal saat AR Receipt di-confirm: Debit `bank_account_id`, Credit Accounts Receivable.
+- [x] Idempoten — re-save setelah `sent`/`confirmed` tidak menduplikasi jurnal.
+- [x] `JournalEntry.source_type/source_id` di-set ke dokumen sumber (`App\Models\CustomerInvoice` / `App\Models\ArReceipt`) untuk audit trail.
+- [x] Cakupan tes: 13 Pest ar-journal-posting (action-level + controller PUT integration), regresi clean pada customer-invoices, ar-receipts, credit-notes, dan ap-journal-posting.
+
 ## Dokumen Terkait
 
 - Status handoff aktif: `task.md`

--- a/task.md
+++ b/task.md
@@ -1,4 +1,4 @@
-# AI Handoff: Idle — AR Journal Auto-Posting Queued
+# AI Handoff: AR Journal Auto-Posting (Pending Decision #2 part 2)
 
 Last updated: 2026-05-15 UTC
 
@@ -10,36 +10,49 @@ Last updated: 2026-05-15 UTC
 
 ## Current Objective
 
-- None active. Next planned phase: AR journal auto-posting (mirror of AP, on `feature/ar-journal-auto-posting`). Awaiting user go-ahead before starting.
+- Ship AR journal auto-posting (mirror of AP). Branch ready; commit + push + PR pending.
 
 ## Current Milestone
 
 - ✅ **PR #13 — Modul 18 (Financial Reports)** — merged as `82b7989e`.
-- ✅ **PR #14 — AP journal auto-posting** — merged as `52d1eb9f`. Pending Decision #2 (AP side) closed. Bills + payments now auto-create posted JournalEntries on confirm with `journal_type='system'` + source morph references; idempotent across re-saves.
+- ✅ **PR #14 — AP journal auto-posting** — merged as `52d1eb9f`.
+- 🚧 **AR journal auto-posting** — branch `feature/ar-journal-auto-posting`. All code + tests + style verifications green locally. Ready to commit + push + open PR.
 
 ## Current State
 
-- Branch: `main`
-- HEAD: `52d1eb9f` (PR #14 merge commit)
-- Working tree: clean
-- All quality gates green at merge: PHPStan 0 errors, Pest 12 affected groups all green, SonarCloud SUCCESS.
+- Branch: `feature/ar-journal-auto-posting`
+- Parent: `c0798b9b` (main, post-checkpoint)
+- Commits: pending
+- PHPStan: 0 errors (full project)
+- Pest groups: ar-journal-posting (13/13), customer-invoices (8/8), ar-receipts (8/8), credit-notes (8/8), ap-journal-posting (13/13), supplier-bills (8/8), ap-payments (12/12), journal-entries (29/29), asset-depreciation-runs (12/12) — all green.
+- Duster: applied (CS Fixer + Pint pass).
 
 ## Active Constraints
 
 - Use Sail for every runtime command.
-- AP control account is currently resolved by code lookup (`code=21100`) in the active `CoaVersion`. If a project ships without that exact code seeded, the action throws a friendly `ValidationException` until the COA is fixed.
+- AR control account is resolved by code lookup (`code=11200`) in active `CoaVersion`. AP control account remains at `code=21100`.
 
 ## Latest Session Delta
 
-- PR #14 went green on first push: Quality checks, Test suite, SonarCloud, SonarCloud Code Analysis — all SUCCESS. Merged via `gh pr merge 14 --merge --delete-branch` (no autofix retrigger needed this time).
-- 12 files / +826 / −82 landed: 3 new actions (AccountingPosting/), extended `CreateJournalEntryAction`, controller hooks for SupplierBill + ApPayment update, 13 new Pest tests in `tests/Feature/AccountingPosting/`, plus minimal seed adjustments in two existing controller tests.
-- Local `feature/ap-journal-auto-posting` branch removed by gh; back on `main`.
+- Added 2 new actions in `app/Actions/AccountingPosting/`:
+  - `PostCustomerInvoiceJournalAction` — on invoice transition to `sent`: Debit AR control (`code=11200`), Credit per-item revenue `account_id` (grouped). Idempotent via `journal_entry_id` short-circuit.
+  - `PostArReceiptJournalAction` — on receipt confirm: Debit `bank_account_id`, Credit AR control. Idempotent.
+- Wired hooks in `CustomerInvoiceController::update()` (transition guard via `sent_at === null`) and `ArReceiptController::update()` (transition guard via `confirmed_at === null`).
+- Pest coverage:
+  - Action-level: balance, idempotency, no-op when not in target status, validation errors (no items, no active COA, non-positive receipt).
+  - Controller-level: PUT endpoint posts journal on transition; second PUT does NOT double-post.
+- Updated existing controller tests `update modifies customer invoice and sets sent_by` + `update modifies ar receipt and allocations` to seed FiscalYear + active CoaVersion + AR control account.
 
 ## Validated Commands and Outcomes
 
-- `gh pr view 14` → state `MERGED`, mergeCommit `52d1eb9f3fb54f60140e83197d482d892f192643`, mergedAt `2026-05-15T14:15:21Z`.
-- `git rev-parse HEAD` → `52d1eb9f3fb54f60140e83197d482d892f192643`.
-- `git status --short` → clean.
+- `./vendor/bin/sail bin phpstan analyze` — 0 errors.
+- `./vendor/bin/sail test --group=ar-journal-posting` — 13 passed (47 assertions).
+- `./vendor/bin/sail test --group=customer-invoices` — 8 passed (41 assertions).
+- `./vendor/bin/sail test --group=ar-receipts` — 8 passed (40 assertions).
+- `./vendor/bin/sail test --group=credit-notes` — 8 passed (41 assertions).
+- `./vendor/bin/sail test --group=ap-journal-posting` — 13 passed (47 assertions, no regression).
+- `./vendor/bin/sail test --group=asset-depreciation-runs` — 12 passed (other CreateJournalEntryAction caller).
+- `./vendor/bin/sail bin duster fix` — clean.
 
 ## Open Risks / Blockers
 
@@ -47,27 +60,20 @@ Last updated: 2026-05-15 UTC
 
 ## Recommended Next Steps
 
-1. Wait for user go-ahead before starting AR work (mirror of AP).
-2. When approved, create `feature/ar-journal-auto-posting`. Mirror plan:
-   - `PostCustomerInvoiceJournalAction` — on invoice confirm: Debit AR control (`code=11200`), Credit per-item revenue/expense `account_id`.
-   - `PostArReceiptJournalAction` — on receipt confirm: Debit `bank_account_id`, Credit AR control.
-   - Hooks in `CustomerInvoiceController::update()` + `ArReceiptController::update()` (transition guard via `confirmed_at === null`).
-   - Pest group `ar-journal-posting` covering balance, idempotency, no-op, validation errors, and controller PUT integration.
-3. Other Tier 1/2/3 follow-ups (in `IMPLEMENTATION_STATUS.md`):
-   - `journal_entry_id` on GR/SR + stock adjustments (Pending Decisions #2 remainder + #3).
+1. Stage + commit all changes in one atomic commit: `feat: auto-post AR journal entries on invoice sent / receipt confirm (Pending Decision #2 partial)`.
+2. Push branch `feature/ar-journal-auto-posting`. Open PR against `main`.
+3. Monitor CI. Merge when green.
+4. Pending Decision #2 will then be fully closed for AP + AR. Remaining accounting integrations:
+   - `journal_entry_id` di GR/SR (Modul 13 §6) — minimal hook on goods receipt confirm.
+   - `journal_entry_id` di stock adjustments (Modul 14 §7).
+   - Pending Decision #1: `product_stocks.branch_id → warehouse_id` migration.
    - Modul 18 formula expression evaluator.
-   - `product_stocks.branch_id → warehouse_id` migration (Pending Decision #1).
-   - Subscription frontend CRUD.
-   - Recurring journal scheduler.
-   - Bank reconciliation CSV/Excel import.
 
 ## Continuation Prompt
 
 ```
-Read task.md. Repository on main at 52d1eb9f, working tree clean.
-Modul 18 (PR #13) and AP journal auto-posting (PR #14) shipped. The mirror
-work for AR (CustomerInvoice/ArReceipt) is queued. When approved, create
-feature/ar-journal-auto-posting and follow the same pattern: control account
-lookup (code=11200 for AR), idempotent posting actions, controller hooks on
-the draft→confirmed transition, Pest group ar-journal-posting.
+Read task.md. Branch feature/ar-journal-auto-posting on parent c0798b9b (main).
+AR auto-posting (CustomerInvoice + ArReceipt) implemented + tested. Commit
+"feat: auto-post AR journal entries on invoice sent / receipt confirm",
+push, open PR, monitor CI, merge.
 ```

--- a/tests/Feature/AccountingPosting/ArJournalPostingTest.php
+++ b/tests/Feature/AccountingPosting/ArJournalPostingTest.php
@@ -1,0 +1,437 @@
+<?php
+
+use App\Actions\AccountingPosting\PostArReceiptJournalAction;
+use App\Actions\AccountingPosting\PostCustomerInvoiceJournalAction;
+use App\Models\Account;
+use App\Models\ArReceipt;
+use App\Models\CoaVersion;
+use App\Models\CustomerInvoice;
+use App\Models\FiscalYear;
+use App\Models\JournalEntry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\putJson;
+
+uses(RefreshDatabase::class)->group('ar-journal-posting');
+
+function makeArPostingFiscalYear(): FiscalYear
+{
+    return FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+}
+
+function makeArPostingChartOfAccounts(): array
+{
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+
+    $arAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11200',
+        'name' => 'Accounts Receivable',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
+    $revenueAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '41000',
+        'name' => 'Sales Revenue',
+        'type' => 'revenue',
+        'normal_balance' => 'credit',
+        'is_active' => true,
+    ]);
+
+    $bankAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11110',
+        'name' => 'Cash in Bank',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
+    return [
+        'coa_version' => $coaVersion,
+        'ar' => $arAccount,
+        'revenue' => $revenueAccount,
+        'bank' => $bankAccount,
+    ];
+}
+
+test('PostCustomerInvoiceJournalAction creates a balanced posted journal entry', function () {
+    $fiscalYear = makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $invoice = CustomerInvoice::factory()->sent()->create([
+        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_number' => 'INV-2026-000001',
+        'invoice_date' => '2026-03-15',
+        'subtotal' => 1000000,
+        'tax_amount' => 110000,
+        'discount_amount' => 0,
+        'grand_total' => 1110000,
+        'amount_received' => 0,
+        'credit_note_amount' => 0,
+        'amount_due' => 1110000,
+    ]);
+
+    $invoice->items()->create([
+        'account_id' => $accounts['revenue']->id,
+        'description' => 'Service fee',
+        'quantity' => 1,
+        'unit_price' => 1000000,
+        'discount_percent' => 0,
+        'tax_percent' => 11,
+        'line_total' => 1110000,
+    ]);
+
+    $action = app(PostCustomerInvoiceJournalAction::class);
+
+    $journalEntry = $action->execute($invoice->fresh());
+
+    expect($journalEntry)->not->toBeNull()
+        ->and($journalEntry->status)->toBe('posted')
+        ->and($journalEntry->journal_type)->toBe('system')
+        ->and($journalEntry->source_type)->toBe(CustomerInvoice::class)
+        ->and($journalEntry->source_id)->toBe($invoice->id)
+        ->and((float) $journalEntry->total_debit)->toBe(1110000.0)
+        ->and((float) $journalEntry->total_credit)->toBe(1110000.0);
+
+    assertDatabaseHas('customer_invoices', [
+        'id' => $invoice->id,
+        'journal_entry_id' => $journalEntry->id,
+    ]);
+
+    $arLine = $journalEntry->lines()->where('account_id', $accounts['ar']->id)->first();
+    expect((float) $arLine->debit)->toBe(1110000.0)
+        ->and((float) $arLine->credit)->toBe(0.0);
+
+    $revenueLine = $journalEntry->lines()->where('account_id', $accounts['revenue']->id)->first();
+    expect((float) $revenueLine->credit)->toBe(1110000.0)
+        ->and((float) $revenueLine->debit)->toBe(0.0);
+});
+
+test('PostCustomerInvoiceJournalAction is idempotent and returns existing entry', function () {
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $invoice = CustomerInvoice::factory()->sent()->create([
+        'invoice_date' => '2026-03-15',
+        'grand_total' => 500000,
+        'amount_due' => 500000,
+    ]);
+    $invoice->items()->create([
+        'account_id' => $accounts['revenue']->id,
+        'description' => 'Item',
+        'quantity' => 1,
+        'unit_price' => 500000,
+        'discount_percent' => 0,
+        'tax_percent' => 0,
+        'line_total' => 500000,
+    ]);
+
+    $action = app(PostCustomerInvoiceJournalAction::class);
+
+    $first = $action->execute($invoice->fresh());
+    $second = $action->execute($invoice->fresh());
+
+    expect($second->id)->toBe($first->id);
+    expect(JournalEntry::count())->toBe(1);
+});
+
+test('PostCustomerInvoiceJournalAction returns null when invoice is not sent', function () {
+    makeArPostingFiscalYear();
+    makeArPostingChartOfAccounts();
+
+    $invoice = CustomerInvoice::factory()->create(['status' => 'draft']);
+
+    $action = app(PostCustomerInvoiceJournalAction::class);
+
+    expect($action->execute($invoice))->toBeNull();
+    expect(JournalEntry::count())->toBe(0);
+});
+
+test('PostCustomerInvoiceJournalAction throws when no items exist', function () {
+    makeArPostingFiscalYear();
+    makeArPostingChartOfAccounts();
+
+    $invoice = CustomerInvoice::factory()->sent()->create(['invoice_date' => '2026-03-15']);
+
+    $action = app(PostCustomerInvoiceJournalAction::class);
+
+    expect(fn () => $action->execute($invoice->fresh()))
+        ->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('PostCustomerInvoiceJournalAction throws when no active COA version exists', function () {
+    makeArPostingFiscalYear();
+
+    $invoice = CustomerInvoice::factory()->sent()->create(['invoice_date' => '2026-03-15']);
+    $orphanAccount = Account::factory()->create();
+    $invoice->items()->create([
+        'account_id' => $orphanAccount->id,
+        'description' => 'Item',
+        'quantity' => 1,
+        'unit_price' => 100000,
+        'discount_percent' => 0,
+        'tax_percent' => 0,
+        'line_total' => 100000,
+    ]);
+
+    $action = app(PostCustomerInvoiceJournalAction::class);
+
+    expect(fn () => $action->execute($invoice->fresh()))
+        ->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('PostArReceiptJournalAction creates a balanced posted journal entry', function () {
+    $fiscalYear = makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $arReceipt = ArReceipt::factory()->confirmed()->create([
+        'fiscal_year_id' => $fiscalYear->id,
+        'receipt_number' => 'RCV-2026-000001',
+        'receipt_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 1110000,
+    ]);
+
+    $action = app(PostArReceiptJournalAction::class);
+
+    $journalEntry = $action->execute($arReceipt->fresh());
+
+    expect($journalEntry)->not->toBeNull()
+        ->and($journalEntry->status)->toBe('posted')
+        ->and($journalEntry->journal_type)->toBe('system')
+        ->and($journalEntry->source_type)->toBe(ArReceipt::class)
+        ->and($journalEntry->source_id)->toBe($arReceipt->id);
+
+    assertDatabaseHas('ar_receipts', [
+        'id' => $arReceipt->id,
+        'journal_entry_id' => $journalEntry->id,
+    ]);
+
+    $bankLine = $journalEntry->lines()->where('account_id', $accounts['bank']->id)->first();
+    expect((float) $bankLine->debit)->toBe(1110000.0)
+        ->and((float) $bankLine->credit)->toBe(0.0);
+
+    $arLine = $journalEntry->lines()->where('account_id', $accounts['ar']->id)->first();
+    expect((float) $arLine->credit)->toBe(1110000.0)
+        ->and((float) $arLine->debit)->toBe(0.0);
+});
+
+test('PostArReceiptJournalAction is idempotent', function () {
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $arReceipt = ArReceipt::factory()->confirmed()->create([
+        'receipt_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 500000,
+    ]);
+
+    $action = app(PostArReceiptJournalAction::class);
+
+    $first = $action->execute($arReceipt->fresh());
+    $second = $action->execute($arReceipt->fresh());
+
+    expect($second->id)->toBe($first->id);
+    expect(JournalEntry::count())->toBe(1);
+});
+
+test('PostArReceiptJournalAction returns null when receipt is not confirmed', function () {
+    makeArPostingFiscalYear();
+    makeArPostingChartOfAccounts();
+
+    $arReceipt = ArReceipt::factory()->create(['status' => 'draft']);
+
+    $action = app(PostArReceiptJournalAction::class);
+
+    expect($action->execute($arReceipt))->toBeNull();
+    expect(JournalEntry::count())->toBe(0);
+});
+
+test('PostArReceiptJournalAction throws on non-positive total amount', function () {
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $arReceipt = ArReceipt::factory()->confirmed()->create([
+        'receipt_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 0,
+    ]);
+
+    $action = app(PostArReceiptJournalAction::class);
+
+    expect(fn () => $action->execute($arReceipt->fresh()))
+        ->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('CustomerInvoiceController update triggers journal posting on sent transition', function () {
+    $user = createTestUserWithPermissions([
+        'customer_invoice',
+        'customer_invoice.create',
+        'customer_invoice.edit',
+        'customer_invoice.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $invoice = CustomerInvoice::factory()->create([
+        'status' => 'draft',
+        'invoice_date' => '2026-03-15',
+        'subtotal' => 800000,
+        'tax_amount' => 0,
+        'discount_amount' => 0,
+        'grand_total' => 800000,
+        'amount_received' => 0,
+        'credit_note_amount' => 0,
+        'amount_due' => 800000,
+        'sent_by' => null,
+        'sent_at' => null,
+    ]);
+
+    $payload = [
+        'status' => 'sent',
+        'items' => [
+            [
+                'account_id' => $accounts['revenue']->id,
+                'description' => 'Service',
+                'quantity' => 1,
+                'unit_price' => 800000,
+                'discount_percent' => 0,
+                'tax_percent' => 0,
+            ],
+        ],
+    ];
+
+    putJson("/api/customer-invoices/{$invoice->id}", $payload)
+        ->assertOk()
+        ->assertJsonPath('data.status', 'sent');
+
+    $invoice->refresh();
+    expect($invoice->journal_entry_id)->not->toBeNull();
+
+    assertDatabaseHas('journal_entries', [
+        'id' => $invoice->journal_entry_id,
+        'status' => 'posted',
+        'journal_type' => 'system',
+        'source_type' => CustomerInvoice::class,
+        'source_id' => $invoice->id,
+    ]);
+});
+
+test('CustomerInvoiceController update does not double-post on subsequent saves', function () {
+    $user = createTestUserWithPermissions([
+        'customer_invoice',
+        'customer_invoice.create',
+        'customer_invoice.edit',
+        'customer_invoice.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $invoice = CustomerInvoice::factory()->create([
+        'status' => 'draft',
+        'invoice_date' => '2026-03-15',
+        'grand_total' => 500000,
+        'amount_due' => 500000,
+        'sent_by' => null,
+        'sent_at' => null,
+    ]);
+
+    $items = [[
+        'account_id' => $accounts['revenue']->id,
+        'description' => 'Service',
+        'quantity' => 1,
+        'unit_price' => 500000,
+        'discount_percent' => 0,
+        'tax_percent' => 0,
+    ]];
+
+    putJson("/api/customer-invoices/{$invoice->id}", [
+        'status' => 'sent',
+        'items' => $items,
+    ])->assertOk();
+
+    putJson("/api/customer-invoices/{$invoice->id}", [
+        'notes' => 'edited after sent',
+    ])->assertOk();
+
+    expect(JournalEntry::where('source_type', CustomerInvoice::class)->count())->toBe(1);
+});
+
+test('ArReceiptController update triggers journal posting on confirm transition', function () {
+    $user = createTestUserWithPermissions([
+        'ar_receipt',
+        'ar_receipt.create',
+        'ar_receipt.edit',
+        'ar_receipt.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $arReceipt = ArReceipt::factory()->create([
+        'status' => 'draft',
+        'receipt_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 750000,
+        'confirmed_by' => null,
+        'confirmed_at' => null,
+    ]);
+
+    putJson("/api/ar-receipts/{$arReceipt->id}", [
+        'status' => 'confirmed',
+    ])->assertOk()->assertJsonPath('data.status', 'confirmed');
+
+    $arReceipt->refresh();
+    expect($arReceipt->journal_entry_id)->not->toBeNull();
+
+    assertDatabaseHas('journal_entries', [
+        'id' => $arReceipt->journal_entry_id,
+        'status' => 'posted',
+        'journal_type' => 'system',
+        'source_type' => ArReceipt::class,
+        'source_id' => $arReceipt->id,
+    ]);
+});
+
+test('ArReceiptController update does not double-post on subsequent saves', function () {
+    $user = createTestUserWithPermissions([
+        'ar_receipt',
+        'ar_receipt.create',
+        'ar_receipt.edit',
+        'ar_receipt.delete',
+    ]);
+    Sanctum::actingAs($user, ['*']);
+
+    makeArPostingFiscalYear();
+    $accounts = makeArPostingChartOfAccounts();
+
+    $arReceipt = ArReceipt::factory()->create([
+        'status' => 'draft',
+        'receipt_date' => '2026-03-20',
+        'bank_account_id' => $accounts['bank']->id,
+        'total_amount' => 250000,
+        'confirmed_by' => null,
+        'confirmed_at' => null,
+    ]);
+
+    putJson("/api/ar-receipts/{$arReceipt->id}", ['status' => 'confirmed'])->assertOk();
+    putJson("/api/ar-receipts/{$arReceipt->id}", ['notes' => 'reconciled note'])->assertOk();
+
+    expect(JournalEntry::where('source_type', ArReceipt::class)->count())->toBe(1);
+});

--- a/tests/Feature/ArReceipts/ArReceiptControllerTest.php
+++ b/tests/Feature/ArReceipts/ArReceiptControllerTest.php
@@ -3,6 +3,7 @@
 use App\Models\Account;
 use App\Models\ArReceipt;
 use App\Models\Branch;
+use App\Models\CoaVersion;
 use App\Models\Customer;
 use App\Models\CustomerInvoice;
 use App\Models\FiscalYear;
@@ -139,16 +140,39 @@ test('show returns ar receipt detail', function () {
 });
 
 test('update modifies ar receipt and allocations', function () {
+    FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+    Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11200',
+        'name' => 'Accounts Receivable',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+    $bankAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11110',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
     $customer = Customer::factory()->create();
-    $fiscalYear = FiscalYear::factory()->create();
     $invoice = CustomerInvoice::factory()->create([
         'customer_id' => $customer->id,
-        'fiscal_year_id' => $fiscalYear->id,
         'status' => 'sent',
     ]);
     $receipt = ArReceipt::factory()->create([
         'customer_id' => $customer->id,
-        'fiscal_year_id' => $fiscalYear->id,
+        'receipt_date' => '2026-03-06',
+        'bank_account_id' => $bankAccount->id,
+        'total_amount' => 75000,
         'status' => 'draft',
     ]);
 

--- a/tests/Feature/CustomerInvoices/CustomerInvoiceControllerTest.php
+++ b/tests/Feature/CustomerInvoices/CustomerInvoiceControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Account;
 use App\Models\Branch;
+use App\Models\CoaVersion;
 use App\Models\Customer;
 use App\Models\CustomerInvoice;
 use App\Models\FiscalYear;
@@ -148,11 +149,34 @@ test('show returns customer invoice detail', function () {
 });
 
 test('update modifies customer invoice and sets sent_by when status changes to sent', function () {
-    [$customer, $branch, $fiscalYear, $product, $unit, $account] = createCustomerInvoiceWithItem();
+    FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+    Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '11200',
+        'name' => 'Accounts Receivable',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_active' => true,
+    ]);
+
+    [$customer, $branch, , $product, $unit] = createCustomerInvoiceWithItem();
+    $revenueAccount = Account::factory()->create([
+        'coa_version_id' => $coaVersion->id,
+        'code' => '41000',
+        'type' => 'revenue',
+        'normal_balance' => 'credit',
+        'is_active' => true,
+    ]);
     $invoice = CustomerInvoice::factory()->create([
         'customer_id' => $customer->id,
         'branch_id' => $branch->id,
-        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_date' => '2026-03-01',
         'status' => 'draft',
         'sent_by' => null,
         'sent_at' => null,
@@ -164,7 +188,7 @@ test('update modifies customer invoice and sets sent_by when status changes to s
             [
                 'product_id' => $product->id,
                 'unit_id' => $unit->id,
-                'account_id' => $account->id,
+                'account_id' => $revenueAccount->id,
                 'description' => 'Updated item',
                 'quantity' => 7,
                 'unit_price' => 10000,


### PR DESCRIPTION
## Summary

- Mirrors PR #14 for the AR side. Closes Pending Decision #2 — combined with #14, AP and AR bookkeeping integration is now end-to-end.
- Implements `16_accounts_receivable_design.md` §4 (Posting Jurnal) via the same controller-hook approach used for AP.

## What posts when

- `CustomerInvoice` transition to **`sent`** → **Debit** Accounts Receivable control account (`code=11200`), **Credit** each item's revenue `account_id` (grouped).
- `ArReceipt` confirm → **Debit** `bank_account_id`, **Credit** Accounts Receivable.

Each generated `JournalEntry` carries:
- `status='posted'`
- `journal_type='system'`
- `source_type` + `source_id` → back-reference to the originating document.

## Idempotency

Re-saving an invoice/receipt after its trigger transition never produces a duplicate journal — every action checks `journal_entry_id` first and returns the existing entry. Verified by dedicated tests (`does not double-post on subsequent saves`).

## New surface area

- `app/Actions/AccountingPosting/PostCustomerInvoiceJournalAction.php`
- `app/Actions/AccountingPosting/PostArReceiptJournalAction.php`

Reuses `ResolveControlAccountAction` and the `CreateJournalEntryAction` posted-status path introduced in #14.

## Modified

- `app/Http/Controllers/CustomerInvoiceController.php` — fires posting on the `draft → sent` transition (guarded by `sent_at === null`).
- `app/Http/Controllers/ArReceiptController.php` — fires posting on the `draft → confirmed` transition (guarded by `confirmed_at === null`).

## Tests (all green locally)

| Group | Result |
| --- | --- |
| `ar-journal-posting` (new) | 13 / 13 — 47 assertions |
| `customer-invoices` | 8 / 8 |
| `ar-receipts` | 8 / 8 |
| `credit-notes` | 8 / 8 (no spillover) |
| `ap-journal-posting` | 13 / 13 (no regression on the AP side from #14) |
| `supplier-bills` | 8 / 8 |
| `ap-payments` | 12 / 12 |
| `journal-entries` | 29 / 29 |
| `asset-depreciation-runs` | 12 / 12 |

\`./vendor/bin/sail bin phpstan analyze\` — **0 errors** (full project).
\`./vendor/bin/sail bin duster fix\` — **clean**.

## Migration / data impact

None. Reuses the existing `journal_entries.journal_type / source_type / source_id` columns. No new tables, no data backfill — historical invoices/receipts stay untouched.

## Follow-up

After this lands, Pending Decision #2 is fully closed. Next planned integrations:
- \`journal_entry_id\` on Goods Receipt / Supplier Return (Modul 13 §6)
- \`journal_entry_id\` on Stock Adjustments (Modul 14 §7)
- Pending Decision #1: \`product_stocks.branch_id → warehouse_id\` migration
- Modul 18 formula expression evaluator

🤖 Generated with [Claude Code](https://claude.com/claude-code)