### PR TITLE
fix(stock-adjustments,supplier-bills,supplier-returns): close postJournal race via afterCommit hook (Finding #4 — wave 3)

### DIFF
--- a/app/Http/Controllers/StockAdjustmentController.php
+++ b/app/Http/Controllers/StockAdjustmentController.php
@@ -100,18 +100,23 @@ class StockAdjustmentController extends Controller
             syncItems: function (StockAdjustment $stockAdjustment, array $items) use ($syncItems): void {
                 $syncItems->execute($stockAdjustment, $items);
             },
+            afterCommit: $isNewlyApproved
+                ? function (StockAdjustment $stockAdjustment) use ($postJournal): void {
+                    try {
+                        $postJournal->execute($stockAdjustment->refresh());
+                    } catch (ValidationException $e) {
+                        // Validation failures (e.g. missing COA mapping) are intentionally
+                        // swallowed so the stock adjustment itself stays approved; user can
+                        // post the journal later. Non-validation errors propagate and
+                        // roll back the entire transaction (status flip included).
+                        Log::warning('Stock adjustment journal posting skipped', [
+                            'stock_adjustment_id' => $stockAdjustment->id,
+                            'reason' => $e->getMessage(),
+                        ]);
+                    }
+                }
+            : null,
         );
-
-        if ($isNewlyApproved) {
-            try {
-                $postJournal->execute($stockAdjustment->refresh());
-            } catch (ValidationException $e) {
-                Log::warning('Stock adjustment journal posting skipped', [
-                    'stock_adjustment_id' => $stockAdjustment->id,
-                    'reason' => $e->getMessage(),
-                ]);
-            }
-        }
 
         $stockAdjustment->load(['warehouse', 'inventoryStocktake', 'journalEntry', 'items.product', 'items.unit']);
 

--- a/app/Http/Controllers/SupplierBillController.php
+++ b/app/Http/Controllers/SupplierBillController.php
@@ -86,11 +86,12 @@ class SupplierBillController extends Controller
             syncItems: function (SupplierBill $supplierBill, array $items) use ($syncItems): void {
                 $syncItems->execute($supplierBill, $items);
             },
+            afterCommit: $isNewlyConfirmed
+                ? function (SupplierBill $supplierBill) use ($postJournal): void {
+                    $postJournal->execute($supplierBill->refresh());
+                }
+            : null,
         );
-
-        if ($isNewlyConfirmed) {
-            $postJournal->execute($supplierBill->refresh());
-        }
 
         return (new SupplierBillResource($this->loadResourceRelations($supplierBill)))->response();
     }

--- a/app/Http/Controllers/SupplierReturnController.php
+++ b/app/Http/Controllers/SupplierReturnController.php
@@ -106,18 +106,23 @@ class SupplierReturnController extends Controller
             syncItems: function (SupplierReturn $supplierReturn, array $items) use ($syncItems): void {
                 $syncItems->execute($supplierReturn, $items);
             },
+            afterCommit: $isNewlyConfirmed
+                ? function (SupplierReturn $supplierReturn) use ($postJournal): void {
+                    try {
+                        $postJournal->execute($supplierReturn->refresh());
+                    } catch (ValidationException $e) {
+                        // Validation failures (e.g. missing COA mapping) are intentionally
+                        // swallowed so the supplier return itself stays confirmed; user can
+                        // post the journal later. Non-validation errors propagate and
+                        // roll back the entire transaction (status flip included).
+                        Log::warning('Supplier return journal posting skipped', [
+                            'supplier_return_id' => $supplierReturn->id,
+                            'reason' => $e->getMessage(),
+                        ]);
+                    }
+                }
+            : null,
         );
