### PR TITLE
fix(ap-ar-payments): close postJournal race via afterCommit hook (Finding #4 — AP+AR)

### DIFF
--- a/app/Http/Controllers/ApPaymentController.php
+++ b/app/Http/Controllers/ApPaymentController.php
@@ -95,11 +95,12 @@ class ApPaymentController extends Controller
             syncItems: function (ApPayment $apPayment, array $allocations) use ($syncAllocations): void {
                 $syncAllocations->execute($apPayment, $allocations);
             },
+            afterCommit: $isNewlyConfirmed
+                ? function (ApPayment $apPayment) use ($postJournal): void {
+                    $postJournal->execute($apPayment->refresh());
+                }
+            : null,
         );
-
-        if ($isNewlyConfirmed) {
-            $postJournal->execute($apPayment->refresh());
-        }
 
         return (new ApPaymentResource($this->loadResourceRelations($apPayment)))->response();
     }

--- a/app/Http/Controllers/ArReceiptController.php
+++ b/app/Http/Controllers/ArReceiptController.php
@@ -90,11 +90,12 @@ class ArReceiptController extends Controller
             syncItems: function (ArReceipt $arReceipt, array $allocations) use ($syncAllocations): void {
                 $syncAllocations->execute($arReceipt, $allocations);
             },
+            afterCommit: $isNewlyConfirmed
+                ? function (ArReceipt $arReceipt) use ($postJournal): void {
+                    $postJournal->execute($arReceipt->refresh());
+                }
+            : null,
         );
-
-        if ($isNewlyConfirmed) {
-            $postJournal->execute($arReceipt->refresh());
-        }
 
         return (new ArReceiptResource($this->loadResourceRelations($arReceipt)))->response();
     }

--- a/app/Http/Controllers/Concerns/StoresItemsInTransaction.php
+++ b/app/Http/Controllers/Concerns/StoresItemsInTransaction.php
@@ -63,21 +63,32 @@ trait StoresItemsInTransaction
      * @param  array<int, array<string, mixed>>|null  $items
      * @param  callable(array<string, mixed>): array<string, mixed>  $payloadResolver
      * @param  callable(TModel, array<int, array<string, mixed>>): void  $syncItems
