### PR TITLE
fix(bank-reconciliations): recalc on removeItem + thin match/remove to actions (Oracle Findings #1-#3)

### DIFF
--- a/app/Actions/BankReconciliations/RemoveBankReconciliationItemAction.php
+++ b/app/Actions/BankReconciliations/RemoveBankReconciliationItemAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Actions\BankReconciliations;
+
+use App\Models\BankReconciliation;
+use Illuminate\Support\Facades\DB;
+
+class RemoveBankReconciliationItemAction
+{
+    public function execute(BankReconciliation $bankReconciliation, int $itemId): void
+    {
+        DB::transaction(function () use ($bankReconciliation, $itemId): void {
+            $bankReconciliation->items()->whereKey($itemId)->delete();
+
+            $bankReconciliation->recalculateBalances();
+        });
+    }
+}

--- a/app/Http/Controllers/BankReconciliationController.php
+++ b/app/Http/Controllers/BankReconciliationController.php
@@ -13,6 +13,7 @@ use App\Actions\BankReconciliations\ImportBankStatementAction;
 use App\Actions\BankReconciliations\IndexBankReconciliationsAction;
 use App\Actions\BankReconciliations\MatchBankReconciliationItemAction;
 use App\Actions\BankReconciliations\PreviewBankStatementAction;
+use App\Actions\BankReconciliations\RemoveBankReconciliationItemAction;
 use App\Actions\BankReconciliations\StoreBankReconciliationAction;
 use App\Actions\BankReconciliations\UnmatchBankReconciliationItemAction;
 use App\Actions\BankReconciliations\UpdateBankReconciliationAction;
@@ -22,6 +23,7 @@ use App\Http\Requests\BankReconciliations\AssignBankReconciliationItemAccountReq
 use App\Http\Requests\BankReconciliations\ExportBankReconciliationRequest;
 use App\Http\Requests\BankReconciliations\ImportBankStatementRequest;
 use App\Http\Requests\BankReconciliations\IndexBankReconciliationRequest;
+use App\Http\Requests\BankReconciliations\MatchBankReconciliationItemRequest;
 use App\Http\Requests\BankReconciliations\StoreBankReconciliationRequest;
 use App\Http\Requests\BankReconciliations\UpdateBankReconciliationRequest;
 use App\Http\Resources\BankReconciliations\BankReconciliationCollection;
@@ -101,12 +103,18 @@ class BankReconciliationController extends Controller
     ): JsonResponse {
         $item = $action->execute($request, $bankReconciliation);
 
-        return response()->json(['data' => $item], 201);
+        return response()->json([
+            'data' => $item,
+            'reconciliation' => $bankReconciliation->only(['id', 'reconciled_balance', 'difference', 'status']),
+        ], 201);
     }
 
-    public function removeItem(BankReconciliation $bankReconciliation, int $item): JsonResponse
-    {
-        $bankReconciliation->items()->whereKey($item)->delete();
+    public function removeItem(
+        BankReconciliation $bankReconciliation,
+        int $item,
+        RemoveBankReconciliationItemAction $action,
+    ): JsonResponse {
+        $action->execute($bankReconciliation, $item);
 
         return response()->json(null, 204);
     }
@@ -140,24 +148,27 @@ class BankReconciliationController extends Controller
         return response()->json($action->execute($bankReconciliation));
     }
 
-    public function matchItem(Request $request, BankReconciliation $bankReconciliation, int $item): JsonResponse
-    {
-        $validated = $request->validate([
-            'journal_entry_line_id' => ['required', 'integer', 'exists:journal_entry_lines,id'],
-        ]);
-
+    public function matchItem(
+        MatchBankReconciliationItemRequest $request,
+        BankReconciliation $bankReconciliation,
+        int $item,
+        MatchBankReconciliationItemAction $action,
+    ): JsonResponse {
         /** @var BankReconciliationItem $bankItem */
         $bankItem = $bankReconciliation->items()->findOrFail($item);
-        $result = (new MatchBankReconciliationItemAction)->execute($bankItem, $validated['journal_entry_line_id']);
+        $result = $action->execute($bankItem, $request->validated('journal_entry_line_id'));
 
         return response()->json(['data' => $result]);
     }
 
-    public function unmatchItem(BankReconciliation $bankReconciliation, int $item): JsonResponse
-    {
+    public function unmatchItem(
+        BankReconciliation $bankReconciliation,
+        int $item,
+        UnmatchBankReconciliationItemAction $action,
+    ): JsonResponse {
         /** @var BankReconciliationItem $bankItem */
         $bankItem = $bankReconciliation->items()->findOrFail($item);
-        $result = (new UnmatchBankReconciliationItemAction)->execute($bankItem);
+        $result = $action->execute($bankItem);
 
         return response()->json(['data' => $result]);
     }

--- a/app/Http/Requests/BankReconciliations/MatchBankReconciliationItemRequest.php
+++ b/app/Http/Requests/BankReconciliations/MatchBankReconciliationItemRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\BankReconciliations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MatchBankReconciliationItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'journal_entry_line_id' => ['required', 'integer', 'exists:journal_entry_lines,id'],
+        ];
+    }
+}

