### PR TITLE
refactor(my-approvals): thin controller via action extract (Oracle Finding #10)

### DIFF
--- a/app/Actions/Approvals/ApproveApprovalRequestAction.php
+++ b/app/Actions/Approvals/ApproveApprovalRequestAction.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Actions\Approvals;
+
+use App\Models\ApprovalAuditLog;
+use App\Models\ApprovalRequest;
+use App\Models\ApprovalRequestStep;
+use Illuminate\Support\Facades\DB;
+
+class ApproveApprovalRequestAction
+{
+    public function execute(
+        ApprovalRequest $approvalRequest,
+        ApprovalRequestStep $currentStep,
+        int $userId,
+        ?string $comments,
+    ): void {
+        DB::transaction(function () use ($approvalRequest, $currentStep, $userId, $comments): void {
+            $currentStep->update([
+                'status' => 'approved',
+                'acted_by' => $userId,
+                'action' => 'approve',
+                'comments' => $comments,
+                'acted_at' => now(),
+            ]);
+
+            ApprovalAuditLog::create([
+                'approval_request_id' => $approvalRequest->id,
+                'approvable_type' => $approvalRequest->approvable_type,
+                'approvable_id' => $approvalRequest->approvable_id,
+                'event' => 'step_approved',
+                'actor_user_id' => $userId,
+                'step_order' => $currentStep->step_order,
+                'metadata' => json_encode(['comments' => $comments]),
+            ]);
+
+            /** @var ApprovalRequestStep|null $nextStep */
+            $nextStep = $approvalRequest->steps()
+                ->where('step_order', '>', $currentStep->step_order)
+                ->orderBy('step_order', 'asc')
+                ->first();
+
+            if ($nextStep instanceof ApprovalRequestStep) {
+                $approvalRequest->update([
+                    'current_step_order' => $nextStep->step_order,
+                    'status' => 'in_progress',
+                ]);
+
+                return;
+            }
+
+            $approvalRequest->update([
+                'status' => 'approved',
+                'completed_at' => now(),
+            ]);
+
+            ApprovalAuditLog::create([
+                'approval_request_id' => $approvalRequest->id,
+                'approvable_type' => $approvalRequest->approvable_type,
+                'approvable_id' => $approvalRequest->approvable_id,
+                'event' => 'completed',
+                'actor_user_id' => $userId,
+                'metadata' => json_encode([]),
+            ]);
+        });
+    }
+}

--- a/app/Actions/Approvals/RejectApprovalRequestAction.php
+++ b/app/Actions/Approvals/RejectApprovalRequestAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Actions\Approvals;
+
+use App\Models\ApprovalAuditLog;
+use App\Models\ApprovalRequest;
+use App\Models\ApprovalRequestStep;
+use Illuminate\Support\Facades\DB;
+
+class RejectApprovalRequestAction
+{
+    public function execute(
+        ApprovalRequest $approvalRequest,
+        ApprovalRequestStep $currentStep,
+        int $userId,
+        string $comments,
+    ): void {
+        DB::transaction(function () use ($approvalRequest, $currentStep, $userId, $comments): void {
+            $currentStep->update([
+                'status' => 'rejected',
+                'acted_by' => $userId,
+                'action' => 'reject',
+                'comments' => $comments,
+                'acted_at' => now(),
+            ]);
+
+            $approvalRequest->update([
+                'status' => 'rejected',
+                'completed_at' => now(),
+            ]);
+
+            ApprovalAuditLog::create([
+                'approval_request_id' => $approvalRequest->id,
+                'approvable_type' => $approvalRequest->approvable_type,
+                'approvable_id' => $approvalRequest->approvable_id,
+                'event' => 'step_rejected',
+                'actor_user_id' => $userId,
+                'step_order' => $currentStep->step_order,
+                'metadata' => json_encode(['comments' => $comments]),
+            ]);
+        });
+    }
+}

--- a/app/Http/Controllers/MyApprovalController.php
+++ b/app/Http/Controllers/MyApprovalController.php
@@ -2,16 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\ApprovalAuditLog;
+use App\Actions\Approvals\ApproveApprovalRequestAction;
+use App\Actions\Approvals\RejectApprovalRequestAction;
+use App\Http\Requests\MyApprovals\ApproveMyApprovalRequest;
+use App\Http\Requests\MyApprovals\RejectMyApprovalRequest;
 use App\Models\ApprovalRequest;
 use App\Models\ApprovalRequestStep;
-use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 
 class MyApprovalController extends Controller
 {
-    public function index()
+    public function index(): JsonResponse
     {
         $userId = Auth::id();
 
@@ -52,96 +54,36 @@ class MyApprovalController extends Controller
         ]);
     }
 
