### PR TITLE
fix(customer-invoices,goods-receipts): close postJournal race via afterCommit hook (Finding #4 — wave 2)

### DIFF
--- a/app/Http/Controllers/CustomerInvoiceController.php
+++ b/app/Http/Controllers/CustomerInvoiceController.php
@@ -88,11 +88,12 @@ class CustomerInvoiceController extends Controller
             syncItems: function (CustomerInvoice $customerInvoice, array $items) use ($syncItems): void {
                 $syncItems->execute($customerInvoice, $items);
             },
+            afterCommit: $isNewlySent
+                ? function (CustomerInvoice $customerInvoice) use ($postJournal): void {
+                    $postJournal->execute($customerInvoice->refresh());
+                }
+            : null,
         );
-
-        if ($isNewlySent) {
-            $postJournal->execute($customerInvoice->refresh());
-        }
 
         return (new CustomerInvoiceResource($this->loadResourceRelations($customerInvoice)))->response();
     }

--- a/app/Http/Controllers/GoodsReceiptController.php
+++ b/app/Http/Controllers/GoodsReceiptController.php
@@ -93,18 +93,23 @@ class GoodsReceiptController extends Controller
             syncItems: function (GoodsReceipt $goodsReceipt, array $items) use ($syncItems): void {
                 $syncItems->execute($goodsReceipt, $items);
             },
+            afterCommit: $isNewlyConfirmed
+                ? function (GoodsReceipt $goodsReceipt) use ($postJournal): void {
+                    try {
+                        $postJournal->execute($goodsReceipt->refresh());
+                    } catch (ValidationException $e) {
+                        // Validation failures (e.g. missing COA mapping) are intentionally
+                        // swallowed so the goods receipt itself stays confirmed; user can
+                        // post the journal later. Non-validation errors propagate and
+                        // roll back the entire transaction (status flip included).
+                        Log::warning('Goods receipt journal posting skipped', [
+                            'goods_receipt_id' => $goodsReceipt->id,
+                            'reason' => $e->getMessage(),
+                        ]);
+                    }
+                }
+            : null,
         );
-
-        if ($isNewlyConfirmed) {
-            try {
-                $postJournal->execute($goodsReceipt->refresh());
-            } catch (ValidationException $e) {
-                Log::warning('Goods receipt journal posting skipped', [
-                    'goods_receipt_id' => $goodsReceipt->id,
-                    'reason' => $e->getMessage(),
-                ]);
-            }
-        }
 
         return (new GoodsReceiptResource($this->loadResourceRelations($goodsReceipt)))->response();
     }

--- a/tests/Feature/CustomerInvoices/CustomerInvoiceControllerTest.php
+++ b/tests/Feature/CustomerInvoices/CustomerInvoiceControllerTest.php
@@ -1,11 +1,15 @@
 <?php
 
+use App\Actions\AccountingPosting\PostCustomerInvoiceJournalAction;
+use App\Actions\AccountingPosting\ResolveControlAccountAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
 use App\Models\Account;
 use App\Models\Branch;
 use App\Models\CoaVersion;
 use App\Models\Customer;
 use App\Models\CustomerInvoice;
 use App\Models\FiscalYear;
