### PR TITLE
refactor: extract branch_id parsing to ResolvesBranchScope trait (Finding #4)

### DIFF
--- a/app/Http/Controllers/AgingDashboardController.php
+++ b/app/Http/Controllers/AgingDashboardController.php
@@ -19,9 +19,7 @@ class AgingDashboardController extends Controller
         GetAgingDashboardDataAction $action,
     ): JsonResponse {
         $asOfDate = $this->resolveAsOfDate($request->query('as_of_date'));
-        $branchIdRaw = $request->query('branch_id');
-        $requestedBranchId = is_numeric($branchIdRaw) ? (int) $branchIdRaw : null;
-        $branchId = $this->resolveBranchScope($requestedBranchId);
+        $branchId = $this->resolveBranchFromRequest($request);
 
         $branches = Branch::orderBy('name')->get(['id', 'name']);
 

--- a/app/Http/Controllers/AssetDashboardController.php
+++ b/app/Http/Controllers/AssetDashboardController.php
@@ -13,9 +13,7 @@ class AssetDashboardController extends Controller
 
     public function getData(Request $request, GetAssetDashboardDataAction $action): JsonResponse
     {
-        $branchIdRaw = $request->query('branch_id');
-        $requestedBranchId = is_numeric($branchIdRaw) ? (int) $branchIdRaw : null;
-        $branchId = $this->resolveBranchScope($requestedBranchId);
+        $branchId = $this->resolveBranchFromRequest($request);
 
         $data = $action->execute($branchId);
 

--- a/app/Http/Controllers/Concerns/ResolvesBranchScope.php
+++ b/app/Http/Controllers/Concerns/ResolvesBranchScope.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Concerns;
 
 use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -15,6 +17,27 @@ use Illuminate\Support\Facades\Auth;
  */
 trait ResolvesBranchScope
 {
+    /**
+     * Parses the `branch_id` query param from a request and resolves it
+     * through the branch-scope policy in a single call.
+     *
+     * Accepts both raw {@see Request} (query string parsing) and
+     * {@see FormRequest} (validated input parsing).
+     *
+     * @return int|null null = unscoped; int = forced branch
+     */
+    protected function resolveBranchFromRequest(Request $request): ?int
+    {
+        if ($request instanceof FormRequest) {
+            $requestedBranchId = $request->integer('branch_id') ?: null;
+        } else {
+            $branchIdRaw = $request->query('branch_id');
+            $requestedBranchId = is_numeric($branchIdRaw) ? (int) $branchIdRaw : null;
+        }
+
+        return $this->resolveBranchScope($requestedBranchId);
+    }
+
     /**
      * @param  int|null  $requestedBranchId  branch_id from request query
      * @return int|null null = unscoped; int = forced branch

--- a/app/Http/Controllers/StockMonitorController.php
+++ b/app/Http/Controllers/StockMonitorController.php
@@ -34,8 +34,7 @@ class StockMonitorController extends Controller
 
     private function forceBranchScope(IndexStockMonitorRequest|ExportStockMonitorRequest $request): void
     {
-        $requestedBranchId = $request->integer('branch_id') ?: null;
-        $effective = $this->resolveBranchScope($requestedBranchId);
+        $effective = $this->resolveBranchFromRequest($request);
 
         if ($effective === null) {
             $request->offsetUnset('branch_id');


### PR DESCRIPTION
## Summary

Closes Oracle post-H3 audit **Finding #4** (LOW severity, ~45 min effort).

Adds `resolveBranchFromRequest(Request)` helper to the `ResolvesBranchScope` trait. Removes 3× duplicated branch_id parsing boilerplate across dashboard controllers.

## Why

Three dashboard controllers were each parsing `branch_id` from the request query string with the same 3-line boilerplate before delegating to `resolveBranchScope()`. This blocked clean polymorphic scoping work on Pipeline/Approval dashboards (called out as a hard prerequisite in handoff doc `task.md`).

## Changes

### `app/Http/Controllers/Concerns/ResolvesBranchScope.php`
- New `resolveBranchFromRequest(Request $request): ?int` method.
- Handles both `Illuminate\Http\Request` (raw `query()` parsing with `is_numeric` guard) and `FormRequest` (validated `integer()` accessor) — single signature, polymorphic dispatch via `instanceof`.

### Controllers refactored
| Controller | Before | After |
|---|---|---|
| `AgingDashboardController` | 3 lines parse + resolve | 1 line |
| `AssetDashboardController` | 3 lines parse + resolve | 1 line |
| `StockMonitorController` | 2 lines parse + resolve (FormRequest path) | 1 line |

`DashboardController` already calls `resolveBranchScope(null)` directly (no request parsing) — unchanged.

## Diff stats

```
4 files changed, 26 insertions(+), 8 deletions(-)
```

## Verification

| Check | Result |
|---|---|
| `sail test --group aging-dashboard` | ✅ 15 pass / 113 assertions |
| `sail test --group asset-dashboard` | ✅ 6 pass / 30 assertions |
| `sail test --group stock-monitor` | ✅ 11 pass / 70 assertions |
| `sail test --group dashboard` | ✅ 1 pass / 5 assertions |
| `sail bin phpstan analyze` (5 affected files) | ✅ No errors |
| `sail bin duster fix` | ✅ No changes needed |

## Behavior preservation

- API contract unchanged on all 3 endpoints.
- Branch scope policy unchanged (handled by existing `resolveBranchScope()`).
- FormRequest `integer()` truthy-coalesce semantics preserved for StockMonitor.
- Raw `Request` `is_numeric` guard preserved for Aging + Asset dashboards.

## Unblocks

Polymorphic Pipeline/Approval dashboard scoping (deferred items in `task.md`).