-    public function approve(Request $request, ApprovalRequest $approvalRequest)
-    {
-        $request->validate(['comments' => 'nullable|string']);
-
+    public function approve(
+        ApproveMyApprovalRequest $request,
+        ApprovalRequest $approvalRequest,
+        ApproveApprovalRequestAction $action,
+    ): JsonResponse {
         $userId = Auth::id();
-
         $currentStep = $this->findCurrentPendingAssignedStep($approvalRequest, $userId);
 
         if (! $currentStep instanceof ApprovalRequestStep) {
             abort(403, 'You are not authorized to act on this approval step.');
         }
 
-        DB::transaction(function () use ($approvalRequest, $userId, $request, $currentStep) {
-            $currentStep->update([
-                'status' => 'approved',
-                'acted_by' => $userId,
-                'action' => 'approve',
-                'comments' => $request->comments,
-                'acted_at' => now(),
-            ]);
-
-            ApprovalAuditLog::create([
-                'approval_request_id' => $approvalRequest->id,
-                'approvable_type' => $approvalRequest->approvable_type,
-                'approvable_id' => $approvalRequest->approvable_id,
-                'event' => 'step_approved',
-                'actor_user_id' => $userId,
-                'step_order' => $currentStep->step_order,
-                'metadata' => json_encode(['comments' => $request->comments]),
-            ]);
-
-            // Check if there are more steps
-            /** @var ApprovalRequestStep|null $nextStep */
-            $nextStep = $approvalRequest->steps()
-                ->where('step_order', '>', $currentStep->step_order)
-                ->orderBy('step_order', 'asc')
-                ->first();
-
-            if ($nextStep) {
-                $approvalRequest->update(['current_step_order' => $nextStep->step_order, 'status' => 'in_progress']);
-            } else {
-                $approvalRequest->update(['status' => 'approved', 'completed_at' => now()]);
-
-                ApprovalAuditLog::create([
-                    'approval_request_id' => $approvalRequest->id,
-                    'approvable_type' => $approvalRequest->approvable_type,
-                    'approvable_id' => $approvalRequest->approvable_id,
-                    'event' => 'completed',
-                    'actor_user_id' => $userId,
-                    'metadata' => json_encode([]),
-                ]);
-            }
-        });
+        $action->execute($approvalRequest, $currentStep, $userId, $request->validated('comments'));
 
         return response()->json(['message' => 'Request approved successfully.']);
     }
 
-    public function reject(Request $request, ApprovalRequest $approvalRequest)
-    {
-        $request->validate(['comments' => 'required|string']);
-
+    public function reject(
+        RejectMyApprovalRequest $request,
+        ApprovalRequest $approvalRequest,
+        RejectApprovalRequestAction $action,
+    ): JsonResponse {
         $userId = Auth::id();
-
         $currentStep = $this->findCurrentPendingAssignedStep($approvalRequest, $userId);
 
         if (! $currentStep instanceof ApprovalRequestStep) {
             abort(403, 'You are not authorized to act on this approval step.');
         }
 
-        DB::transaction(function () use ($approvalRequest, $userId, $request, $currentStep) {
-            $currentStep->update([
-                'status' => 'rejected',
-                'acted_by' => $userId,
-                'action' => 'reject',
-                'comments' => $request->comments,
-                'acted_at' => now(),
-            ]);
-
-            $approvalRequest->update(['status' => 'rejected', 'completed_at' => now()]);
-
-            ApprovalAuditLog::create([
-                'approval_request_id' => $approvalRequest->id,
-                'approvable_type' => $approvalRequest->approvable_type,
-                'approvable_id' => $approvalRequest->approvable_id,
-                'event' => 'step_rejected',
-                'actor_user_id' => $userId,
-                'step_order' => $currentStep->step_order,
-                'metadata' => json_encode(['comments' => $request->comments]),
-            ]);
-        });
+        $action->execute($approvalRequest, $currentStep, $userId, $request->validated('comments'));
 
         return response()->json(['message' => 'Request rejected.']);
     }

--- a/app/Http/Requests/MyApprovals/ApproveMyApprovalRequest.php
+++ b/app/Http/Requests/MyApprovals/ApproveMyApprovalRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\MyApprovals;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveMyApprovalRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'comments' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/MyApprovals/RejectMyApprovalRequest.php
+++ b/app/Http/Requests/MyApprovals/RejectMyApprovalRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\MyApprovals;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectMyApprovalRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'comments' => ['required', 'string'],
+        ];
+    }
+}