-
-        if ($isNewlyConfirmed) {
-            try {
-                $postJournal->execute($supplierReturn->refresh());
-            } catch (ValidationException $e) {
-                Log::warning('Supplier return journal posting skipped', [
-                    'supplier_return_id' => $supplierReturn->id,
-                    'reason' => $e->getMessage(),
-                ]);
-            }
-        }
 
         $supplierReturn->load([
             'purchaseOrder',

--- a/tests/Feature/StockAdjustments/StockAdjustmentControllerTest.php
+++ b/tests/Feature/StockAdjustments/StockAdjustmentControllerTest.php
@@ -1,11 +1,16 @@
 <?php
 
+use App\Actions\AccountingPosting\PostStockAdjustmentJournalAction;
+use App\Actions\AccountingPosting\ResolveControlAccountAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\JournalEntry;
 use App\Models\Product;
 use App\Models\StockAdjustment;
 use App\Models\StockAdjustmentItem;
 use App\Models\Unit;
 use App\Models\Warehouse;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
@@ -334,5 +339,59 @@ describe('Stock Adjustment API Endpoints', function () {
         postJson("/api/stock-adjustments/{$adjustment->id}/items", ['items' => []])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['items']);
+    });
+
+    test('approving stock adjustment rolls back state when journal posting fails with non-validation error', function () {
+        $adjustment = StockAdjustment::factory()->create([
+            'status' => 'draft',
+            'approved_at' => null,
+            'approved_by' => null,
+        ]);
+
+        $this->app->bind(PostStockAdjustmentJournalAction::class, function ($app) {
+            return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostStockAdjustmentJournalAction
+            {
+                public function execute(StockAdjustment $stockAdjustment): ?JournalEntry
+                {
+                    throw new RuntimeException('Simulated journal posting failure');
+                }
+            };
+        });
+
+        putJson('/api/stock-adjustments/' . $adjustment->id, ['status' => 'approved'])
+            ->assertStatus(500);
+
+        $adjustment->refresh();
+        expect($adjustment->status)->toBe('draft');
+        expect($adjustment->approved_at)->toBeNull();
+        expect($adjustment->approved_by)->toBeNull();
+    });
+
+    test('approving stock adjustment swallows validation errors and keeps state approved', function () {
+        $adjustment = StockAdjustment::factory()->create([
+            'status' => 'draft',
+            'approved_at' => null,
+            'approved_by' => null,
+        ]);
+
+        $this->app->bind(PostStockAdjustmentJournalAction::class, function ($app) {
+            return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostStockAdjustmentJournalAction
+            {
+                public function execute(StockAdjustment $stockAdjustment): ?JournalEntry
+                {
+                    throw ValidationException::withMessages([
+                        'coa' => 'Missing COA mapping for journal posting',
+                    ]);
+                }
+            };
+        });
+
+        putJson('/api/stock-adjustments/' . $adjustment->id, ['status' => 'approved'])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'approved');
+
+        $adjustment->refresh();
+        expect($adjustment->status)->toBe('approved');
+        expect($adjustment->approved_at)->not->toBeNull();
     });
 });

--- a/tests/Feature/SupplierBills/SupplierBillControllerTest.php
+++ b/tests/Feature/SupplierBills/SupplierBillControllerTest.php
@@ -1,9 +1,13 @@
 <?php
 
+use App\Actions\AccountingPosting\PostSupplierBillJournalAction;
+use App\Actions\AccountingPosting\ResolveControlAccountAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
 use App\Models\Account;
 use App\Models\Branch;
 use App\Models\CoaVersion;
 use App\Models\FiscalYear;
+use App\Models\JournalEntry;
 use App\Models\Product;
 use App\Models\Supplier;
 use App\Models\SupplierBill;
