### PR TITLE
fix(reports): enforce single-currency guard on AP/AR aging + outstanding (Oracle Finding #6)

### DIFF
--- a/app/Actions/Reports/Concerns/BuildsCustomerInvoiceReportQuery.php
+++ b/app/Actions/Reports/Concerns/BuildsCustomerInvoiceReportQuery.php
@@ -2,12 +2,15 @@
 
 namespace App\Actions\Reports\Concerns;
 
+use App\Actions\Concerns\AssertsSingleCurrency;
 use App\Models\CustomerInvoice;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 
 trait BuildsCustomerInvoiceReportQuery
 {
+    use AssertsSingleCurrency;
+
     /**
      * Build base customer invoice report query with common joins and columns.
      *
@@ -69,6 +72,27 @@ trait BuildsCustomerInvoiceReportQuery
         $this->applyStringFilter($request, $query, 'status', 'ci.status');
         $this->applyDateRangeFilter($request, $query, 'ci.invoice_date');
         $this->applySearchFilter($request, $query, $this->getBaseSearchColumns());
+    }
+
+    protected function guardCustomerInvoiceCurrency(FormRequest $request, string $context): void
+    {
+        $query = CustomerInvoice::query()
+            ->getQuery()
+            ->from('customer_invoices');
+
+        if (($customerId = $request->integer('customer_id')) > 0) {
+            $query->where('customer_id', $customerId);
+        }
+
+        if (($branchId = $request->integer('branch_id')) > 0) {
+            $query->where('branch_id', $branchId);
+        }
+
+        if (($status = $request->string('status')->toString()) !== '') {
+            $query->where('status', $status);
+        }
+
+        $this->assertSingleCurrency($query, $context);
     }
 
     /**

--- a/app/Actions/Reports/Concerns/BuildsSupplierBillReportQuery.php
+++ b/app/Actions/Reports/Concerns/BuildsSupplierBillReportQuery.php
@@ -2,12 +2,14 @@
 
 namespace App\Actions\Reports\Concerns;
 
+use App\Actions\Concerns\AssertsSingleCurrency;
 use App\Models\SupplierBill;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 
 trait BuildsSupplierBillReportQuery
 {
+    use AssertsSingleCurrency;
     use HandlesReportQuery;
 
     /**
@@ -63,6 +65,28 @@ trait BuildsSupplierBillReportQuery
         $this->applyIntegerFilter($request, $query, 'branch_id', 'sb.branch_id');
         $this->applyStringFilter($request, $query, 'status', 'sb.status');
         $this->applySearchFilter($request, $query, ['sb.bill_number', 's.name', 'b.name']);
+    }
+
+    protected function guardSupplierBillCurrency(FormRequest $request, string $context): void
+    {
+        $query = SupplierBill::query()
+            ->getQuery()
+            ->from('supplier_bills')
+            ->whereIn('status', ['confirmed', 'partially_paid', 'overdue']);
+
+        if (($supplierId = $request->integer('supplier_id')) > 0) {
+            $query->where('supplier_id', $supplierId);
+        }
+
+        if (($branchId = $request->integer('branch_id')) > 0) {
+            $query->where('branch_id', $branchId);
+        }
+
+        if (($status = $request->string('status')->toString()) !== '') {
+            $query->where('status', $status);
+        }
+
+        $this->assertSingleCurrency($query, $context);
     }
 
     /**

--- a/app/Actions/Reports/IndexApAgingReportAction.php
+++ b/app/Actions/Reports/IndexApAgingReportAction.php
@@ -15,6 +15,8 @@ class IndexApAgingReportAction
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
+        $this->guardSupplierBillCurrency($request, 'AP Aging Report');
+
         $boundaries = $this->agingBoundaries();
 
         $query = $this->buildBaseSupplierBillQuery(

--- a/app/Actions/Reports/IndexApOutstandingReportAction.php
+++ b/app/Actions/Reports/IndexApOutstandingReportAction.php
@@ -13,6 +13,8 @@ class IndexApOutstandingReportAction
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
+        $this->guardSupplierBillCurrency($request, 'AP Outstanding Report');
+
         // days_overdue computed in PHP via Carbon (cross-DB). See ApOutstandingReportResource.
         $query = $this->buildBaseSupplierBillQuery();
 

--- a/app/Actions/Reports/IndexArAgingReportAction.php
+++ b/app/Actions/Reports/IndexArAgingReportAction.php
@@ -18,6 +18,8 @@ class IndexArAgingReportAction
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
+        $this->guardCustomerInvoiceCurrency($request, 'AR Aging Report');
+
         $query = $this->buildQuery();
 
         $this->applyBaseCustomerInvoiceFilters($request, $query);

--- a/app/Actions/Reports/IndexArOutstandingReportAction.php
+++ b/app/Actions/Reports/IndexArOutstandingReportAction.php
@@ -16,6 +16,8 @@ class IndexArOutstandingReportAction
 
     public function execute(FormRequest $request): LengthAwarePaginator|Collection
     {
+        $this->guardCustomerInvoiceCurrency($request, 'AR Outstanding Report');
+
         $query = $this->buildQuery();
 
         $this->applyBaseCustomerInvoiceFilters($request, $query);

--- a/tests/Feature/Reports/ApAgingReportTest.php
+++ b/tests/Feature/Reports/ApAgingReportTest.php
@@ -113,3 +113,18 @@ test('it can export ap aging report', function () {
     expect($filename)->toContain('ap_aging_report_');
     Excel::assertStored('exports/' . $filename, 'public');
 });
+
+test('it rejects mixed currencies in the aggregated scope', function () {
+    SupplierBill::factory()->confirmed()->create([
+        'currency' => 'IDR',
+        'due_date' => Carbon::now()->addDays(10)->format('Y-m-d'),
+    ]);
+    SupplierBill::factory()->confirmed()->create([
+        'currency' => 'USD',
+        'due_date' => Carbon::now()->subDays(35)->format('Y-m-d'),
+    ]);
+
+    getJson('/api/reports/ap-aging')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('currency');
+});

--- a/tests/Feature/Reports/ArAgingReportTest.php
+++ b/tests/Feature/Reports/ArAgingReportTest.php
@@ -127,3 +127,20 @@ test('it can export ar aging report', function () {
     Excel::assertStored('exports/' . $filename, 'public');
     Carbon::setTestNow();
 });
+
+test('it rejects mixed currencies in the aggregated scope', function () {
+    Sanctum::actingAs($this->user, ['*']);
+
+    CustomerInvoice::factory()->create([
+        'currency' => 'IDR',
+        'due_date' => Carbon::now()->addDays(10)->format('Y-m-d'),
+    ]);
+    CustomerInvoice::factory()->create([
+        'currency' => 'USD',
+        'due_date' => Carbon::now()->subDays(35)->format('Y-m-d'),
+    ]);
+
+    getJson('/api/reports/ar-aging')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('currency');
+});


### PR DESCRIPTION
## Summary

Closes Oracle audit Finding #6 (MEDIUM) — the last remaining finding from the original audit. Extends `CurrencyGuard` / `AssertsSingleCurrency` coverage beyond `GetAgingDashboardDataAction` (the only prior consumer) to all four money-aggregation report actions.

## Changes

The guard now fires before aggregation in:

- `IndexApAgingReportAction` → `guardSupplierBillCurrency`
- `IndexApOutstandingReportAction` → `guardSupplierBillCurrency`
- `IndexArAgingReportAction` → `guardCustomerInvoiceCurrency`
- `IndexArOutstandingReportAction` → `guardCustomerInvoiceCurrency`

Guard helpers added to `BuildsSupplierBillReportQuery` and `BuildsCustomerInvoiceReportQuery` traits. Each builds a **clean filter-scoped query** mirroring the report's own supplier/branch/status filters (plus the AP hardcoded `confirmed/partially_paid/overdue` status set) and calls `assertSingleCurrency()` before the main query runs.

A separate clean query is used deliberately: the report builders carry complex `selectRaw` bindings that would collide with the guard's `distinct()->pluck('currency')`.

## Scope note

`FinancialReportService` and `BudgetVarianceService` were listed in the original finding, but their underlying tables (`journal_entries`, `budgets`) have **no `currency` column** (verified via schema). The guard is not applicable there — per the finding's own "skip if currency column absent" guidance.

## Quality Gates (local)

- `sail bin duster fix` — clean (TLint, PHP CS Fixer, Pint)
- `sail bin phpstan analyze` — clean (`No errors`)
- Tests:
  - `ap-aging-report` — **6 passed** (1 new: rejects mixed currencies → 422)
  - `ar-aging-report` — **6 passed** (1 new: rejects mixed currencies → 422)
  - `ap-outstanding-report` — 6 passed (no regression)
  - `ar-outstanding-report` — 7 passed (no regression)
  - `aging-dashboard` — 15 passed (no regression on the prior guard consumer)

## Closes

Oracle audit Finding #6 (MEDIUM). With this merged, **all 10 original audit findings + 3 audit-refresh findings are closed**. Only schema-blocked items remain deferred.
