### PR TITLE
refactor(reports): port AR/AP aging + outstanding actions to Carbon pattern (Finding #1)

### DIFF
--- a/app/Actions/Reports/Concerns/AgingReportBoundaries.php
+++ b/app/Actions/Reports/Concerns/AgingReportBoundaries.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Actions\Reports\Concerns;
+
+use App\Actions\AgingDashboard\GetAgingDashboardDataAction;
+use Illuminate\Support\Carbon;
+
+/**
+ * Computes Carbon-based aging bucket boundaries (today, 1, 30, 31, 60, 61, 90)
+ * and renders cross-DB safe parameterized SQL fragments for AR/AP aging
+ * + outstanding reports.
+ *
+ * Mirrors the pattern used in {@see GetAgingDashboardDataAction}:
+ * date math is performed in PHP (UTC Carbon) and injected via prepared
+ * statement bindings instead of MariaDB-only `CURDATE()` / `DATEDIFF()` calls.
+ */
+trait AgingReportBoundaries
+{
+    /**
+     * @return array{today: string, d1: string, d30: string, d31: string, d60: string, d61: string, d90: string}
+     */
+    protected function agingBoundaries(): array
+    {
+        $today = Carbon::today();
+
+        return [
+            'today' => $today->toDateString(),
+            'd1' => $today->copy()->subDays(1)->toDateString(),
+            'd30' => $today->copy()->subDays(30)->toDateString(),
+            'd31' => $today->copy()->subDays(31)->toDateString(),
+            'd60' => $today->copy()->subDays(60)->toDateString(),
+            'd61' => $today->copy()->subDays(61)->toDateString(),
+            'd90' => $today->copy()->subDays(90)->toDateString(),
+        ];
+    }
+
+    /**
+     * Aliases: aging_current, aging_1_30, aging_31_60, aging_61_90, aging_over_90.
+     * Pair with {@see agingBucketBindings()} when calling selectRaw().
+     */
+    protected function agingBucketSelectSql(string $tableAlias): string
+    {
+        return "CASE WHEN {$tableAlias}.due_date >= ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_current,
+        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_1_30,
+        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_31_60,
+        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_61_90,
+        CASE WHEN {$tableAlias}.due_date < ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_over_90";
+    }
+
+    /**
+     * @param  array{today: string, d1: string, d30: string, d31: string, d60: string, d61: string, d90: string}  $boundaries
+     * @return list<string>
+     */
+    protected function agingBucketBindings(array $boundaries): array
+    {
+        return [
+            $boundaries['today'],
+            $boundaries['d30'], $boundaries['d1'],
+            $boundaries['d60'], $boundaries['d31'],
+            $boundaries['d90'], $boundaries['d61'],
+            $boundaries['d90'],
+        ];
+    }
+}

--- a/app/Actions/Reports/Concerns/BuildsCustomerInvoiceReportQuery.php
+++ b/app/Actions/Reports/Concerns/BuildsCustomerInvoiceReportQuery.php
@@ -10,8 +10,11 @@ trait BuildsCustomerInvoiceReportQuery
 {
     /**
      * Build base customer invoice report query with common joins and columns.
+     *
+     * @param  array<int, string>  $additionalColumns
+     * @param  array<int, mixed>  $additionalBindings
      */
-    protected function buildBaseCustomerInvoiceQuery(array $additionalColumns = []): Builder
+    protected function buildBaseCustomerInvoiceQuery(array $additionalColumns = [], array $additionalBindings = []): Builder
     {
         $baseColumns = [
             'ci.id as customer_invoice_id',
@@ -35,7 +38,7 @@ trait BuildsCustomerInvoiceReportQuery
             ->from('customer_invoices as ci')
             ->join('customers as c', 'ci.customer_id', '=', 'c.id')
             ->leftJoin('branches as b', 'ci.branch_id', '=', 'b.id')
-            ->selectRaw($this->compileSelectColumns($allColumns))
+            ->selectRaw($this->compileSelectColumns($allColumns), $additionalBindings)
             ->withCasts($this->getBaseCasts());
     }
 

--- a/app/Actions/Reports/Concerns/BuildsSupplierBillReportQuery.php
+++ b/app/Actions/Reports/Concerns/BuildsSupplierBillReportQuery.php
@@ -13,9 +13,13 @@ trait BuildsSupplierBillReportQuery
     /**
      * @param  array<int, string>  $extraSelectColumns
      * @param  array<string, string>  $extraCasts
+     * @param  array<int, mixed>  $extraSelectBindings
      */
-    protected function buildBaseSupplierBillQuery(array $extraSelectColumns = [], array $extraCasts = []): Builder
-    {
+    protected function buildBaseSupplierBillQuery(
+        array $extraSelectColumns = [],
+        array $extraCasts = [],
+        array $extraSelectBindings = [],
+    ): Builder {
         $baseSelectColumns = [
             'sb.id',
             'sb.bill_number',
@@ -48,7 +52,7 @@ trait BuildsSupplierBillReportQuery
             ->from('supplier_bills as sb')
             ->join('suppliers as s', 'sb.supplier_id', '=', 's.id')
             ->join('branches as b', 'sb.branch_id', '=', 'b.id')
-            ->selectRaw(implode(",\n                ", $allSelectColumns))
+            ->selectRaw(implode(",\n                ", $allSelectColumns), $extraSelectBindings)
             ->whereIn('sb.status', ['confirmed', 'partially_paid', 'overdue'])
             ->withCasts($allCasts);
     }

--- a/app/Actions/Reports/IndexApAgingReportAction.php
+++ b/app/Actions/Reports/IndexApAgingReportAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Reports;
 
+use App\Actions\Reports\Concerns\AgingReportBoundaries;
 use App\Actions\Reports\Concerns\BuildsSupplierBillReportQuery;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
@@ -9,22 +10,20 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class IndexApAgingReportAction
 {
+    use AgingReportBoundaries;
     use BuildsSupplierBillReportQuery;
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
+        $boundaries = $this->agingBoundaries();
+
         $query = $this->buildBaseSupplierBillQuery(
             extraSelectColumns: [
-                'CASE WHEN sb.due_date >= CURDATE() THEN sb.amount_due ELSE 0 END '
-                    . 'as current_amount',
-                'CASE WHEN DATEDIFF(CURDATE(), sb.due_date) BETWEEN 1 AND 30 '
-                    . 'THEN sb.amount_due ELSE 0 END as days_1_30',
-                'CASE WHEN DATEDIFF(CURDATE(), sb.due_date) BETWEEN 31 AND 60 '
-                    . 'THEN sb.amount_due ELSE 0 END as days_31_60',
-                'CASE WHEN DATEDIFF(CURDATE(), sb.due_date) BETWEEN 61 AND 90 '
-                    . 'THEN sb.amount_due ELSE 0 END as days_61_90',
-                'CASE WHEN DATEDIFF(CURDATE(), sb.due_date) > 90 '
-                    . 'THEN sb.amount_due ELSE 0 END as days_over_90',
+                'CASE WHEN sb.due_date >= ? THEN sb.amount_due ELSE 0 END as current_amount',
+                'CASE WHEN sb.due_date BETWEEN ? AND ? THEN sb.amount_due ELSE 0 END as days_1_30',
+                'CASE WHEN sb.due_date BETWEEN ? AND ? THEN sb.amount_due ELSE 0 END as days_31_60',
+                'CASE WHEN sb.due_date BETWEEN ? AND ? THEN sb.amount_due ELSE 0 END as days_61_90',
+                'CASE WHEN sb.due_date < ? THEN sb.amount_due ELSE 0 END as days_over_90',
             ],
             extraCasts: [
                 'current_amount' => 'decimal:2',
@@ -32,6 +31,13 @@ class IndexApAgingReportAction
                 'days_31_60' => 'decimal:2',
                 'days_61_90' => 'decimal:2',
                 'days_over_90' => 'decimal:2',
+            ],
+            extraSelectBindings: [
+                $boundaries['today'],
+                $boundaries['d30'], $boundaries['d1'],
+                $boundaries['d60'], $boundaries['d31'],
+                $boundaries['d90'], $boundaries['d61'],
+                $boundaries['d90'],
             ],
         );
 

--- a/app/Actions/Reports/IndexApOutstandingReportAction.php
+++ b/app/Actions/Reports/IndexApOutstandingReportAction.php
@@ -6,6 +6,7 @@ use App\Actions\Reports\Concerns\BuildsSupplierBillReportQuery;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
 
 class IndexApOutstandingReportAction
 {
@@ -13,14 +14,17 @@ class IndexApOutstandingReportAction
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
+        $today = Carbon::today()->toDateString();
+
         $query = $this->buildBaseSupplierBillQuery(
             extraSelectColumns: [
                 'sb.payment_terms',
-                'CASE WHEN sb.due_date < CURDATE() THEN DATEDIFF(CURDATE(), sb.due_date) ELSE 0 END as days_overdue',
+                'CASE WHEN sb.due_date < ? THEN DATEDIFF(?, sb.due_date) ELSE 0 END as days_overdue',
             ],
             extraCasts: [
                 'days_overdue' => 'integer',
             ],
+            extraSelectBindings: [$today, $today],
         );
 
         $this->applySupplierBillFilters($request, $query);

--- a/app/Actions/Reports/IndexArAgingReportAction.php
+++ b/app/Actions/Reports/IndexArAgingReportAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Reports;
 
+use App\Actions\Reports\Concerns\AgingReportBoundaries;
 use App\Actions\Reports\Concerns\BuildsCustomerInvoiceReportQuery;
 use App\Actions\Reports\Concerns\HandlesReportQuery;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -11,6 +12,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class IndexArAgingReportAction
 {
+    use AgingReportBoundaries;
     use BuildsCustomerInvoiceReportQuery;
     use HandlesReportQuery;
 
@@ -34,14 +36,18 @@ class IndexArAgingReportAction
 
     protected function buildQuery(): Builder
     {
-        return $this->buildBaseCustomerInvoiceQuery([$this->agingBucketSelectSql()])
-            ->withCasts(array_merge($this->getBaseCasts(), [
-                'aging_current' => 'decimal:2',
-                'aging_1_30' => 'decimal:2',
-                'aging_31_60' => 'decimal:2',
-                'aging_61_90' => 'decimal:2',
-                'aging_over_90' => 'decimal:2',
-            ]));
+        $boundaries = $this->agingBoundaries();
+
+        return $this->buildBaseCustomerInvoiceQuery(
+            [$this->agingBucketSelectSql('ci')],
+            $this->agingBucketBindings($boundaries),
+        )->withCasts(array_merge($this->getBaseCasts(), [
+            'aging_current' => 'decimal:2',
+            'aging_1_30' => 'decimal:2',
+            'aging_31_60' => 'decimal:2',
+            'aging_61_90' => 'decimal:2',
+            'aging_over_90' => 'decimal:2',
+        ]));
     }
 
     protected function defaultSortBy(): string
@@ -73,29 +79,5 @@ class IndexArAgingReportAction
     protected function fallbackSortBy(): string
     {
         return $this->defaultSortBy();
-    }
-
-    private function agingBucketSelectSql(): string
-    {
-        return 'CASE
-            WHEN DATEDIFF(CURDATE(), ci.due_date) <= 0 THEN ci.amount_due
-            ELSE 0
-        END as aging_current,
-        CASE
-            WHEN DATEDIFF(CURDATE(), ci.due_date) BETWEEN 1 AND 30 THEN ci.amount_due
-            ELSE 0
-        END as aging_1_30,
-        CASE
-            WHEN DATEDIFF(CURDATE(), ci.due_date) BETWEEN 31 AND 60 THEN ci.amount_due
-            ELSE 0
-        END as aging_31_60,
-        CASE
-            WHEN DATEDIFF(CURDATE(), ci.due_date) BETWEEN 61 AND 90 THEN ci.amount_due
-            ELSE 0
-        END as aging_61_90,
-        CASE
-            WHEN DATEDIFF(CURDATE(), ci.due_date) > 90 THEN ci.amount_due
-            ELSE 0
-        END as aging_over_90';
     }
 }

--- a/app/Actions/Reports/IndexArOutstandingReportAction.php
+++ b/app/Actions/Reports/IndexArOutstandingReportAction.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
 
 class IndexArOutstandingReportAction
 {
@@ -34,10 +35,14 @@ class IndexArOutstandingReportAction
 
     protected function buildQuery(): Builder
     {
-        return $this->buildBaseCustomerInvoiceQuery([$this->daysOverdueSelectSql()])
-            ->withCasts(array_merge($this->getBaseCasts(), [
-                'days_overdue' => 'integer',
-            ]));
+        $today = Carbon::today()->toDateString();
+
+        return $this->buildBaseCustomerInvoiceQuery(
+            [$this->daysOverdueSelectSql()],
+            [$today, $today],
+        )->withCasts(array_merge($this->getBaseCasts(), [
+            'days_overdue' => 'integer',
+        ]));
     }
 
     protected function defaultSortBy(): string
@@ -70,8 +75,8 @@ class IndexArOutstandingReportAction
     private function daysOverdueSelectSql(): string
     {
         return "CASE
-            WHEN ci.status IN ('sent', 'partially_paid', 'overdue') AND ci.due_date < CURDATE()
-            THEN DATEDIFF(CURDATE(), ci.due_date)
+            WHEN ci.status IN ('sent', 'partially_paid', 'overdue') AND ci.due_date < ?
+            THEN DATEDIFF(?, ci.due_date)
             ELSE 0
         END as days_overdue";
     }


### PR DESCRIPTION
## Summary

Closes Oracle post-H3 audit **Finding #1** (HIGH severity, ~1-2d effort) and folds in **M3 timezone** fix.

Replaces MariaDB-only `CURDATE()` and `DATEDIFF(CURDATE(), x)` raw SQL in 4 legacy report actions with Carbon-precomputed date strings injected via prepared statement bindings — mirroring the canonical pattern in `GetAgingDashboardDataAction`.

## Why

The 4 legacy aging/outstanding report actions used raw `CURDATE()` / `DATEDIFF(CURDATE(), x)` SQL expressions, which:
1. Are MariaDB/MySQL specific (not portable to Postgres/SQLite without rewrites).
2. Compute date math at the DB layer, bypassing app timezone configuration.
3. Diverged from the canonical pattern already proven in `GetAgingDashboardDataAction` (which uses `Carbon::today()` + parameterized bindings).

This refactor unifies all aging logic on the Carbon-based pattern.

## Changes

### New trait: `app/Actions/Reports/Concerns/AgingReportBoundaries.php`
Centralizes the 7 bucket boundary dates (today, today-1, today-30, today-31, today-60, today-61, today-90) and renders parameterized SELECT fragment with aliases:
- `aging_current` (due_date >= today)
- `aging_1_30` (due_date BETWEEN today-30 AND today-1)
- `aging_31_60` (due_date BETWEEN today-60 AND today-31)
- `aging_61_90` (due_date BETWEEN today-90 AND today-61)
- `aging_over_90` (due_date < today-90)

Used by both AR + AP aging actions.

### Trait extensions (backward compatible)
| Trait | Method | New param |
|---|---|---|
| `BuildsCustomerInvoiceReportQuery` | `buildBaseCustomerInvoiceQuery` | `array $additionalBindings = []` |
| `BuildsSupplierBillReportQuery` | `buildBaseSupplierBillQuery` | `array $extraSelectBindings = []` |

Default empty array preserves existing callers (`IndexCustomerStatementReportAction` confirmed unaffected — full test suite green).

### Action ports
| Action | Before | After |
|---|---|---|
| `IndexArAgingReportAction` | 5 `DATEDIFF(CURDATE(), …)` CASE | parameterized via shared trait |
| `IndexApAgingReportAction` | 5 `DATEDIFF(CURDATE(), …)` CASE | parameterized via shared trait |
| `IndexArOutstandingReportAction` | `days_overdue` with `CURDATE()` + `DATEDIFF` | `Carbon::today()` + bindings |
| `IndexApOutstandingReportAction` | `days_overdue` with `CURDATE()` + `DATEDIFF` | `Carbon::today()` + bindings |

For `days_overdue` integer alias, `DATEDIFF` is retained but called with parameterized today-string instead of `CURDATE()`. This keeps the column queryable for ORDER BY while removing the implicit DB-side timezone dependency.

## M3 timezone bonus

Closing this finding also closes the standalone M3 timezone item:
- `Carbon::today()` honors the app's default timezone (UTC per app config).
- Orphan `regional.timezone` setting was already removed via QW#1 (PR #18).
- All date math now flows through the same UTC-anchored Carbon path as `GetAgingDashboardDataAction`.

## Diff stats

```
7 files changed, 122 insertions(+), 54 deletions(-)
```

## Verification

| Check | Result |
|---|---|
| `sail test --group ar-aging-report` | ✅ 5 pass / 28 assertions |
| `sail test --group ap-aging-report` | ✅ 5 pass / 59 assertions |
| `sail test --group ar-outstanding-report` | ✅ 5 pass / 28 assertions |
| `sail test --group ap-outstanding-report` | ✅ 5 pass / 17 assertions |
| `sail test --group aging-dashboard` (regression) | ✅ 15 pass / 113 assertions |
| `sail test --group customer-statement-report` (regression) | ✅ 5 pass / 26 assertions |
| `sail bin phpstan analyze` (7 affected files) | ✅ No errors |
| `sail bin duster fix` | ✅ No further changes needed |

## Behavior preservation

- Bucket math is mathematically equivalent: `DATEDIFF(today, due_date) <= 0` ≡ `due_date >= today`; `BETWEEN 1 AND 30` ≡ `due_date BETWEEN today-30 AND today-1`; etc.
- API contract unchanged on all 4 endpoints (same response keys, same column aliases).
- Sortable columns unchanged (`days_overdue`, `aging_*` aliases preserved).
- Date casts preserved.