+use App\Models\JournalEntry;
 use App\Models\Product;
 use App\Models\Unit;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -204,6 +208,32 @@ test('update modifies customer invoice and sets sent_by when status changes to s
 
     $invoice->refresh();
     expect($invoice->sent_by)->not->toBeNull();
+});
+
+test('marking customer invoice sent rolls back state when journal posting fails', function () {
+    $invoice = CustomerInvoice::factory()->create([
+        'status' => 'draft',
+        'sent_at' => null,
+        'sent_by' => null,
+    ]);
+
+    $this->app->bind(PostCustomerInvoiceJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostCustomerInvoiceJournalAction
+        {
+            public function execute(CustomerInvoice $invoice): ?JournalEntry
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    putJson('/api/customer-invoices/' . $invoice->id, ['status' => 'sent'])
+        ->assertStatus(500);
+
+    $invoice->refresh();
+    expect($invoice->status)->toBe('draft');
+    expect($invoice->sent_at)->toBeNull();
+    expect($invoice->sent_by)->toBeNull();
 });
 
 test('destroy removes customer invoice', function () {

--- a/tests/Feature/GoodsReceipts/GoodsReceiptControllerTest.php
+++ b/tests/Feature/GoodsReceipts/GoodsReceiptControllerTest.php
@@ -1,12 +1,17 @@
 <?php
 
+use App\Actions\AccountingPosting\PostGoodsReceiptJournalAction;
+use App\Actions\AccountingPosting\ResolveControlAccountAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
 use App\Models\Employee;
 use App\Models\GoodsReceipt;
+use App\Models\JournalEntry;
 use App\Models\Product;
 use App\Models\PurchaseOrder;
 use App\Models\Unit;
 use App\Models\Warehouse;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\Sanctum;
 
 use function Pest\Laravel\assertDatabaseHas;
@@ -222,6 +227,60 @@ test('update keeps current goods receipt number unique', function () {
     ])
         ->assertOk()
         ->assertJsonPath('data.gr_number', 'GR-KEEP-001');
+});
+
+test('confirming goods receipt rolls back state when journal posting fails with non-validation error', function () {
+    $goodsReceipt = GoodsReceipt::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostGoodsReceiptJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostGoodsReceiptJournalAction
+        {
+            public function execute(GoodsReceipt $goodsReceipt): ?JournalEntry
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    putJson('/api/goods-receipts/' . $goodsReceipt->id, ['status' => 'confirmed'])
+        ->assertStatus(500);
+
+    $goodsReceipt->refresh();
+    expect($goodsReceipt->status)->toBe('draft');
+    expect($goodsReceipt->confirmed_at)->toBeNull();
+    expect($goodsReceipt->confirmed_by)->toBeNull();
+});
+
+test('confirming goods receipt swallows validation errors and keeps state confirmed', function () {
+    $goodsReceipt = GoodsReceipt::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostGoodsReceiptJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostGoodsReceiptJournalAction
+        {
+            public function execute(GoodsReceipt $goodsReceipt): ?JournalEntry
+            {
+                throw ValidationException::withMessages([
+                    'coa' => 'Missing COA mapping for journal posting',
+                ]);
+            }
+        };
+    });
+
+    putJson('/api/goods-receipts/' . $goodsReceipt->id, ['status' => 'confirmed'])
+        ->assertOk()
+        ->assertJsonPath('data.status', 'confirmed');
+
+    $goodsReceipt->refresh();
+    expect($goodsReceipt->status)->toBe('confirmed');
+    expect($goodsReceipt->confirmed_at)->not->toBeNull();
 });
 
 test('destroy removes goods receipt', function () {


### PR DESCRIPTION
## Summary

Wave 2 of Oracle audit Finding #4. Replays the `afterCommit` hook pattern from PR #25 (AP+AR) on `CustomerInvoiceController::update` and `GoodsReceiptController::update` so the state flip + journal posting commit/rollback atomically.

## Changes

### CustomerInvoiceController

`postJournal->execute()` moved into `afterCommit` callable. When `isNewlySent` is true, the call runs INSIDE the same `DB::transaction` as `updateWithSyncedItems`. If posting throws, `status` + `sent_at` + `sent_by` all roll back.

### GoodsReceiptController

Same pattern. The pre-existing `try/catch ValidationException` swallow semantic is **preserved verbatim INSIDE the hook**:
- `ValidationException` (e.g. missing COA mapping) → swallowed + logged. Goods receipt stays confirmed; user can post the journal later.
- Other exceptions (e.g. `RuntimeException`) → propagate and roll back the entire transaction (status flip included).

### Regression tests (3 new)

- CI rollback on `RuntimeException` from journal action
- GR rollback on `RuntimeException` (status returns to draft)
- GR keeps state confirmed when journal action throws `ValidationException` (verifies preserved swallow semantic)

All bind a fake action via container-extending pattern (with proper ctor injection) so the type-hinted dependencies on the controller method still resolve.

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `customer-invoices` — **9 passed**, 45 assertions (1 new regression)
  - `goods-receipts` — **24 passed**, 73 assertions (2 new regression)
  - `ar-journal-posting` — 13 passed (no regression)
  - `gr-sr-journal-posting` — 8 passed (no regression)

## Closes

Oracle audit Finding #4 — wave 2 (CustomerInvoice + GoodsReceipt).

Combined with PR #25 (AP+AR), Finding #4 is now closed for **4 of original 8 controllers**.

## Out of Scope

- 4 remaining controllers from Finding #4 (StockAdjustment, SupplierBill, SupplierReturn, plus any other with the same shape)
- Findings #6, #7, #8, #10 — polish, deferred.
- Schema-blocked items — deferred.