--- a/tests/Unit/Actions/Approvals/ApproveApprovalRequestActionTest.php
+++ b/tests/Unit/Actions/Approvals/ApproveApprovalRequestActionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Actions\Approvals\ApproveApprovalRequestAction;
+use App\Models\ApprovalAuditLog;
+use App\Models\ApprovalFlow;
+use App\Models\ApprovalFlowStep;
+use App\Models\ApprovalRequest;
+use App\Models\ApprovalRequestStep;
+use App\Models\PurchaseRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('my-approvals');
+
+beforeEach(function () {
+    $this->action = new ApproveApprovalRequestAction;
+    $this->actor = User::factory()->create();
+    $this->entity = PurchaseRequest::factory()->create();
+});
+
+function makeApprovalRequestWithSteps(int $stepCount, User $actor, PurchaseRequest $entity): ApprovalRequest
+{
+    /** @var ApprovalFlow $flow */
+    $flow = ApprovalFlow::factory()->create(['approvable_type' => PurchaseRequest::class]);
+
+    /** @var ApprovalRequest $request */
+    $request = ApprovalRequest::create([
+        'approval_flow_id' => $flow->id,
+        'approvable_type' => PurchaseRequest::class,
+        'approvable_id' => $entity->id,
+        'submitted_by' => $actor->id,
+        'status' => 'in_progress',
+        'current_step_order' => 1,
+    ]);
+
+    for ($i = 1; $i <= $stepCount; $i++) {
+        $flowStep = ApprovalFlowStep::factory()->create([
+            'approval_flow_id' => $flow->id,
+            'step_order' => $i,
+            'approver_type' => 'user',
+            'approver_user_id' => $actor->id,
+        ]);
+
+        ApprovalRequestStep::create([
+            'approval_request_id' => $request->id,
+            'approval_flow_step_id' => $flowStep->id,
+            'step_order' => $i,
+            'status' => 'pending',
+        ]);
+    }
+
+    return $request;
+}
+
+test('approving a single-step request marks the request approved and logs completion', function () {
+    $request = makeApprovalRequestWithSteps(1, $this->actor, $this->entity);
+    $step = $request->steps()->where('step_order', 1)->firstOrFail();
+
+    $this->action->execute($request, $step, $this->actor->id, 'looks good');
+
+    $request->refresh();
+    $step->refresh();
+
+    expect($step->status)->toBe('approved');
+    expect($step->action)->toBe('approve');
+    expect($step->acted_by)->toBe($this->actor->id);
+    expect($step->comments)->toBe('looks good');
+    expect($request->status)->toBe('approved');
+    expect($request->completed_at)->not->toBeNull();
+
+    expect(ApprovalAuditLog::where('approval_request_id', $request->id)->where('event', 'step_approved')->count())->toBe(1);
+    expect(ApprovalAuditLog::where('approval_request_id', $request->id)->where('event', 'completed')->count())->toBe(1);
+});
+
+test('approving a non-final step advances current_step_order and keeps request in_progress', function () {
+    $request = makeApprovalRequestWithSteps(2, $this->actor, $this->entity);
+    $step1 = $request->steps()->where('step_order', 1)->firstOrFail();
+
+    $this->action->execute($request, $step1, $this->actor->id, null);
+
+    $request->refresh();
+
+    expect($request->status)->toBe('in_progress');
+    expect($request->current_step_order)->toBe(2);
+    expect($request->completed_at)->toBeNull();
+
+    expect(ApprovalAuditLog::where('approval_request_id', $request->id)->where('event', 'completed')->count())->toBe(0);
+});
+
+test('approve persists null comments cleanly', function () {
+    $request = makeApprovalRequestWithSteps(1, $this->actor, $this->entity);
+    $step = $request->steps()->where('step_order', 1)->firstOrFail();
+
+    $this->action->execute($request, $step, $this->actor->id, null);
+
+    $step->refresh();
+    expect($step->comments)->toBeNull();
+});

