### PR TITLE
feat(journals): add idempotent journals:backfill-branch command (PR2)

### DIFF
--- a/app/Console/Commands/BackfillJournalEntryBranch.php
+++ b/app/Console/Commands/BackfillJournalEntryBranch.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ApPayment;
+use App\Models\ArReceipt;
+use App\Models\CustomerInvoice;
+use App\Models\GoodsReceipt;
+use App\Models\JournalEntry;
+use App\Models\StockAdjustment;
+use App\Models\SupplierBill;
+use App\Models\SupplierReturn;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+class BackfillJournalEntryBranch extends Command
+{
+    /**
+     * Source models that resolve a branch directly via their own branch_id column.
+     *
+     * @var list<class-string<Model>>
+     */
+    private const DIRECT_BRANCH_SOURCES = [
+        ApPayment::class,
+        ArReceipt::class,
+        CustomerInvoice::class,
+        SupplierBill::class,
+    ];
+
+    /**
+     * Source models that resolve a branch indirectly via warehouse->branch_id (nullable).
+     *
+     * @var list<class-string<Model>>
+     */
+    private const WAREHOUSE_BRANCH_SOURCES = [
+        GoodsReceipt::class,
+        StockAdjustment::class,
+        SupplierReturn::class,
+    ];
+
+    /**
+     * @var string
+     */
+    protected $signature = 'journals:backfill-branch {--dry-run : Report what would change without writing} {--chunk=500 : Number of rows processed per batch}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Backfill journal_entries.branch_id from each entry polymorphic source. Idempotent: only touches rows where branch_id is null.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $chunkSize = max(1, (int) $this->option('chunk'));
+
+        if ($dryRun) {
+            $this->warn('DRY RUN — no rows will be written.');
+        }
+
+        $resolvers = $this->branchResolvers();
+
+        /** @var array<string, array{matched: int, resolved: int, unresolved: int}> $stats */
+        $stats = [];
+        $totalUpdated = 0;
+
+        foreach ($resolvers as $sourceType => $resolver) {
+            $relation = $this->eagerLoadFor($sourceType);
+
+            $stats[$sourceType] = ['matched' => 0, 'resolved' => 0, 'unresolved' => 0];
+
+            JournalEntry::query()
+                ->whereNull('branch_id')
+                ->where('source_type', $sourceType)
+                ->whereNotNull('source_id')
+                ->with($relation)
+                ->chunkById($chunkSize, function ($entries) use ($resolver, &$stats, &$totalUpdated, $sourceType, $dryRun): void {
+                    foreach ($entries as $entry) {
+                        $stats[$sourceType]['matched']++;
+
+                        $source = $entry->source;
+
+                        if (! $source instanceof Model) {
+                            $stats[$sourceType]['unresolved']++;
+
+                            continue;
+                        }
+
+                        $branchId = $resolver($source);
+
+                        if ($branchId === null) {
+                            $stats[$sourceType]['unresolved']++;
+
+                            continue;
+                        }
+
+                        $stats[$sourceType]['resolved']++;
+
+                        if (! $dryRun) {
+                            $entry->branch_id = $branchId;
+                            $entry->save();
+                        }
+
+                        $totalUpdated++;
+                    }
+                });
+        }
+
+        $this->renderSummary($stats, $dryRun);
+
+        $nullSkipped = JournalEntry::query()
+            ->whereNull('branch_id')
+            ->whereNotIn('source_type', array_keys($resolvers))
+            ->count();
+
+        $this->line('');
+        $this->info(sprintf(
+            '%s %d journal entries from branch-bearing sources.',
+            $dryRun ? 'Would update' : 'Updated',
+            $totalUpdated,
+        ));
+        $this->line(sprintf(
+            '%d entries left null by design (no-branch sources or null source_type).',
+            $nullSkipped,
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Map each branch-bearing source_type (FQCN) to a closure returning its branch id or null.
+     *
+     * source_type stores FQCNs (no morph map registered); keys are ::class to avoid string literals.
+     *
+     * @return array<string, callable(Model): ?int>
+     */
+    private function branchResolvers(): array
+    {
+        $resolvers = [];
+
+        foreach (self::DIRECT_BRANCH_SOURCES as $sourceClass) {
+            $resolvers[$sourceClass] = static fn (Model $source): ?int => $source->getAttribute('branch_id') !== null
+                ? (int) $source->getAttribute('branch_id')
+                : null;
+        }
+
+        foreach (self::WAREHOUSE_BRANCH_SOURCES as $sourceClass) {
+            $resolvers[$sourceClass] = static function (Model $source): ?int {
+                $warehouse = $source->getAttribute('warehouse');
+
+                if (! $warehouse instanceof Model) {
+                    return null;
+                }
+
+                return $warehouse->getAttribute('branch_id') !== null
+                    ? (int) $warehouse->getAttribute('branch_id')
+                    : null;
+            };
+        }
+
+        return $resolvers;
+    }
+
+    /**
+     * The eager-load path needed to resolve a branch for the given source_type.
+     *
+     * @param  class-string<Model>  $sourceType
+     * @return list<string>
+     */
+    private function eagerLoadFor(string $sourceType): array
+    {
+        if (in_array($sourceType, self::WAREHOUSE_BRANCH_SOURCES, true)) {
+            return ['source.warehouse'];
+        }
+
+        return ['source'];
+    }
+
+    /**
+     * @param  array<string, array{matched: int, resolved: int, unresolved: int}>  $stats
+     */
+    private function renderSummary(array $stats, bool $dryRun): void
+    {
+        $rows = [];
+
+        foreach ($stats as $sourceType => $counts) {
+            if ($counts['matched'] === 0) {
+                continue;
+            }
+
+            $rows[] = [
+                class_basename($sourceType),
+                $counts['matched'],
+                $counts['resolved'],
+                $counts['unresolved'],
+            ];
+        }
+
+        if ($rows === []) {
+            $this->line('No null-branch journal entries from branch-bearing sources found.');
+
+            return;
+        }
+
+        $this->table(
+            ['Source', 'Matched', $dryRun ? 'Would set' : 'Set', 'Left null'],
+            $rows,
+        );
+    }
+}

--- a/task.md
+++ b/task.md
@@ -1,6 +1,6 @@
 # AI Handoff: ERP Active State
 
-Last updated: 2026-06-17 (Oracle design for financial-dashboard branch scoping recorded; impl DEFERRED on accounting-policy blocker) UTC
+Last updated: 2026-06-18 (PR #33 MERGED — financial-dashboard branch scoping PR1: inert journal_entries.branch_id schema. PR2 backfill command in progress) UTC
 
 ## Document Roles
 
@@ -12,8 +12,12 @@ Last updated: 2026-06-17 (Oracle design for financial-dashboard branch scoping r
 
 User is switching to a new 0pencode session. Read this section first.
 
-1. **Verify baseline**: `git status --short` → expect empty (or only `task.md`). `git log --oneline -1` on main → expect `e3ad1029` (or fresher). No open PRs. Latest main CI green (`27679994418`).
-2. **ALL Oracle audit findings CLOSED.** Latest 2 PRs:
+1. **Verify baseline**: `git status --short` → expect empty (or only `task.md`). `git log --oneline -1` on main → expect `dfde121e` (or fresher). Latest main CI green.
+2. **ALL Oracle audit findings CLOSED.** Financial-dashboard branch scoping NOW IN PROGRESS:
+   - **PR #33** (squash `dfde121e`) — branch-scoping **PR1**: inert nullable `journal_entries.branch_id` FK (restrictOnDelete) + composite index `(fiscal_year_id, status, branch_id)` + model wiring (fillable, `branch()` relation, PHPDoc). Zero behavior change, all rows null by design. Unblocks PR2-PR4.
+   - **PR2 (backfill command) IN PROGRESS this session** — idempotent `journals:backfill-branch --dry-run`, morph-map driven, per-source branch resolution. Policy-independent.
+   - **STILL BLOCKED:** PR4 (read path) shape depends on the accounting-policy decision (Option 1 Head-Office branch vs Option 3 P&L-segment-only). PR2 + PR3 do NOT need it.
+   - Latest audit PRs:
    - **PR #32** (squash `a97a4b67`) — Finding #6: CurrencyGuard on 4 AP/AR aging+outstanding report actions (last original finding)
    - **PR #31** (squash `f6bbcf82`) — Audit-refresh Findings #1-#3: BankReconciliation removeItem recalc + match/remove thinned + addItem refreshed parent
    - **Post-audit (no code):** Oracle design recorded for financial-dashboard branch scoping — impl DEFERRED, blocked on an accounting-policy decision. See the "Financial dashboard branch scoping — Oracle design + the blocker" section.

--- a/tests/Feature/JournalEntries/BackfillJournalEntryBranchTest.php
+++ b/tests/Feature/JournalEntries/BackfillJournalEntryBranchTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\ApPayment;
+use App\Models\Branch;
+use App\Models\GoodsReceipt;
+use App\Models\JournalEntry;
+use App\Models\RecurringJournal;
+use App\Models\Warehouse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\artisan;
+
+uses(RefreshDatabase::class)->group('journal-entries');
+
+it('backfills branch_id from a direct-branch source', function () {
+    $payment = ApPayment::factory()->create();
+
+    $entry = JournalEntry::factory()->create([
+        'branch_id' => null,
+        'source_type' => ApPayment::class,
+        'source_id' => $payment->id,
+    ]);
+
+    artisan('journals:backfill-branch')->assertSuccessful();
+
+    expect($entry->fresh()->branch_id)->toBe($payment->branch_id);
+});
+
+it('backfills branch_id via warehouse for warehouse-based sources', function () {
+    $branch = Branch::factory()->create();
+    $warehouse = Warehouse::factory()->create(['branch_id' => $branch->id]);
+    $receipt = GoodsReceipt::factory()->create(['warehouse_id' => $warehouse->id]);
+
+    $entry = JournalEntry::factory()->create([
+        'branch_id' => null,
+        'source_type' => GoodsReceipt::class,
+        'source_id' => $receipt->id,
+    ]);
+
+    artisan('journals:backfill-branch')->assertSuccessful();
+
+    expect($entry->fresh()->branch_id)->toBe($branch->id);
+});
+
+it('leaves branch_id null when the warehouse has no branch', function () {
+    $warehouse = Warehouse::factory()->create(['branch_id' => null]);
+    $receipt = GoodsReceipt::factory()->create(['warehouse_id' => $warehouse->id]);
+
+    $entry = JournalEntry::factory()->create([
+        'branch_id' => null,
+        'source_type' => GoodsReceipt::class,
+        'source_id' => $receipt->id,
+    ]);
+
+    artisan('journals:backfill-branch')->assertSuccessful();
+
+    expect($entry->fresh()->branch_id)->toBeNull();
+});
+
+it('leaves branch_id null for no-branch sources', function () {
+    $recurring = RecurringJournal::factory()->create();
+
+    $entry = JournalEntry::factory()->create([
+        'branch_id' => null,
+        'source_type' => RecurringJournal::class,
+        'source_id' => $recurring->id,
+    ]);
+
+    artisan('journals:backfill-branch')->assertSuccessful();
+
+    expect($entry->fresh()->branch_id)->toBeNull();
+});
+
+it('writes nothing in dry-run mode', function () {
+    $payment = ApPayment::factory()->create();
+
+    $entry = JournalEntry::factory()->create([
+        'branch_id' => null,
+        'source_type' => ApPayment::class,
+        'source_id' => $payment->id,
+    ]);
+
+    artisan('journals:backfill-branch', ['--dry-run' => true])->assertSuccessful();
+
+    expect($entry->fresh()->branch_id)->toBeNull();
+});
+
+it('does not overwrite an already-populated branch_id', function () {
+    $original = Branch::factory()->create();
+    $payment = ApPayment::factory()->create();
+
+    $entry = JournalEntry::factory()->create([
+        'branch_id' => $original->id,
+        'source_type' => ApPayment::class,
+        'source_id' => $payment->id,
+    ]);
+
+    artisan('journals:backfill-branch')->assertSuccessful();
+
+    expect($entry->fresh()->branch_id)->toBe($original->id);
+});


### PR DESCRIPTION
## Summary

PR2 of the financial-dashboard branch-scoping initiative (per the Oracle design in `task.md`). Builds on PR1 (#33, inert schema) by adding an **idempotent backfill command** that populates `journal_entries.branch_id` from each entry's polymorphic source. This PR is **policy-independent** — it does not touch the per-branch balance-sheet blocker (that affects PR4 read path only).

## What it does

New artisan command:

```
journals:backfill-branch [--dry-run] [--chunk=500]
```

- **Idempotent**: only processes rows where `branch_id IS NULL`. Never overwrites an existing value (re-runnable safely).
- **`--dry-run`**: reports a per-source summary table without writing.
- **`--chunk`**: tunes batch size (`chunkById`, default 500).

## Branch resolution per source

No morph map is registered in this app, so `source_type` stores FQCNs. Resolution is keyed by `::class` constants (no hardcoded string literals):

| Source | Resolution | Nullable |
|---|---|---|
| ApPayment, ArReceipt, CustomerInvoice, SupplierBill | `->branch_id` (direct) | No |
| GoodsReceipt, StockAdjustment, SupplierReturn | `->warehouse->branch_id` | Yes (left null if warehouse has no branch) |
| BankReconciliation, AssetDepreciationRun, RecurringJournal, PeriodClosing | NONE — stays null by design | — |

Eager-loads `source` (and `source.warehouse` for warehouse-based sources) per `source_type` to avoid N+1.

## Deviation note

The Oracle design suggested using the morph map. There is **no morph map registered** in this codebase (verified — `source_type` stores FQCNs), so keying by `::class` constants achieves the same "no hardcoded strings" intent without the risk of registering a morph map that would orphan existing FQCN-valued rows. Registering a morph map is a separate, higher-risk change best deferred.

## Verification

- `sail artisan journals:backfill-branch --dry-run` — runs clean (dev DB has 0 journal entries).
- `sail bin duster fix` — clean (command + test).
- `sail bin phpstan analyze app/Console/Commands/BackfillJournalEntryBranch.php` — no errors. (phpstan scans `app/` only; the test-file generic-inference notes match the existing repo pattern and are not in the CI gate.)
- `sail test --group journal-entries` — **35 passed** (29 prior + 6 new), 206 assertions.

New tests (`tests/Feature/JournalEntries/BackfillJournalEntryBranchTest.php`):
1. direct-branch source resolution
2. warehouse-based source resolution
3. null when warehouse has no branch
4. no-branch source stays null
5. dry-run writes nothing
6. does not overwrite an already-populated `branch_id`

## Roadmap (subsequent PRs)

- **PR3** — write-path wiring (resolve branch in `CreateJournalEntryAction` before the txn/retry closure; 9 posting actions; authz gate on manual store; reversal/void inheritance).
- **PR4** — read-path scoping for P&L / income-statement / trend metrics only (NOT per-branch balance sheet — see the accounting-policy blocker in `task.md`). **Blocked on the Option 1 vs Option 3 policy decision.**