--- a/tests/Feature/BankReconciliations/BankReconciliationControllerTest.php
+++ b/tests/Feature/BankReconciliations/BankReconciliationControllerTest.php
@@ -164,6 +164,41 @@ test('it can remove an item from a bank reconciliation', function () {
     assertDatabaseMissing('bank_reconciliation_items', ['id' => $item->id]);
 });
 
+test('removing a reconciled item recalculates the reconciliation difference', function () {
+    $reconciliation = BankReconciliation::factory()->create([
+        'book_balance' => 1000,
+        'statement_balance' => 1500,
+    ]);
+
+    BankReconciliationItem::factory()->create([
+        'bank_reconciliation_id' => $reconciliation->id,
+        'is_reconciled' => true,
+        'debit' => 0,
+        'credit' => 500,
+    ]);
+
+    $reconciliation->recalculateBalances();
+    $reconciliation->refresh();
+    expect((float) $reconciliation->difference)->toBe(0.0);
+
+    $item = BankReconciliationItem::factory()->create([
+        'bank_reconciliation_id' => $reconciliation->id,
+        'is_reconciled' => true,
+        'debit' => 0,
+        'credit' => 200,
+    ]);
+
+    $reconciliation->recalculateBalances();
+    $reconciliation->refresh();
+    expect((float) $reconciliation->difference)->toBe(-200.0);
+
+    deleteJson("/api/bank-reconciliations/{$reconciliation->id}/items/{$item->id}")->assertNoContent();
+
+    $reconciliation->refresh();
+    expect((float) $reconciliation->difference)->toBe(0.0);
+    expect((float) $reconciliation->reconciled_balance)->toBe(1500.0);
+});
+
 // ─── Import Preview ───────────────────────────────────────────────────────────
 
 test('it can preview a bank statement file', function () {


### PR DESCRIPTION
## Summary

Closes the 3 findings from the post-Finding-#4 Oracle audit refresh, all localized to the `removeItem`/`matchItem` corner of `BankReconciliationController` that the earlier refactor wave didn't fully reach.

## Finding #1 (MEDIUM) — financial integrity bug

`removeItem` deleted items inline with **no** `recalculateBalances()` and **no** transaction, while every other item mutation (`AddItem`, `Match`, `Unmatch`, import, auto-match — all hardened in PR #22) recalculates inside a transaction. There is no model `deleted` hook to compensate.

Impact: removing a `is_reconciled = true` item left `reconciled_balance`/`difference` stale. Since `CompleteBankReconciliationAction` gates completion on `difference == 0`, a user could add reconciled items (difference → 0), remove one, and still complete against a stale-zero difference — producing a financially incorrect 'balanced' reconciliation.

**Fix**: extract `RemoveBankReconciliationItemAction` (`DB::transaction` → delete → `recalculateBalances()`), mirroring `Add`/`Unmatch`. Controller delegates.

## Finding #2 (LOW) — pattern consistency

`matchItem` validated inline + manually instantiated its action; `unmatchItem`/`removeItem` had no request class. The other 5 item endpoints use the FormRequest + DI pattern.

**Fix**: add `MatchBankReconciliationItemRequest`; inject `Match`/`Unmatch`/`Remove` actions via method DI.

## Finding #3 (LOW) — stale client state after addItem

`addItem` recalculated the parent inside the transaction but returned only the new item, so the client couldn't see the updated difference without a refetch.

**Fix**: `addItem` now returns the new item plus the parent's refreshed `reconciled_balance`/`difference`/`status`.

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests: `bank-reconciliations` — **52 passed**, 162 assertions (1 new regression asserting removeItem recalculates difference back to zero after dropping a reconciled item; was 51 before)

## Closes

Oracle audit refresh Findings #1 (MEDIUM), #2 (LOW), #3 (LOW).

## Out of Scope

- Finding #6 (CurrencyGuard coverage) — deferred.
- Schema-blocked items — deferred.