+     * @param  (callable(TModel): void)|null  $afterCommit  Optional hook executed inside
+     *                                                      the same transaction after items
+     *                                                      sync. Use this to atomically pair
+     *                                                      state mutations with side effects
+     *                                                      like journal posting so the change
+     *                                                      and its effect rollback together.
      */
     protected function updateWithSyncedItems(
         Model $model,
         array $attributes,
         ?array $items,
         callable $payloadResolver,
-        callable $syncItems
+        callable $syncItems,
+        ?callable $afterCommit = null
     ): void {
         $payload = $payloadResolver($attributes);
 
-        DB::transaction(function () use ($model, $payload, $items, $syncItems): void {
+        DB::transaction(function () use ($model, $payload, $items, $syncItems, $afterCommit): void {
             $model->update($payload);
 
             if (is_array($items)) {
                 $syncItems($model, $items);
+            }
+
+            if ($afterCommit !== null) {
+                $afterCommit($model);
             }
         });
     }

--- a/tests/Feature/ApPayments/ApPaymentControllerTest.php
+++ b/tests/Feature/ApPayments/ApPaymentControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\AccountingPosting\PostApPaymentJournalAction;
 use App\Models\Account;
 use App\Models\ApPayment;
 use App\Models\Branch;
@@ -183,4 +184,30 @@ test('destroy removes ap payment', function () {
         ->assertNoContent();
 
     assertDatabaseMissing('ap_payments', ['id' => $apPayment->id]);
+});
+
+test('confirming ap payment rolls back state when journal posting fails', function () {
+    $apPayment = ApPayment::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostApPaymentJournalAction::class, function () {
+        return new class
+        {
+            public function execute(ApPayment $apPayment): void
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    putJson('/api/ap-payments/' . $apPayment->id, ['status' => 'confirmed'])
+        ->assertStatus(500);
+
+    $apPayment->refresh();
+    expect($apPayment->status)->toBe('draft');
+    expect($apPayment->confirmed_at)->toBeNull();
+    expect($apPayment->confirmed_by)->toBeNull();
 });

--- a/tests/Feature/ArReceipts/ArReceiptControllerTest.php
+++ b/tests/Feature/ArReceipts/ArReceiptControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\AccountingPosting\PostArReceiptJournalAction;
 use App\Models\Account;
 use App\Models\ArReceipt;
 use App\Models\Branch;
@@ -199,4 +200,30 @@ test('destroy removes ar receipt', function () {
         ->assertNoContent();
 
     assertDatabaseMissing('ar_receipts', ['id' => $receipt->id]);
+});
+
+test('confirming ar receipt rolls back state when journal posting fails', function () {
+    $receipt = ArReceipt::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostArReceiptJournalAction::class, function () {
+        return new class
+        {
+            public function execute(ArReceipt $arReceipt): void
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    putJson('/api/ar-receipts/' . $receipt->id, ['status' => 'confirmed'])
+        ->assertStatus(500);
+
+    $receipt->refresh();
+    expect($receipt->status)->toBe('draft');
+    expect($receipt->confirmed_at)->toBeNull();
+    expect($receipt->confirmed_by)->toBeNull();
 });


### PR DESCRIPTION
## Summary

Closes the race window in `ApPaymentController::update` and `ArReceiptController::update` where `postJournal->execute()` ran AFTER `updateWithSyncedItems` committed. If the process died between commit and journal post, a confirmed payment/receipt could exist with no journal entry.

This is the AP+AR pilot for Oracle audit Finding #4 (8 controllers). 6 remaining controllers (CustomerInvoice, GoodsReceipt, StockAdjustment, SupplierBill, SupplierReturn, plus any others using the same shape) can adopt the same hook in follow-up waves.

## Approach

Extended `StoresItemsInTransaction::updateWithSyncedItems` with an optional `?callable $afterCommit` parameter that runs INSIDE the same `DB::transaction` as the state mutation and items sync. State flip + journal posting now commit/rollback atomically.

Why a hook (Option A) instead of extracting an action (Option B from Oracle):
- Pattern is reusable verbatim across the remaining 6 controllers with the same `isNewlyConfirmed` shape.
- Zero changes to DTO/Action contracts.
- Tiny blast radius (1 trait + 2 controllers + 2 regression tests).
- Action thinning can still happen later in a dedicated PR if desired.

## Changes

- `app/Http/Controllers/Concerns/StoresItemsInTransaction.php` — add `?callable $afterCommit = null` parameter to `updateWithSyncedItems()`. Invoked inside the existing transaction after items sync. Backward compatible (default `null`).
- `app/Http/Controllers/ApPaymentController.php` — pass `postJournal` as `afterCommit` callable when `$isNewlyConfirmed`.
- `app/Http/Controllers/ArReceiptController.php` — same.
- `tests/Feature/ApPayments/ApPaymentControllerTest.php` — new regression test that binds a failing `PostApPaymentJournalAction` and asserts `status`, `confirmed_at`, `confirmed_by` all roll back when journal posting throws.
- `tests/Feature/ArReceipts/ArReceiptControllerTest.php` — same.

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `ap-payments` — **13 passed**, 62 assertions (1 new regression)
  - `ar-receipts` — **9 passed**, 44 assertions (1 new regression)
  - `ap-journal-posting` — 13 passed (no regression)
  - `ar-journal-posting` — 13 passed (no regression)
  - `purchase-orders` (smoke for the shared trait) — 18 passed

## Closes

Oracle audit Finding #4 (MEDIUM) — partial: AP+AR. 6 controllers remaining (deferred to follow-up waves).

## Out of Scope

- 6 remaining controllers from Finding #4 (CustomerInvoice, GoodsReceipt, StockAdjustment, SupplierBill, SupplierReturn, etc.)
- Findings #6, #7, #8, #10 — polish, deferred.
- Schema-blocked items (financial dashboard branch scoping, etc.) — deferred.