@@ -234,4 +238,30 @@ test('store rejects unsupported currency', function () {
     postJson('/api/supplier-bills', $payload)
         ->assertUnprocessable()
         ->assertJsonValidationErrors(['currency']);
+});
+
+test('confirming supplier bill rolls back state when journal posting fails', function () {
+    $supplierBill = SupplierBill::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostSupplierBillJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostSupplierBillJournalAction
+        {
+            public function execute(SupplierBill $supplierBill): ?JournalEntry
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    putJson('/api/supplier-bills/' . $supplierBill->id, ['status' => 'confirmed'])
+        ->assertStatus(500);
+
+    $supplierBill->refresh();
+    expect($supplierBill->status)->toBe('draft');
+    expect($supplierBill->confirmed_at)->toBeNull();
+    expect($supplierBill->confirmed_by)->toBeNull();
 });

--- a/tests/Feature/SupplierReturns/SupplierReturnControllerTest.php
+++ b/tests/Feature/SupplierReturns/SupplierReturnControllerTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use App\Actions\AccountingPosting\PostSupplierReturnJournalAction;
+use App\Actions\AccountingPosting\ResolveControlAccountAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
 use App\Models\GoodsReceipt;
+use App\Models\JournalEntry;
 use App\Models\Product;
 use App\Models\PurchaseOrder;
 use App\Models\Supplier;
@@ -8,6 +12,7 @@ use App\Models\SupplierReturn;
 use App\Models\Unit;
 use App\Models\Warehouse;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\Sanctum;
 
 use function Pest\Laravel\assertDatabaseHas;
@@ -212,6 +217,60 @@ test('update modifies supplier return and items', function () {
         ->assertOk()
         ->assertJsonPath('data.status', 'confirmed')
         ->assertJsonCount(1, 'data.items');
+});
+
+test('confirming supplier return rolls back state when journal posting fails with non-validation error', function () {
+    $supplierReturn = SupplierReturn::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostSupplierReturnJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostSupplierReturnJournalAction
+        {
+            public function execute(SupplierReturn $supplierReturn): ?JournalEntry
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    putJson('/api/supplier-returns/' . $supplierReturn->id, ['status' => 'confirmed'])
+        ->assertStatus(500);
+
+    $supplierReturn->refresh();
+    expect($supplierReturn->status)->toBe('draft');
+    expect($supplierReturn->confirmed_at)->toBeNull();
+    expect($supplierReturn->confirmed_by)->toBeNull();
+});
+
+test('confirming supplier return swallows validation errors and keeps state confirmed', function () {
+    $supplierReturn = SupplierReturn::factory()->create([
+        'status' => 'draft',
+        'confirmed_at' => null,
+        'confirmed_by' => null,
+    ]);
+
+    $this->app->bind(PostSupplierReturnJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class), $app->make(ResolveControlAccountAction::class)) extends PostSupplierReturnJournalAction
+        {
+            public function execute(SupplierReturn $supplierReturn): ?JournalEntry
+            {
+                throw ValidationException::withMessages([
+                    'coa' => 'Missing COA mapping for journal posting',
+                ]);
+            }
+        };
+    });
+
+    putJson('/api/supplier-returns/' . $supplierReturn->id, ['status' => 'confirmed'])
+        ->assertOk()
+        ->assertJsonPath('data.status', 'confirmed');
+
+    $supplierReturn->refresh();
+    expect($supplierReturn->status)->toBe('confirmed');
+    expect($supplierReturn->confirmed_at)->not->toBeNull();
 });
 
 test('destroy removes supplier return', function () {


### PR DESCRIPTION
## Summary

Wave 3 of Oracle audit Finding #4. Replays the `afterCommit` hook pattern from PR #25 (AP+AR) and PR #26 (CI+GR) on the remaining 3 controllers identified by Oracle: StockAdjustment, SupplierBill, SupplierReturn.

After this PR, **Finding #4 is closed for 7 of 8 controllers** that Oracle originally flagged. Any other controller with the same shape can be swept in a follow-up if discovered.

## Changes

### StockAdjustmentController

`postJournal->execute()` moved into `afterCommit` callable (when `isNewlyApproved`). Pre-existing ValidationException swallow semantic preserved INSIDE the hook (validation errors keep state `approved`; non-validation errors propagate + rollback).

### SupplierBillController

Same pattern as AP/AR — simple shape, no swallow. Hook runs when `isNewlyConfirmed`.

### SupplierReturnController

Same as StockAdjustment — preserves ValidationException swallow semantic INSIDE the hook.

### Regression tests (5 new)

- SA rollback on `RuntimeException` (status returns to draft)
- SA keeps state `approved` when posting throws `ValidationException`
- SB rollback on `RuntimeException` (status returns to draft)
- SR rollback on `RuntimeException` (status returns to draft)
- SR keeps state `confirmed` when posting throws `ValidationException`

All bind a fake action via container-extending pattern (with proper ctor injection) so type-hinted dependencies on the controller method still resolve. Pattern matches PR #26.

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `stock-adjustments` — **42 passed**, 228 assertions (2 new regression)
  - `supplier-bills` — **10 passed**, 49 assertions (1 new regression)
  - `supplier-returns` — **21 passed**, 67 assertions (2 new regression)
  - `ap-journal-posting` — 13 passed (no regression)
  - `gr-sr-journal-posting` — 8 passed (no regression)
  - `stock-adjustment-journal-posting` — 7 passed (no regression)

## Closes

Oracle audit Finding #4 — wave 3 (StockAdjustment + SupplierBill + SupplierReturn).

Combined with PR #25 (AP+AR) and PR #26 (CI+GR), Finding #4 is now **closed for 7 of 8 controllers**.

## Out of Scope

- Any further controller with same shape (sweep follow-up if discovered)
- Findings #6, #7, #8, #10 — polish, deferred.
- Schema-blocked items — deferred.