### PR TITLE
refactor: H3 polish quick wins (Oracle audit follow-up)

### DIFF
--- a/app/Http/Requests/AdminSettingRequest.php
+++ b/app/Http/Requests/AdminSettingRequest.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Requests;
 
+use App\Http\Requests\Concerns\HasSupportedCurrencyRules;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Validation\Rule;
 
 class AdminSettingRequest extends AuthorizedFormRequest
 {
+    use HasSupportedCurrencyRules;
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -14,9 +16,6 @@ class AdminSettingRequest extends AuthorizedFormRequest
      */
     public function rules(): array
     {
-        /** @var array<int, string> $supportedCurrencies */
-        $supportedCurrencies = config('app.supported_transaction_currencies', ['IDR']);
-
         return [
             'company_name' => ['nullable', 'string', 'max:255'],
             'company_address' => ['nullable', 'string', 'max:1000'],
@@ -24,8 +23,7 @@ class AdminSettingRequest extends AuthorizedFormRequest
             'company_email' => ['nullable', 'string', 'email', 'max:255'],
             'company_logo' => ['nullable', 'file', 'mimetypes:image/svg+xml', 'max:2048'],
             'company_logo_svg' => ['nullable', 'string', 'max:262144'],
-            'timezone' => ['nullable', 'string', 'max:100', 'timezone:all'],
-            'currency' => ['nullable', 'string', 'max:10', Rule::in($supportedCurrencies)],
+            'currency' => ['nullable', ...$this->supportedCurrencyRules()],
             'date_format' => ['nullable', 'string', 'max:20'],
             'number_format_decimal' => ['nullable', 'string', 'max:5'],
             'number_format_thousand' => ['nullable', 'string', 'max:5'],

--- a/app/Imports/AssetImport.php
+++ b/app/Imports/AssetImport.php
@@ -107,7 +107,7 @@ class AssetImport implements SkipsEmptyRows, ToCollection, WithHeadingRow
                         'currency' => strtoupper($rowData['currency']),
                         'warranty_end_date' => $rowData['warranty_end_date'] ?? null,
                         'status' => strtolower($rowData['status']),
-                        'condition' => strtolower($rowData['condition']),
+                        'condition' => isset($rowData['condition']) ? strtolower($rowData['condition']) : null,
                         'notes' => $rowData['notes'] ?? null,
                     ]
                 );

--- a/database/seeders/SettingSampleDataSeeder.php
+++ b/database/seeders/SettingSampleDataSeeder.php
@@ -49,12 +49,6 @@ class SettingSampleDataSeeder extends Seeder
             // Regional settings
             [
                 'group' => 'regional',
-                'key' => 'timezone',
-                'value' => 'Asia/Jakarta',
-                'type' => 'string',
-            ],
-            [
-                'group' => 'regional',
                 'key' => 'currency',
                 'value' => 'IDR',
                 'type' => 'string',

--- a/resources/js/components/aging-dashboard/TopOverdueCustomers.tsx
+++ b/resources/js/components/aging-dashboard/TopOverdueCustomers.tsx
@@ -9,22 +9,13 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { formatCurrency } from '@/lib/utils';
+import { formatDateByRegionalSettings } from '@/utils/date-format';
 import { memo } from 'react';
 import type { TopOverdueCustomer } from '../../hooks/useAgingDashboard';
 
 interface TopOverdueCustomersProps {
     readonly customers: TopOverdueCustomer[];
     readonly isLoading?: boolean;
-}
-
-function formatDate(dateString: string | null): string {
-    if (!dateString) return '-';
-    const date = new Date(dateString);
-    return new Intl.DateTimeFormat('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: '2-digit',
-    }).format(date);
 }
 
 export const TopOverdueCustomers = memo<TopOverdueCustomersProps>(
@@ -118,7 +109,9 @@ export const TopOverdueCustomers = memo<TopOverdueCustomersProps>(
                                         {customer.invoice_count}
                                     </TableCell>
                                     <TableCell className="text-right tabular-nums">
-                                        {formatDate(customer.oldest_due_date)}
+                                        {formatDateByRegionalSettings(
+                                            customer.oldest_due_date,
+                                        )}
                                     </TableCell>
                                     <TableCell className="text-right tabular-nums">
                                         {customer.max_days_overdue}

--- a/resources/js/components/aging-dashboard/TopOverdueSuppliers.tsx
+++ b/resources/js/components/aging-dashboard/TopOverdueSuppliers.tsx
@@ -9,22 +9,13 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { formatCurrency } from '@/lib/utils';
+import { formatDateByRegionalSettings } from '@/utils/date-format';
 import { memo } from 'react';
 import type { TopOverdueSupplier } from '../../hooks/useAgingDashboard';
 
 interface TopOverdueSuppliersProps {
     readonly suppliers: TopOverdueSupplier[];
     readonly isLoading?: boolean;
-}
-
-function formatDate(dateString: string | null): string {
-    if (!dateString) return '-';
-    const date = new Date(dateString);
-    return new Intl.DateTimeFormat('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: '2-digit',
-    }).format(date);
 }
 
 export const TopOverdueSuppliers = memo<TopOverdueSuppliersProps>(
@@ -118,7 +109,9 @@ export const TopOverdueSuppliers = memo<TopOverdueSuppliersProps>(
                                         {supplier.bill_count}
                                     </TableCell>
                                     <TableCell className="text-right tabular-nums">
-                                        {formatDate(supplier.oldest_due_date)}
+                                        {formatDateByRegionalSettings(
+                                            supplier.oldest_due_date,
+                                        )}
                                     </TableCell>
                                     <TableCell className="text-right tabular-nums">
                                         {supplier.max_days_overdue}

--- a/resources/js/pages/admin-settings/index.tsx
+++ b/resources/js/pages/admin-settings/index.tsx
@@ -342,7 +342,7 @@ function RegionalSettings({
         <div className="space-y-6">
             <HeadingSmall
                 title="Regional Settings"
-                description="Configure timezone, currency, and format preferences"
+                description="Configure currency and format preferences"
             />
 
             <form
@@ -350,22 +350,6 @@ function RegionalSettings({
                 data-testid="regional-settings-form"
                 className="space-y-6"
             >
-                <div className="grid gap-2">
-                    <Label htmlFor="timezone">Timezone</Label>
-                    <Input
-                        id="timezone"
-                        name="timezone"
-                        defaultValue={settings?.timezone ?? 'Asia/Jakarta'}
-                        placeholder="e.g. Asia/Jakarta"
-                        className="mt-1 block w-full"
-                    />
-                    {errors.timezone && (
-                        <p className="text-sm text-destructive">
-                            {errors.timezone}
-                        </p>
-                    )}
-                </div>
-
                 <div className="grid gap-2">
                     <Label htmlFor="currency">Currency</Label>
                     <Select value={currency} onValueChange={setCurrency}>

--- a/tests/Feature/AdminSettings/AdminSettingControllerTest.php
+++ b/tests/Feature/AdminSettings/AdminSettingControllerTest.php
@@ -61,7 +61,6 @@ describe('AdminSettingController@index', function () {
                     'company_logo_url',
                 ],
                 'regional' => [
-                    'timezone',
                     'currency',
                     'date_format',
                     'number_format_decimal',
@@ -105,7 +104,6 @@ describe('AdminSettingController@update', function () {
 
         Sanctum::actingAs($user, ['*']);
         $response = $this->putJson('/api/admin-settings', [
-            'timezone' => 'Asia/Makassar',
             'currency' => 'IDR',
             'date_format' => 'Y-m-d',
             'number_format_decimal' => '.',
@@ -115,7 +113,6 @@ describe('AdminSettingController@update', function () {
 
         $response->assertOk();
 
-        expect(Setting::get('timezone'))->toBe('Asia/Makassar');
         expect(Setting::get('currency'))->toBe('IDR');
         expect(Setting::get('date_format'))->toBe('Y-m-d');
         expect(Setting::get('number_format_decimal'))->toBe('.');
@@ -145,18 +142,6 @@ describe('AdminSettingController@update', function () {
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors('company_email');
-    });
-
-    test('update validates timezone', function () {
-        $user = createTestUserWithPermissions(['admin_setting', 'admin_setting.edit']);
-
-        Sanctum::actingAs($user, ['*']);
-        $response = $this->putJson('/api/admin-settings', [
-            'timezone' => 'Invalid/Timezone',
-        ]);
-
-        $response->assertStatus(422);
-        $response->assertJsonValidationErrors('timezone');
     });
 
     test('update validates max length', function () {

--- a/tests/Unit/Models/SettingTest.php
+++ b/tests/Unit/Models/SettingTest.php
@@ -23,8 +23,8 @@ describe('Setting Model', function () {
     });
 
     test('get returns value for existing key', function () {
-        $result = Setting::get('timezone');
-        expect($result)->toBe('Asia/Jakarta');
+        $result = Setting::get('currency');
+        expect($result)->toBe('IDR');
     });
 
     test('set updates existing setting value', function () {
@@ -46,8 +46,8 @@ describe('Setting Model', function () {
             ->toHaveKeys(['general', 'regional']);
         expect($grouped['general'])->toHaveKey('company_name');
         expect($grouped['general']['company_name'])->toBe('Test Company');
-        expect($grouped['regional'])->toHaveKey('timezone');
-        expect($grouped['regional']['timezone'])->toBe('Asia/Jakarta');
+        expect($grouped['regional'])->toHaveKey('currency');
+        expect($grouped['regional']['currency'])->toBe('IDR');
         expect($grouped['regional'])->toHaveKey('number_format_hide_decimal');
         expect($grouped['regional']['number_format_hide_decimal'])->toBeFalse();
     });

--- a/tests/e2e/admin-settings/admin-settings.spec.ts
+++ b/tests/e2e/admin-settings/admin-settings.spec.ts
@@ -65,7 +65,6 @@ test.describe('Admin Settings', () => {
         await expect(page.getByText('Regional Settings')).toBeVisible();
 
         // Regional form fields should be visible
-        await expect(page.locator('input[name="timezone"]')).toBeVisible();
         await expect(page.getByTestId('currency-select-trigger')).toBeVisible();
         await expect(page.locator('input[name="date_format"]')).toBeVisible();
         await expect(page.locator('input[name="number_format_decimal"]')).toBeVisible();


### PR DESCRIPTION
## Summary

Bundle 4 quick wins dari Oracle post-H3 codebase audit. Polish cleanup, no new features atau contract changes.

## Quick Wins

| # | Item | Effort | Risk |
|---|---|---|---|
| QW#1 | Kill orphan `regional.timezone` setting (stored, never read) | 15 min | None |
| QW#2 | AssetImport `strtolower(null)` PHP 8.1+ deprecation guard | 5 min | None |
| QW#3 | TopOverdueCustomers/Suppliers replace `'en-US'` Intl with `formatDateByRegionalSettings` | 10 min | None |
| QW#5 | AdminSettingRequest reuse `HasSupportedCurrencyRules` trait | 15 min | None |

QW#6 (drop `_ide_helper.php` from git) skipped — already in `.gitignore` line 38, not tracked.

## Changes

### QW#1: Kill `regional.timezone` (dishonest UI)

Setting `regional.timezone='Asia/Jakarta'` was stored in DB + editable from admin-settings page, but NEVER read anywhere in `app/` or `resources/js/`. All Carbon usage falls back to `config('app.timezone')='UTC'`. Pure orphan plumbing.

Removed from:
- `resources/js/pages/admin-settings/index.tsx` — Timezone Input + label + description text
- `database/seeders/SettingSampleDataSeeder.php` — timezone seed row
- `app/Http/Requests/AdminSettingRequest.php` — `timezone` validation rule
- `tests/Feature/AdminSettings/AdminSettingControllerTest.php` — 2 test cases (regional structure key + validates timezone) + 1 fixture cleanup
- `tests/Unit/Models/SettingTest.php` — 2 timezone sample assertions → switched to `currency` (still seeded)
- `tests/e2e/admin-settings/admin-settings.spec.ts` — timezone visibility check

When multi-currency Wave 2 ships and per-user TZ becomes a real feature, this field can be re-added wired to actual Carbon localization.

### QW#2: AssetImport `strtolower(null)` deprecation

`app/Imports/AssetImport.php:110` called `strtolower($rowData['condition'])` on a `nullable|in:good,needs_repair,damaged` field. PHP 8.1+ deprecates `strtolower(null)` and returns `''` (writes empty string to DB instead of NULL). Wrapped:

```php
'condition' => isset($rowData['condition']) ? strtolower($rowData['condition']) : null,
```

### QW#3: TopOverdue locale consistency

Both `TopOverdueCustomers.tsx` and `TopOverdueSuppliers.tsx` had inline `formatDate` helper using hardcoded `Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: '2-digit' })`. Inconsistent with rest of dashboard which uses `formatCurrencyByRegionalSettings`.

Replaced with shared `formatDateByRegionalSettings` from `@/utils/date-format` (defaults `'id-ID'` locale, respects regional date_format setting).

### QW#5: AdminSettingRequest trait reuse

`AdminSettingRequest::rules()` used inline `['nullable', 'string', 'max:10', Rule::in($supportedCurrencies)]`. Replaced with:

```php
'currency' => ['nullable', ...$this->supportedCurrencyRules()],
```

Drops `max:10` foot-gun (would allow 4-10 char garbage when Wave 2 widens config). Single source of truth via `HasSupportedCurrencyRules` trait.

## Verification

| Gate | Result |
|---|---|
| PHPStan | `[OK] No errors` |
| Duster | clean (no autofix needed) |
| npm types | clean |
| npm lint | clean |
| Pest full suite | 1864 pass (was 1865 -1 deleted `validates timezone` test) |
| 3 affected groups | 90 pass (admin-settings, aging-dashboard, assets) |

## Stats

- 9 files changed
- +18 / -72 lines (net **-54 lines**, polish/dead-code removal)

## Repo conventions checked

- ✅ AGENTS.md compliance
- ✅ Trait reuse over inline duplication (`HasSupportedCurrencyRules`)
- ✅ Existing helper reuse (`formatDateByRegionalSettings`)
- ✅ Test coverage maintained for surviving features
- ✅ No commit without explicit user request — user said "lanjut" → bundle was offered as recommended path

Refs: Oracle post-H3 audit (in-session), `task.md` handoff
