### PR TITLE
fix(reports): port DATEDIFF + MONTH SQL to cross-DB Carbon/EXTRACT (Oracle Findings #1, #2)

### DIFF
--- a/app/Actions/Reports/IndexApOutstandingReportAction.php
+++ b/app/Actions/Reports/IndexApOutstandingReportAction.php
@@ -6,7 +6,6 @@ use App\Actions\Reports\Concerns\BuildsSupplierBillReportQuery;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Carbon;
 
 class IndexApOutstandingReportAction
 {
@@ -14,18 +13,8 @@ class IndexApOutstandingReportAction
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
-        $today = Carbon::today()->toDateString();
-
-        $query = $this->buildBaseSupplierBillQuery(
-            extraSelectColumns: [
-                'sb.payment_terms',
-                'CASE WHEN sb.due_date < ? THEN DATEDIFF(?, sb.due_date) ELSE 0 END as days_overdue',
-            ],
-            extraCasts: [
-                'days_overdue' => 'integer',
-            ],
-            extraSelectBindings: [$today, $today],
-        );
+        // days_overdue computed in PHP via Carbon (cross-DB). See ApOutstandingReportResource.
+        $query = $this->buildBaseSupplierBillQuery();
 
         $this->applySupplierBillFilters($request, $query);
         $this->applyDateRangeFilter($request, $query, 'sb.due_date', 'due_date_from', 'due_date_to');

--- a/app/Actions/Reports/IndexArOutstandingReportAction.php
+++ b/app/Actions/Reports/IndexArOutstandingReportAction.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Carbon;
 
 class IndexArOutstandingReportAction
 {
@@ -20,29 +19,16 @@ class IndexArOutstandingReportAction
         $query = $this->buildQuery();
 
         $this->applyBaseCustomerInvoiceFilters($request, $query);
-        $this->applyRequestSorting(
-            $request,
-            $query,
-            $this->defaultSortBy(),
-            $this->sortAliases(),
-            $this->plainSortableColumns(),
-            $this->aggregateSortableColumns(),
-            $this->fallbackSortBy(),
-        );
+        $this->applyOutstandingSorting($request, $query);
 
         return $this->exportOrPaginate($request, $query);
     }
 
     protected function buildQuery(): Builder
     {
-        $today = Carbon::today()->toDateString();
-
-        return $this->buildBaseCustomerInvoiceQuery(
-            [$this->daysOverdueSelectSql()],
-            [$today, $today],
-        )->withCasts(array_merge($this->getBaseCasts(), [
-            'days_overdue' => 'integer',
-        ]));
+        // days_overdue computed in PHP via Carbon (cross-DB). See ArOutstandingReportResource.
+        return $this->buildBaseCustomerInvoiceQuery()
+            ->withCasts($this->getBaseCasts());
     }
 
     protected function defaultSortBy(): string
@@ -62,22 +48,39 @@ class IndexArOutstandingReportAction
 
     protected function aggregateSortableColumns(): array
     {
-        return [
-            'days_overdue',
-        ];
+        return [];
     }
 
     protected function fallbackSortBy(): string
     {
-        return $this->defaultSortBy();
+        return 'due_date';
     }
 
-    private function daysOverdueSelectSql(): string
+    /**
+     * Resolves days_overdue sort to due_date with inverted direction:
+     * "most overdue first" (desc) == "oldest due first" (asc).
+     * All other sort keys delegate to the standard request sorting.
+     */
+    private function applyOutstandingSorting(FormRequest $request, Builder $query): void
     {
-        return "CASE
-            WHEN ci.status IN ('sent', 'partially_paid', 'overdue') AND ci.due_date < ?
-            THEN DATEDIFF(?, ci.due_date)
-            ELSE 0
-        END as days_overdue";
+        $sortBy = $request->string('sort_by', $this->defaultSortBy())->toString();
+
+        if ($sortBy === 'days_overdue') {
+            $sortDirection = $request->string('sort_direction', 'desc')->toString();
+            $invertedDirection = strtolower($sortDirection) === 'asc' ? 'desc' : 'asc';
+            $query->orderBy('due_date', $invertedDirection);
+
+            return;
+        }
+
+        $this->applyRequestSorting(
+            $request,
+            $query,
+            $this->defaultSortBy(),
+            $this->sortAliases(),
+            $this->plainSortableColumns(),
+            $this->aggregateSortableColumns(),
+            $this->fallbackSortBy(),
+        );
     }
 }

--- a/app/Exports/ApOutstandingReportExport.php
+++ b/app/Exports/ApOutstandingReportExport.php
@@ -4,6 +4,7 @@ namespace App\Exports;
 
 use App\Actions\Reports\IndexApOutstandingReportAction;
 use App\Exports\Concerns\AbstractReportIndexExport;
+use App\Exports\Concerns\ComputesDaysOverdue;
 use App\Exports\Concerns\MapsSupplierBillExportRow;
 use App\Http\Requests\Reports\IndexApOutstandingReportRequest;
 use Maatwebsite\Excel\Concerns\WithHeadings;
@@ -11,6 +12,7 @@ use Maatwebsite\Excel\Concerns\WithMapping;
 
 class ApOutstandingReportExport extends AbstractReportIndexExport implements WithHeadings, WithMapping
 {
+    use ComputesDaysOverdue;
     use MapsSupplierBillExportRow;
 
     public function headings(): array
@@ -40,7 +42,7 @@ class ApOutstandingReportExport extends AbstractReportIndexExport implements Wit
         return array_merge(
             $this->baseBillExportRow($row),
             [
-                $row->days_overdue ?? 0,
+                $this->computeDaysOverdue($row->due_date),
             ],
             $this->billExportTrailingColumns($row)
         );

--- a/app/Exports/ArOutstandingReportExport.php
+++ b/app/Exports/ArOutstandingReportExport.php
@@ -4,6 +4,7 @@ namespace App\Exports;
 
 use App\Actions\Reports\IndexArOutstandingReportAction;
 use App\Exports\Concerns\AbstractReportIndexExport;
+use App\Exports\Concerns\ComputesDaysOverdue;
 use App\Exports\Concerns\MapsCustomerInvoiceExportRow;
 use App\Http\Requests\Reports\IndexArOutstandingReportRequest;
 use Maatwebsite\Excel\Concerns\WithHeadings;
@@ -11,7 +12,10 @@ use Maatwebsite\Excel\Concerns\WithMapping;
 
 class ArOutstandingReportExport extends AbstractReportIndexExport implements WithHeadings, WithMapping
 {
+    use ComputesDaysOverdue;
     use MapsCustomerInvoiceExportRow;
+
+    private const OVERDUE_STATUSES = ['sent', 'partially_paid', 'overdue'];
 
     public function headings(): array
     {
@@ -23,7 +27,7 @@ class ArOutstandingReportExport extends AbstractReportIndexExport implements Wit
     public function map($row): array
     {
         return array_merge($this->mapBaseInvoiceColumns($row), [
-            $row->days_overdue ?? 0,
+            $this->computeDaysOverdue($row->due_date, $row->status, self::OVERDUE_STATUSES),
         ]);
     }
 

--- a/app/Exports/Concerns/ComputesDaysOverdue.php
+++ b/app/Exports/Concerns/ComputesDaysOverdue.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Exports\Concerns;
+
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+
+trait ComputesDaysOverdue
+{
+    /**
+     * Cross-DB safe replacement for MariaDB DATEDIFF(today, due_date).
+     * Optional $statusGate restricts non-zero result to specific statuses.
+     *
+     * @param  list<string>|null  $statusGate
+     */
+    protected function computeDaysOverdue(mixed $dueDate, ?string $status = null, ?array $statusGate = null): int
+    {
+        if ($statusGate !== null && ($status === null || ! in_array($status, $statusGate, true))) {
+            return 0;
+        }
+
+        if ($dueDate === null) {
+            return 0;
+        }
+
+        $due = $dueDate instanceof DateTimeInterface
+            ? Carbon::instance($dueDate)
+            : Carbon::parse((string) $dueDate);
+
+        $today = Carbon::today();
+
+        return $due->lt($today) ? $due->diffInDays($today) : 0;
+    }
+}

--- a/app/Http/Resources/Reports/ApOutstandingReportResource.php
+++ b/app/Http/Resources/Reports/ApOutstandingReportResource.php
@@ -6,6 +6,7 @@ use App\Http\Resources\Reports\Concerns\FormatsBillReportData;
 use DateTimeInterface;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
@@ -26,7 +27,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property string $branch_name
  * @property string|null $purchase_order_number
  * @property string|null $goods_receipt_number
- * @property int $days_overdue
  */
 class ApOutstandingReportResource extends JsonResource
 {
@@ -35,7 +35,24 @@ class ApOutstandingReportResource extends JsonResource
     public function toArray(Request $request): array
     {
         return array_merge($this->baseBillReportData(), [
-            'days_overdue' => $this->days_overdue,
+            'days_overdue' => $this->computeDaysOverdue(),
         ]);
+    }
+
+    private function computeDaysOverdue(): int
+    {
+        $dueDate = $this->due_date;
+
+        if ($dueDate === null) {
+            return 0;
+        }
+
+        $due = $dueDate instanceof DateTimeInterface
+            ? Carbon::instance($dueDate)
+            : Carbon::parse((string) $dueDate);
+
+        $today = Carbon::today();
+
+        return $due->lt($today) ? $due->diffInDays($today) : 0;
     }
 }

--- a/app/Http/Resources/Reports/ArOutstandingReportResource.php
+++ b/app/Http/Resources/Reports/ArOutstandingReportResource.php
@@ -6,6 +6,7 @@ use App\Http\Resources\Reports\Concerns\FormatsInvoiceReportData;
 use DateTimeInterface;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $customer_invoice_id
@@ -21,16 +22,38 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property string $customer_name
  * @property int $branch_id
  * @property string $branch_name
- * @property int $days_overdue
  */
 class ArOutstandingReportResource extends JsonResource
 {
     use FormatsInvoiceReportData;
 
+    private const OVERDUE_STATUSES = ['sent', 'partially_paid', 'overdue'];
+
     public function toArray(Request $request): array
     {
         return array_merge($this->formatBaseInvoiceData(), [
-            'days_overdue' => $this->days_overdue,
+            'days_overdue' => $this->computeDaysOverdue(),
         ]);
+    }
+
+    private function computeDaysOverdue(): int
+    {
+        if (! in_array($this->status, self::OVERDUE_STATUSES, true)) {
+            return 0;
+        }
+
+        $dueDate = $this->due_date;
+
+        if ($dueDate === null) {
+            return 0;
+        }
+
+        $due = $dueDate instanceof DateTimeInterface
+            ? Carbon::instance($dueDate)
+            : Carbon::parse((string) $dueDate);
+
+        $today = Carbon::today();
+
+        return $due->lt($today) ? $due->diffInDays($today) : 0;
     }
 }

--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -8,6 +8,7 @@ use App\Models\CoaVersion;
 use App\Models\FiscalYear;
 use App\Models\JournalEntryLine;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class FinancialReportService
@@ -76,36 +77,36 @@ class FinancialReportService
             return [];
         }
 
-        /** @var Collection<int, object{month: int, revenue: string, expenses: string}> $results */
-        $results = JournalEntryLine::query()
+        // PHP-side month bucketing keeps query cross-DB safe (avoids MariaDB-only MONTH()).
+        /** @var Collection<int, object{entry_date: string, account_type: string, debit: string, credit: string}> $rows */
+        $rows = JournalEntryLine::query()
             ->join('journal_entries', 'journal_entries.id', '=', 'journal_entry_lines.journal_entry_id')
             ->join('accounts', 'accounts.id', '=', 'journal_entry_lines.account_id')
             ->where('journal_entries.fiscal_year_id', $fiscalYearId)
             ->where('journal_entries.status', 'posted')
             ->where('accounts.coa_version_id', $coaVersion->id)
             ->whereIn('accounts.type', ['revenue', 'expense'])
-            ->selectRaw('MONTH(journal_entries.entry_date) as month')
-            ->selectRaw(
-                "SUM(CASE WHEN accounts.type = 'revenue' "
-                . 'THEN journal_entry_lines.credit - journal_entry_lines.debit '
-                . 'ELSE 0 END) as revenue'
-            )
-            ->selectRaw(
-                "SUM(CASE WHEN accounts.type = 'expense' "
-                . 'THEN journal_entry_lines.debit - journal_entry_lines.credit '
-                . 'ELSE 0 END) as expenses'
-            )
-            ->groupByRaw('MONTH(journal_entries.entry_date)')
-            ->orderByRaw('MONTH(journal_entries.entry_date)')
+            ->select([
+                'journal_entries.entry_date as entry_date',
+                'accounts.type as account_type',
+                'journal_entry_lines.debit as debit',
+                'journal_entry_lines.credit as credit',
+            ])
             ->get();
 
         $dataByMonth = [];
-        /** @var object $row */
-        foreach ($results as $row) {
-            $dataByMonth[(int) $row->month] = [
-                'revenue' => (float) $row->revenue,
-                'expenses' => (float) $row->expenses,
-            ];
+        foreach ($rows as $row) {
+            $month = Carbon::parse((string) $row->entry_date)->month;
+            $debit = (float) $row->debit;
+            $credit = (float) $row->credit;
+
+            $dataByMonth[$month] ??= ['revenue' => 0.0, 'expenses' => 0.0];
+
+            if ($row->account_type === 'revenue') {
+                $dataByMonth[$month]['revenue'] += $credit - $debit;
+            } else {
+                $dataByMonth[$month]['expenses'] += $debit - $credit;
+            }
         }
 
         $months = [];

--- a/tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php
+++ b/tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php
@@ -129,6 +129,80 @@ describe('Financial Dashboard API', function () {
             ->and((float) $kpis['net_income']['value'])->toBe(200000.0);
     });
 
+    test('returns monthly trends bucketed by entry_date across multiple months without MariaDB MONTH()', function () {
+        $fiscalYear = FiscalYear::factory()->create([
+            'status' => 'open',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-12-31',
+        ]);
+        $coaVersion = CoaVersion::factory()->create([
+            'fiscal_year_id' => $fiscalYear->id,
+            'status' => 'active',
+        ]);
+
+        $revenueAccount = Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'type' => 'revenue',
+            'normal_balance' => 'credit',
+            'level' => 1,
+            'parent_id' => null,
+        ]);
+
+        $expenseAccount = Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'type' => 'expense',
+            'normal_balance' => 'debit',
+            'level' => 1,
+            'parent_id' => null,
+        ]);
+
+        $entries = [
+            ['date' => '2024-01-15', 'revenue' => 100000.0, 'expense' => 30000.0],
+            ['date' => '2024-03-10', 'revenue' => 250000.0, 'expense' => 75000.0],
+            ['date' => '2024-03-25', 'revenue' => 50000.0, 'expense' => 25000.0],
+            ['date' => '2024-07-01', 'revenue' => 0.0, 'expense' => 200000.0],
+        ];
+
+        foreach ($entries as $entry) {
+            $journal = JournalEntry::factory()->create([
+                'fiscal_year_id' => $fiscalYear->id,
+                'status' => 'posted',
+                'entry_date' => $entry['date'],
+            ]);
+
+            JournalEntryLine::factory()->create([
+                'journal_entry_id' => $journal->id,
+                'account_id' => $revenueAccount->id,
+                'debit' => 0,
+                'credit' => $entry['revenue'],
+            ]);
+
+            JournalEntryLine::factory()->create([
+                'journal_entry_id' => $journal->id,
+                'account_id' => $expenseAccount->id,
+                'debit' => $entry['expense'],
+                'credit' => 0,
+            ]);
+        }
+
+        $response = getJson("/api/financial-dashboard?fiscal_year_id={$fiscalYear->id}");
+        $response->assertOk();
+
+        $trends = $response->json('monthly_trends');
+        $byMonth = collect($trends)->keyBy('month');
+
+        expect($trends)->toHaveCount(12);
+        expect((float) $byMonth[1]['revenue'])->toBe(100000.0);
+        expect((float) $byMonth[1]['expenses'])->toBe(30000.0);
+        expect((float) $byMonth[3]['revenue'])->toBe(300000.0);
+        expect((float) $byMonth[3]['expenses'])->toBe(100000.0);
+        expect((float) $byMonth[7]['revenue'])->toBe(0.0);
+        expect((float) $byMonth[7]['expenses'])->toBe(200000.0);
+        expect((float) $byMonth[2]['revenue'])->toBe(0.0);
+        expect((float) $byMonth[2]['expenses'])->toBe(0.0);
+        expect($byMonth[3]['label'])->toBe('Mar');
+    });
+
     test('requires authentication', function () {
         // Reset auth
         app('auth')->forgetGuards();

--- a/tests/Feature/Reports/ApOutstandingReportTest.php
+++ b/tests/Feature/Reports/ApOutstandingReportTest.php
@@ -93,6 +93,38 @@ test('it can filter by supplier and due date range', function () {
     expect($data)->toHaveCount(1);
 });
 
+test('it computes days_overdue in PHP without MariaDB-only DATEDIFF', function () {
+    Carbon::setTestNow(Carbon::parse('2026-03-04 10:00:00'));
+
+    $supplier = Supplier::factory()->create(['name' => 'Supplier Overdue']);
+
+    SupplierBill::factory()->confirmed()->create([
+        'supplier_id' => $supplier->id,
+        'bill_number' => 'BILL-OVERDUE',
+        'due_date' => '2026-02-25',
+        'amount_due' => 1000000,
+    ]);
+
+    SupplierBill::factory()->confirmed()->create([
+        'supplier_id' => $supplier->id,
+        'bill_number' => 'BILL-FUTURE',
+        'due_date' => '2026-03-20',
+        'amount_due' => 500000,
+    ]);
+
+    $response = getJson('/api/reports/ap-outstanding?sort_by=bill_number&sort_direction=asc')
+        ->assertOk();
+
+    $data = $response->json('data');
+    expect($data)->toHaveCount(2);
+
+    $byNumber = collect($data)->keyBy('bill.number');
+    expect($byNumber['BILL-FUTURE']['days_overdue'])->toBe(0);
+    expect($byNumber['BILL-OVERDUE']['days_overdue'])->toBe(7);
+
+    Carbon::setTestNow();
+});
+
 test('it can export ap outstanding report', function () {
     Excel::fake();
     Storage::fake('public');

--- a/tests/Feature/Reports/ArOutstandingReportTest.php
+++ b/tests/Feature/Reports/ArOutstandingReportTest.php
@@ -106,6 +106,84 @@ test('it can filter by status', function () {
         ->assertJsonPath('data.0.customer_invoice.invoice_number', 'INV-PARTIAL');
 });
 
+test('it computes days_overdue in PHP without MariaDB-only DATEDIFF', function () {
+    Carbon::setTestNow(Carbon::parse('2026-03-04 10:00:00'));
+
+    $customer = Customer::factory()->create();
+    $fiscalYear = FiscalYear::factory()->create();
+
+    CustomerInvoice::factory()->create([
+        'customer_id' => $customer->id,
+        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_number' => 'INV-OVERDUE',
+        'due_date' => '2026-02-22',
+        'status' => 'sent',
+    ]);
+    CustomerInvoice::factory()->create([
+        'customer_id' => $customer->id,
+        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_number' => 'INV-FUTURE',
+        'due_date' => '2026-04-01',
+        'status' => 'sent',
+    ]);
+    CustomerInvoice::factory()->create([
+        'customer_id' => $customer->id,
+        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_number' => 'INV-DRAFT-OVERDUE',
+        'due_date' => '2026-01-01',
+        'status' => 'draft',
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+    $response = getJson('/api/reports/ar-outstanding?sort_by=invoice_number&sort_direction=asc')
+        ->assertOk();
+
+    $data = $response->json('data');
+    $byNumber = collect($data)->keyBy('customer_invoice.invoice_number');
+
+    expect($byNumber['INV-OVERDUE']['days_overdue'])->toBe(10);
+    expect($byNumber['INV-FUTURE']['days_overdue'])->toBe(0);
+    // Draft invoices appear in result set but days_overdue is zero (status-gated in PHP).
+    expect($byNumber['INV-DRAFT-OVERDUE']['days_overdue'])->toBe(0);
+
+    Carbon::setTestNow();
+});
+
+test('it sorts by days_overdue using due_date ascending', function () {
+    Carbon::setTestNow(Carbon::parse('2026-03-04 10:00:00'));
+
+    $customer = Customer::factory()->create();
+    $fiscalYear = FiscalYear::factory()->create();
+
+    CustomerInvoice::factory()->create([
+        'customer_id' => $customer->id,
+        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_number' => 'INV-OLD',
+        'due_date' => '2026-01-10',
+        'status' => 'sent',
+    ]);
+    CustomerInvoice::factory()->create([
+        'customer_id' => $customer->id,
+        'fiscal_year_id' => $fiscalYear->id,
+        'invoice_number' => 'INV-RECENT',
+        'due_date' => '2026-02-25',
+        'status' => 'sent',
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+    $response = getJson('/api/reports/ar-outstanding?sort_by=days_overdue')
+        ->assertOk();
+
+    $invoiceNumbers = collect($response->json('data'))
+        ->pluck('customer_invoice.invoice_number')
+        ->all();
+
+    expect($invoiceNumbers[0])->toBe('INV-OLD');
+    expect($invoiceNumbers[1])->toBe('INV-RECENT');
+
+    Carbon::setTestNow();
+});
+
 test('it can export ar outstanding report', function () {
     Carbon::setTestNow(Carbon::parse('2026-03-04 10:00:00'));
     Excel::fake();


### PR DESCRIPTION
## Summary

Restores the cross-DB claim from prior PR #20 by removing the last MariaDB-only date functions in the codebase.

## Changes

### Finding #1 (HIGH) — DATEDIFF in AR/AP outstanding reports
- `app/Actions/Reports/IndexApOutstandingReportAction.php`: removed `DATEDIFF(?, sb.due_date)` raw SQL select.
- `app/Actions/Reports/IndexArOutstandingReportAction.php`: removed `DATEDIFF(?, ci.due_date)` raw SQL select; `days_overdue` is no longer an aggregate-sortable SQL alias.
- `app/Http/Resources/Reports/ApOutstandingReportResource.php` + `ArOutstandingReportResource.php`: compute `days_overdue` in PHP via Carbon `diffInDays` (AR keeps original status gate: `sent/partially_paid/overdue`).
- `app/Exports/Concerns/ComputesDaysOverdue.php`: new shared trait (status-gate aware) used by both exports.
- `app/Exports/ApOutstandingReportExport.php` + `ArOutstandingReportExport.php`: pull `days_overdue` from the trait instead of relying on a SQL alias on the row.

**Sort semantics for AR `days_overdue`**: the original SQL allowed sorting by the `days_overdue` alias. Without that alias we map `sort_by=days_overdue` to `due_date` with inverted direction ("most overdue first" desc == "oldest due first" asc). Implementation: `IndexArOutstandingReportAction::applyOutstandingSorting`. Covered by regression test `it sorts by days_overdue using due_date ascending`.

### Finding #2 (HIGH) — MONTH() in FinancialReportService
- `app/Services/FinancialReportService.php::getMonthlyTrends`: replaced `selectRaw('MONTH(...) as month')` + `groupByRaw` + `orderByRaw` with a flat `select` of `entry_date`, `account_type`, `debit`, `credit` and PHP-side bucketing via `Carbon::parse(\$row->entry_date)->month`. Output shape preserved exactly: `[{month, label, revenue, expenses, net_income}, ...]`.

## Tests added (regression)

- `tests/Feature/Reports/ApOutstandingReportTest.php` — `it computes days_overdue in PHP without MariaDB-only DATEDIFF` asserts overdue + future cases.
- `tests/Feature/Reports/ArOutstandingReportTest.php` — `it computes days_overdue in PHP without MariaDB-only DATEDIFF` (covers status gating for draft) + `it sorts by days_overdue using due_date ascending`.
- `tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php` — `returns monthly trends bucketed by entry_date across multiple months without MariaDB MONTH()` covers multi-month aggregation + zero-bucket months.

## Quality gates

- `sail bin phpstan analyze` — clean
- `sail bin duster fix` — clean
- `sail test --filter "ArAgingReport|ApAgingReport|ArOutstandingReport|ApOutstandingReport|FinancialDashboard"` — **32 passed, 212 assertions**

## Scope

Stays scoped to Findings #1 and #2. Does not touch BankReconciliation files (PR B). No new dependencies. Response/JSON shape preserved.