--- a/tests/Unit/Actions/Approvals/RejectApprovalRequestActionTest.php
+++ b/tests/Unit/Actions/Approvals/RejectApprovalRequestActionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Actions\Approvals\RejectApprovalRequestAction;
+use App\Models\ApprovalAuditLog;
+use App\Models\ApprovalFlow;
+use App\Models\ApprovalFlowStep;
+use App\Models\ApprovalRequest;
+use App\Models\ApprovalRequestStep;
+use App\Models\PurchaseRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class)->group('my-approvals');
+
+beforeEach(function () {
+    $this->action = new RejectApprovalRequestAction;
+    $this->actor = User::factory()->create();
+    $this->entity = PurchaseRequest::factory()->create();
+});
+
+function makeRejectableRequest(User $actor, PurchaseRequest $entity): ApprovalRequest
+{
+    /** @var ApprovalFlow $flow */
+    $flow = ApprovalFlow::factory()->create(['approvable_type' => PurchaseRequest::class]);
+
+    /** @var ApprovalRequest $request */
+    $request = ApprovalRequest::create([
+        'approval_flow_id' => $flow->id,
+        'approvable_type' => PurchaseRequest::class,
+        'approvable_id' => $entity->id,
+        'submitted_by' => $actor->id,
+        'status' => 'in_progress',
+        'current_step_order' => 1,
+    ]);
+
+    $flowStep = ApprovalFlowStep::factory()->create([
+        'approval_flow_id' => $flow->id,
+        'step_order' => 1,
+        'approver_type' => 'user',
+        'approver_user_id' => $actor->id,
+    ]);
+
+    ApprovalRequestStep::create([
+        'approval_request_id' => $request->id,
+        'approval_flow_step_id' => $flowStep->id,
+        'step_order' => 1,
+        'status' => 'pending',
+    ]);
+
+    return $request;
+}
+
+test('reject marks step + request rejected and writes audit log', function () {
+    $request = makeRejectableRequest($this->actor, $this->entity);
+    $step = $request->steps()->firstOrFail();
+
+    $this->action->execute($request, $step, $this->actor->id, 'missing receipts');
+
+    $request->refresh();
+    $step->refresh();
+
+    expect($step->status)->toBe('rejected');
+    expect($step->action)->toBe('reject');
+    expect($step->acted_by)->toBe($this->actor->id);
+    expect($step->comments)->toBe('missing receipts');
+    expect($request->status)->toBe('rejected');
+    expect($request->completed_at)->not->toBeNull();
+
+    expect(ApprovalAuditLog::where('approval_request_id', $request->id)->where('event', 'step_rejected')->count())->toBe(1);
+});
+
+test('reject is atomic — rolls back step + request on failure', function () {
+    $request = makeRejectableRequest($this->actor, $this->entity);
+    $step = $request->steps()->firstOrFail();
+    $action = $this->action;
+
+    expect(function () use ($action, $request, $step) {
+        DB::transaction(function () use ($action, $request, $step) {
+            $action->execute($request, $step, $this->actor->id, 'will fail');
+            throw new RuntimeException('boom');
+        });
+    })->toThrow(RuntimeException::class);
+
+    $request->refresh();
+    $step->refresh();
+
+    expect($step->status)->toBe('pending');
+    expect($request->status)->toBe('in_progress');
+    expect(ApprovalAuditLog::where('approval_request_id', $request->id)->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary

Closes Oracle audit Finding #10 (LOW). Replays the controller-thinning pattern from PR #21 (BankReconciliation) and PRs #25-#28 (payment/receipt postJournal) on `MyApprovalController`.

## Changes

### Action extracts (`app/Actions/Approvals/`)

- **`ApproveApprovalRequestAction`** — owns the full approve flow: step update → audit log → next-step advancement OR final completion + completion audit log. All inside `DB::transaction`.
- **`RejectApprovalRequestAction`** — owns the full reject flow: step update → request status flip → audit log. All inside `DB::transaction`.

### FormRequest extracts (`app/Http/Requests/MyApprovals/`)

- **`ApproveMyApprovalRequest`** — `comments: nullable|string`
- **`RejectMyApprovalRequest`** — `comments: required|string`

### Controller (`MyApprovalController`)

165 lines → 105 lines (-58). Both fat methods (~40 lines each) collapse to ~10-line pure delegators.

### Unit tests (`tests/Unit/Actions/Approvals/`)

- **`ApproveApprovalRequestActionTest`** (3 tests): single-step completion, multi-step advancement, null comments
- **`RejectApprovalRequestActionTest`** (2 tests): rejection happy path, transaction rollback (atomicity)

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `my-approvals` — **12 passed**, 42 assertions (was 7 before, +5 unit tests)
  - `approval-flows` — 46 passed (no regression)
  - `approval-audit-trail` — 12 passed (no regression)
  - `approval-monitoring` — 3 passed (no regression)

## Closes

Oracle audit Finding #10 (LOW).

## Out of Scope

- Finding #6 (CurrencyGuard coverage) — deferred.
- Schema-blocked items — deferred.