### PR TITLE
fix(bank-reconciliations): close postJournal race on complete via DB::transaction (Finding #4 sweep)

### DIFF
--- a/app/Actions/BankReconciliations/CompleteBankReconciliationAction.php
+++ b/app/Actions/BankReconciliations/CompleteBankReconciliationAction.php
@@ -4,6 +4,7 @@ namespace App\Actions\BankReconciliations;
 
 use App\Actions\AccountingPosting\PostBankReconciliationJournalAction;
 use App\Models\BankReconciliation;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 use Throwable;
@@ -20,20 +21,27 @@ class CompleteBankReconciliationAction
             throw ValidationException::withMessages(['difference' => 'Bank reconciliation difference must be zero.']);
         }
 
-        $bankReconciliation->update([
-            'status' => 'completed',
-            'completed_by' => auth()->id(),
-            'completed_at' => now(),
-        ]);
-
-        try {
-            $this->postJournal->execute($bankReconciliation->refresh());
-        } catch (Throwable $e) {
-            Log::warning('Bank reconciliation journal posting failed', [
-                'bank_reconciliation_id' => $bankReconciliation->id,
-                'error' => $e->getMessage(),
+        DB::transaction(function () use ($bankReconciliation): void {
+            $bankReconciliation->update([
+                'status' => 'completed',
+                'completed_by' => auth()->id(),
+                'completed_at' => now(),
             ]);
-        }
+
+            try {
+                $this->postJournal->execute($bankReconciliation->refresh());
+            } catch (Throwable $e) {
+                // Best-effort posting: journal failures are intentionally swallowed
+                // so the reconciliation itself stays completed. Wrapping in a
+                // transaction still closes the race where the process dies between
+                // the status update commit and the journal posting call — in that
+                // window the update would roll back atomically.
+                Log::warning('Bank reconciliation journal posting failed', [
+                    'bank_reconciliation_id' => $bankReconciliation->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        });
 
         return $bankReconciliation->refresh()->load([
             'account',

--- a/tests/Feature/BankReconciliations/BankReconciliationControllerTest.php
+++ b/tests/Feature/BankReconciliations/BankReconciliationControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Actions\AccountingPosting\PostBankReconciliationJournalAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
 use App\Models\Account;
 use App\Models\BankReconciliation;
 use App\Models\BankReconciliationItem;
@@ -109,6 +111,33 @@ test('it cannot complete when difference is not zero', function () {
     postJson("/api/bank-reconciliations/{$reconciliation->id}/complete")
         ->assertUnprocessable()
         ->assertJsonValidationErrors('difference');
+});
+
+test('completing a bank reconciliation keeps state completed when journal posting fails (best-effort)', function () {
+    $reconciliation = BankReconciliation::factory()->create([
+        'difference' => 0,
+        'status' => 'in_progress',
+        'completed_at' => null,
+        'completed_by' => null,
+    ]);
+
+    $this->app->bind(PostBankReconciliationJournalAction::class, function ($app) {
+        return new class($app->make(CreateJournalEntryAction::class)) extends PostBankReconciliationJournalAction
+        {
+            public function execute(BankReconciliation $bankReconciliation): ?JournalEntry
+            {
+                throw new RuntimeException('Simulated journal posting failure');
+            }
+        };
+    });
+
+    postJson("/api/bank-reconciliations/{$reconciliation->id}/complete")
+        ->assertOk()
+        ->assertJsonPath('data.status', 'completed');
+
+    $reconciliation->refresh();
+    expect($reconciliation->status)->toBe('completed');
+    expect($reconciliation->completed_at)->not->toBeNull();
 });
 
 test('it can add an item to a bank reconciliation', function () {


### PR DESCRIPTION
## Summary

Sweep follow-up for Oracle audit Finding #4. After wave 3 (PR #27), a sweep of the codebase for any remaining `postJournal->execute()` calls outside a transaction surfaced **`CompleteBankReconciliationAction`** as the last unclosed instance.

This PR wraps the status mutation + journal posting in `DB::transaction`, preserving the existing best-effort `Throwable` swallow semantic (journal failures don't fail the completion — by design).

## Why this matters

The previous shape was:

```php
$bankReconciliation->update([..., 'status' => 'completed']);  // commit #1
try {
    $this->postJournal->execute($bankReconciliation->refresh());  // commit #2
} catch (Throwable $e) {
    Log::warning(...);
}
```

Two independent commits → if the process died between them, the reconciliation status would be `completed` with no journal entry (orphan state).

With the wrap, status flip is held in-flight until the journal posting attempt completes (or throws + is swallowed). Process death now rolls back the status update atomically.

The best-effort semantic is unchanged: if the journal posting throws `ValidationException` or any other `Throwable` during normal execution, it's still logged and swallowed; the reconciliation still ends up `completed`.

## Changes

- `app/Actions/BankReconciliations/CompleteBankReconciliationAction.php` — wrap update + journal post + swallow inside `DB::transaction`. Add inline comment explaining the best-effort semantic and the race-closing rationale (necessary maintainer guidance — without it future readers may "fix" by moving the post call back out or removing the swallow).
- `tests/Feature/BankReconciliations/BankReconciliationControllerTest.php` — 1 new regression test that binds a failing `PostBankReconciliationJournalAction` and asserts the reconciliation still ends up `completed` (best-effort preserved).

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `bank-reconciliations` — **51 passed**, 156 assertions (1 new regression, was 50 before)

## Closes

Oracle audit Finding #4 — **fully closed**. Combined with PRs #19, #22, #25, #26, #27, all 8 originally-flagged controllers + the 1 sweep-discovered action are now race-free.

## Out of Scope

- Findings #6 (CurrencyGuard coverage), #7 (ApAgingReport trait dedupe), #8 (ApprovalFlow step-create dedupe), #10 (MyApproval thin) — polish, deferred.
- Schema-blocked items (financial dashboard branch scoping, polymorphic dashboard, H3 Wave 2) — deferred.