### PR TITLE
refactor(aging-reports,approval-flows): polish dedupe per Oracle Findings #7 + #8

### DIFF
--- a/app/Actions/Reports/Concerns/AgingReportBoundaries.php
+++ b/app/Actions/Reports/Concerns/AgingReportBoundaries.php
@@ -35,16 +35,35 @@ trait AgingReportBoundaries
     }
 
     /**
-     * Aliases: aging_current, aging_1_30, aging_31_60, aging_61_90, aging_over_90.
+     * Default AR-style aliases: aging_current, aging_1_30, aging_31_60, aging_61_90, aging_over_90.
      * Pair with {@see agingBucketBindings()} when calling selectRaw().
      */
     protected function agingBucketSelectSql(string $tableAlias): string
     {
-        return "CASE WHEN {$tableAlias}.due_date >= ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_current,
-        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_1_30,
-        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_31_60,
-        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_61_90,
-        CASE WHEN {$tableAlias}.due_date < ? THEN {$tableAlias}.amount_due ELSE 0 END as aging_over_90";
+        return $this->agingBucketSelectSqlWithAliases($tableAlias, [
+            'current' => 'aging_current',
+            '1_30' => 'aging_1_30',
+            '31_60' => 'aging_31_60',
+            '61_90' => 'aging_61_90',
+            'over_90' => 'aging_over_90',
+        ]);
+    }
+
+    /**
+     * Renders the aging bucket CASE expressions with caller-provided column aliases
+     * so consumers that need a different output shape (e.g. AP uses
+     * `current_amount`, `days_1_30`, etc.) can share the same SQL logic without
+     * forcing an API contract change. Pair with {@see agingBucketBindings()}.
+     *
+     * @param  array{current: string, '1_30': string, '31_60': string, '61_90': string, over_90: string}  $aliases
+     */
+    protected function agingBucketSelectSqlWithAliases(string $tableAlias, array $aliases): string
+    {
+        return "CASE WHEN {$tableAlias}.due_date >= ? THEN {$tableAlias}.amount_due ELSE 0 END as {$aliases['current']},
+        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as {$aliases['1_30']},
+        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as {$aliases['31_60']},
+        CASE WHEN {$tableAlias}.due_date BETWEEN ? AND ? THEN {$tableAlias}.amount_due ELSE 0 END as {$aliases['61_90']},
+        CASE WHEN {$tableAlias}.due_date < ? THEN {$tableAlias}.amount_due ELSE 0 END as {$aliases['over_90']}";
     }
 
     /**

--- a/app/Actions/Reports/IndexApAgingReportAction.php
+++ b/app/Actions/Reports/IndexApAgingReportAction.php
@@ -19,11 +19,13 @@ class IndexApAgingReportAction
 
         $query = $this->buildBaseSupplierBillQuery(
             extraSelectColumns: [
-                'CASE WHEN sb.due_date >= ? THEN sb.amount_due ELSE 0 END as current_amount',
-                'CASE WHEN sb.due_date BETWEEN ? AND ? THEN sb.amount_due ELSE 0 END as days_1_30',
-                'CASE WHEN sb.due_date BETWEEN ? AND ? THEN sb.amount_due ELSE 0 END as days_31_60',
-                'CASE WHEN sb.due_date BETWEEN ? AND ? THEN sb.amount_due ELSE 0 END as days_61_90',
-                'CASE WHEN sb.due_date < ? THEN sb.amount_due ELSE 0 END as days_over_90',
+                $this->agingBucketSelectSqlWithAliases('sb', [
+                    'current' => 'current_amount',
+                    '1_30' => 'days_1_30',
+                    '31_60' => 'days_31_60',
+                    '61_90' => 'days_61_90',
+                    'over_90' => 'days_over_90',
+                ]),
             ],
             extraCasts: [
                 'current_amount' => 'decimal:2',
@@ -32,13 +34,7 @@ class IndexApAgingReportAction
                 'days_61_90' => 'decimal:2',
                 'days_over_90' => 'decimal:2',
             ],
-            extraSelectBindings: [
-                $boundaries['today'],
-                $boundaries['d30'], $boundaries['d1'],
-                $boundaries['d60'], $boundaries['d31'],
-                $boundaries['d90'], $boundaries['d61'],
-                $boundaries['d90'],
-            ],
+            extraSelectBindings: $this->agingBucketBindings($boundaries),
         );
 
         $this->applySupplierBillFilters($request, $query);

--- a/app/Http/Controllers/ApprovalFlowController.php
+++ b/app/Http/Controllers/ApprovalFlowController.php
@@ -39,19 +39,7 @@ class ApprovalFlowController extends Controller
 
             if (! empty($validated['steps'])) {
                 foreach ($validated['steps'] as $index => $stepData) {
-                    $flow->steps()->create([
-                        'step_order' => $index + 1,
-                        'name' => $stepData['name'],
-                        'approver_type' => $stepData['approver_type'],
-                        'approver_user_id' => $stepData['approver_user_id'] ?? null,
-                        'approver_role_id' => $stepData['approver_role_id'] ?? null,
-                        'approver_department_id' => $stepData['approver_department_id'] ?? null,
-                        'required_action' => $stepData['required_action'],
-                        'auto_approve_after_hours' => $stepData['auto_approve_after_hours'] ?? null,
-                        'escalate_after_hours' => $stepData['escalate_after_hours'] ?? null,
-                        'escalation_user_id' => $stepData['escalation_user_id'] ?? null,
-                        'can_reject' => $stepData['can_reject'] ?? true,
-                    ]);
+                    $this->createStep($flow, $index, $stepData);
                 }
             }
 
@@ -78,19 +66,7 @@ class ApprovalFlowController extends Controller
                 $approvalFlow->steps()->delete();
 
                 foreach ($validated['steps'] as $index => $stepData) {
-                    $approvalFlow->steps()->create([
-                        'step_order' => $index + 1,
-                        'name' => $stepData['name'],
-                        'approver_type' => $stepData['approver_type'],
-                        'approver_user_id' => $stepData['approver_user_id'] ?? null,
-                        'approver_role_id' => $stepData['approver_role_id'] ?? null,
-                        'approver_department_id' => $stepData['approver_department_id'] ?? null,
-                        'required_action' => $stepData['required_action'],
-                        'auto_approve_after_hours' => $stepData['auto_approve_after_hours'] ?? null,
-                        'escalate_after_hours' => $stepData['escalate_after_hours'] ?? null,
-                        'escalation_user_id' => $stepData['escalation_user_id'] ?? null,
-                        'can_reject' => $stepData['can_reject'] ?? true,
-                    ]);
+                    $this->createStep($approvalFlow, $index, $stepData);
                 }
             }
 
@@ -108,5 +84,25 @@ class ApprovalFlowController extends Controller
     public function export(ExportApprovalFlowRequest $request, ExportApprovalFlowsAction $action): JsonResponse
     {
         return $action->execute($request);
+    }
+
+    /**
+     * @param  array<string, mixed>  $stepData
+     */
+    private function createStep(ApprovalFlow $flow, int $index, array $stepData): void
+    {
+        $flow->steps()->create([
+            'step_order' => $index + 1,
+            'name' => $stepData['name'],
+            'approver_type' => $stepData['approver_type'],
+            'approver_user_id' => $stepData['approver_user_id'] ?? null,
+            'approver_role_id' => $stepData['approver_role_id'] ?? null,
+            'approver_department_id' => $stepData['approver_department_id'] ?? null,
+            'required_action' => $stepData['required_action'],
+            'auto_approve_after_hours' => $stepData['auto_approve_after_hours'] ?? null,
+            'escalate_after_hours' => $stepData['escalate_after_hours'] ?? null,
+            'escalation_user_id' => $stepData['escalation_user_id'] ?? null,
+            'can_reject' => $stepData['can_reject'] ?? true,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

Polish wave combining Oracle audit Finding #7 (LOW) and Finding #8 (LOW) into a single PR — both are low-risk dedupe refactors with zero API contract change.

## Finding #7 — IndexApAgingReportAction trait dedupe

The aging report family already shares a trait (`AgingReportBoundaries`), but `IndexApAgingReportAction` was reinlining its CASE expressions because AP uses different output column aliases (`current_amount`, `days_1_30`, ...) than AR (`aging_current`, `aging_1_30`, ...). The aliases are part of the public API surface (consumed by `ApAgingReportResource`, `ApAgingReportExport`, `ApAgingReportTest`, the React `Columns.tsx`, and the `AbstractApAgingReportRequest` validator), so they cannot be unified.

**Solution**: extend the trait with `agingBucketSelectSqlWithAliases(string, array)` that accepts caller-provided aliases. Existing `agingBucketSelectSql()` becomes a thin wrapper that calls it with the AR defaults. AP now calls the parameterized variant. Result: single source of truth for the bucket SQL + bindings, zero API change, ~13 lines saved.

## Finding #8 — ApprovalFlowController step-create dedupe

`store()` and `update()` both inlined a ~14-line `->steps()->create([...])` payload. Extracted to a private `createStep(ApprovalFlow, int, array)` method. Saves ~14 lines of duplication.

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `ap-aging-report` — 5 passed (existing coverage exercises the bucket SQL + response shape)
  - `ar-aging-report` — 5 passed (verifies the wrapper still produces the original alias output)
  - `approval-flows` — 46 passed, 240 assertions

## Closes

Oracle audit Findings #7 (LOW), #8 (LOW).

## Out of Scope

- Findings #6 (CurrencyGuard coverage), #10 (MyApproval thin) — deferred.
- Schema-blocked items — deferred.