### PR TITLE
feat(journal-entries): add inert nullable branch_id FK + composite index (PR1)

### DIFF
--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Carbon;
  * @property string $description
  * @property string $status
  * @property string $journal_type
+ * @property int|null $branch_id
  * @property string|null $source_type
  * @property int|null $source_id
  * @property int|null $created_by
@@ -29,6 +30,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read User|null $createdBy
  * @property-read FiscalYear $fiscalYear
+ * @property-read Branch|null $branch
  * @property-read float $total_credit
  * @property-read float $total_debit
  * @property-read Collection<int, JournalEntryLine> $lines
@@ -50,6 +52,7 @@ use Illuminate\Support\Carbon;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry whereFiscalYearId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry whereJournalType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry whereBranchId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry wherePostedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry wherePostedBy($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntry whereReference($value)
@@ -78,6 +81,7 @@ class JournalEntry extends Model
         'description',
         'status',
         'journal_type',
+        'branch_id',
         'source_type',
         'source_id',
         'created_by',
@@ -96,6 +100,11 @@ class JournalEntry extends Model
     public function fiscalYear(): BelongsTo
     {
         return $this->belongsTo(FiscalYear::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 
     public function lines(): HasMany

--- a/database/migrations/2026_06_18_000000_add_branch_id_to_journal_entries_table.php
+++ b/database/migrations/2026_06_18_000000_add_branch_id_to_journal_entries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('journal_entries', function (Blueprint $table) {
+            $table
+                ->foreignId('branch_id')
+                ->nullable()
+                ->after('journal_type')
+                ->constrained('branches')
+                ->restrictOnDelete();
+
+            $table->index(
+                ['fiscal_year_id', 'status', 'branch_id'],
+                'journal_entries_fy_status_branch_index'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('journal_entries', function (Blueprint $table) {
+            $table->dropIndex('journal_entries_fy_status_branch_index');
+            $table->dropForeign(['branch_id']);
+            $table->dropColumn('branch_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

PR1 of the financial-dashboard branch-scoping initiative (per the Oracle design recorded in `task.md`). This is the **inert schema increment** — zero behavior change, fully reversible — that unblocks the rest of the plan.

- Adds nullable `branch_id` FK to `journal_entries` (`restrictOnDelete`), placed after `journal_type`.
- Adds composite index `(fiscal_year_id, status, branch_id)` named `journal_entries_fy_status_branch_index` to back future scoped reads.
- Wires `branch_id` into the `JournalEntry` model: `$fillable`, `branch()` BelongsTo relation, and PHPDoc (`@property`, `@property-read`, `whereBranchId`).

## Why inert

No write path populates `branch_id` yet — all existing and new rows stay `null` by design until PR3 (write-path wiring). Nothing reads the column yet (PR4). This PR exists to get the schema reviewed and merged in isolation, de-risking the larger initiative.

## Roadmap (subsequent PRs)

- **PR2** — idempotent `journals:backfill-branch --dry-run` artisan command.
- **PR3** — write-path wiring (resolve branch in `CreateJournalEntryAction` before the txn/retry closure; 9 posting actions; authz gate on manual store; reversal/void inheritance).
- **PR4** — read-path scoping for **P&L / income-statement / trend metrics only** (NOT per-branch balance sheet — see the accounting-policy blocker in `task.md`).

## Verification

- `sail artisan migrate` — applied clean.
- Schema verified: nullable `bigint unsigned` column, composite index in `(fiscal_year_id, status, branch_id)` order, FK `journal_entries_branch_id_foreign` → `branches` with `RESTRICT` on delete.
- `sail bin duster fix` — clean.
- `sail bin phpstan analyze` — no errors.
- `sail test --group journal-entries` — 29 passed (194 assertions).