### PR TITLE
feat(journals): populate branch_id on the posting write path (PR3)

### DIFF
--- a/app/Actions/AccountingPosting/PostApPaymentJournalAction.php
+++ b/app/Actions/AccountingPosting/PostApPaymentJournalAction.php
@@ -49,6 +49,7 @@ class PostApPaymentJournalAction
                 'journal_type' => 'system',
                 'source_type' => ApPayment::class,
                 'source_id' => $apPayment->id,
+                'branch_id' => $apPayment->branch_id,
                 'lines' => [
                     [
                         'account_id' => $apAccount->id,

--- a/app/Actions/AccountingPosting/PostArReceiptJournalAction.php
+++ b/app/Actions/AccountingPosting/PostArReceiptJournalAction.php
@@ -49,6 +49,7 @@ class PostArReceiptJournalAction
                 'journal_type' => 'system',
                 'source_type' => ArReceipt::class,
                 'source_id' => $arReceipt->id,
+                'branch_id' => $arReceipt->branch_id,
                 'lines' => [
                     [
                         'account_id' => (int) $arReceipt->bank_account_id,

--- a/app/Actions/AccountingPosting/PostCustomerInvoiceJournalAction.php
+++ b/app/Actions/AccountingPosting/PostCustomerInvoiceJournalAction.php
@@ -81,6 +81,7 @@ class PostCustomerInvoiceJournalAction
                 'journal_type' => 'system',
                 'source_type' => CustomerInvoice::class,
                 'source_id' => $invoice->id,
+                'branch_id' => $invoice->branch_id,
                 'lines' => array_merge([$debitLine], $creditLines),
             ]);
 

--- a/app/Actions/AccountingPosting/PostGoodsReceiptJournalAction.php
+++ b/app/Actions/AccountingPosting/PostGoodsReceiptJournalAction.php
@@ -34,7 +34,7 @@ class PostGoodsReceiptJournalAction
         }
 
         return DB::transaction(function () use ($goodsReceipt): JournalEntry {
-            $goodsReceipt->loadMissing('items');
+            $goodsReceipt->loadMissing('items', 'warehouse');
 
             if ($goodsReceipt->items->isEmpty()) {
                 throw ValidationException::withMessages([
@@ -85,6 +85,7 @@ class PostGoodsReceiptJournalAction
                 'journal_type' => 'system',
                 'source_type' => GoodsReceipt::class,
                 'source_id' => $goodsReceipt->id,
+                'branch_id' => $goodsReceipt->warehouse->branch_id,
                 'lines' => $lines,
             ]);
 

--- a/app/Actions/AccountingPosting/PostStockAdjustmentJournalAction.php
+++ b/app/Actions/AccountingPosting/PostStockAdjustmentJournalAction.php
@@ -33,7 +33,7 @@ class PostStockAdjustmentJournalAction
         }
 
         return DB::transaction(function () use ($stockAdjustment): JournalEntry {
-            $stockAdjustment->loadMissing('items');
+            $stockAdjustment->loadMissing('items', 'warehouse');
 
             if ($stockAdjustment->items->isEmpty()) {
                 throw ValidationException::withMessages([
@@ -101,6 +101,7 @@ class PostStockAdjustmentJournalAction
                 'journal_type' => 'system',
                 'source_type' => StockAdjustment::class,
                 'source_id' => $stockAdjustment->id,
+                'branch_id' => $stockAdjustment->warehouse->branch_id,
                 'lines' => $lines,
             ]);
 

--- a/app/Actions/AccountingPosting/PostSupplierBillJournalAction.php
+++ b/app/Actions/AccountingPosting/PostSupplierBillJournalAction.php
@@ -81,6 +81,7 @@ class PostSupplierBillJournalAction
                 'journal_type' => 'system',
                 'source_type' => SupplierBill::class,
                 'source_id' => $supplierBill->id,
+                'branch_id' => $supplierBill->branch_id,
                 'lines' => array_merge($debitLines, [$creditLine]),
             ]);
 

--- a/app/Actions/AccountingPosting/PostSupplierReturnJournalAction.php
+++ b/app/Actions/AccountingPosting/PostSupplierReturnJournalAction.php
@@ -34,7 +34,7 @@ class PostSupplierReturnJournalAction
         }
 
         return DB::transaction(function () use ($supplierReturn): JournalEntry {
-            $supplierReturn->loadMissing('items');
+            $supplierReturn->loadMissing('items', 'warehouse');
 
             if ($supplierReturn->items->isEmpty()) {
                 throw ValidationException::withMessages([
@@ -85,6 +85,7 @@ class PostSupplierReturnJournalAction
                 'journal_type' => 'system',
                 'source_type' => SupplierReturn::class,
                 'source_id' => $supplierReturn->id,
+                'branch_id' => $supplierReturn->warehouse->branch_id,
                 'lines' => $lines,
             ]);
 

--- a/app/Actions/JournalEntries/CreateJournalEntryAction.php
+++ b/app/Actions/JournalEntries/CreateJournalEntryAction.php
@@ -19,6 +19,7 @@ class CreateJournalEntryAction
      * - status: 'draft'|'posted' (default 'draft'). When 'posted', posted_by/posted_at are
      *   filled and the entry is balance-verified before saving.
      * - journal_type: e.g. 'general', 'adjusting', 'closing', 'recurring', 'system'.
+     * - branch_id: owning branch resolved by the caller; null for company-wide entries.
      * - source_type, source_id: morph reference to the originating document.
      */
     public function execute(array $data): JournalEntry
@@ -92,6 +93,7 @@ class CreateJournalEntryAction
                         'description' => $data['description'],
                         'status' => $status,
                         'journal_type' => $data['journal_type'] ?? 'general',
+                        'branch_id' => $data['branch_id'] ?? null,
                         'source_type' => $data['source_type'] ?? null,
                         'source_id' => $data['source_id'] ?? null,
                         'created_by' => $userId,

--- a/tests/Feature/AccountingPosting/BranchWritePathTest.php
+++ b/tests/Feature/AccountingPosting/BranchWritePathTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use App\Actions\AccountingPosting\PostApPaymentJournalAction;
+use App\Actions\AccountingPosting\PostGoodsReceiptJournalAction;
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\Account;
+use App\Models\ApPayment;
+use App\Models\Branch;
+use App\Models\CoaVersion;
+use App\Models\FiscalYear;
+use App\Models\GoodsReceipt;
+use App\Models\GoodsReceiptItem;
+use App\Models\JournalEntry;
+use App\Models\User;
+use App\Models\Warehouse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class)->group('journal-entries');
+
+function makeBranchWritePathFiscalYear(): FiscalYear
+{
+    return FiscalYear::factory()->create([
+        'name' => '2026',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'status' => 'open',
+    ]);
+}
+
+function makeBranchWritePathAccounts(): array
+{
+    $coaVersion = CoaVersion::factory()->create(['status' => 'active']);
+
+    return [
+        'ap' => Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'code' => '21100',
+            'name' => 'Accounts Payable',
+            'type' => 'liability',
+            'normal_balance' => 'credit',
+            'is_active' => true,
+        ]),
+        'inventory' => Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'code' => '11300',
+            'name' => 'Inventory',
+            'type' => 'asset',
+            'normal_balance' => 'debit',
+            'is_active' => true,
+        ]),
+        'bank' => Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'code' => '11110',
+            'name' => 'Cash in Bank',
+            'type' => 'asset',
+            'normal_balance' => 'debit',
+            'is_active' => true,
+        ]),
+    ];
+}
+
+it('keeps branch_id in the JournalEntry fillable contract', function () {
+    expect((new JournalEntry)->getFillable())->toContain('branch_id');
+});
+
+it('persists branch_id through mass assignment in CreateJournalEntryAction', function () {
+    makeBranchWritePathFiscalYear();
+    $accounts = makeBranchWritePathAccounts();
+    $branch = Branch::factory()->create();
+    Sanctum::actingAs(User::factory()->create());
+
+    $entry = app(CreateJournalEntryAction::class)->execute([
+        'entry_date' => '2026-03-15',
+        'description' => 'Manual branch entry',
+        'status' => 'posted',
+        'branch_id' => $branch->id,
+        'lines' => [
+            ['account_id' => $accounts['bank']->id, 'debit' => 1000, 'credit' => 0],
+            ['account_id' => $accounts['ap']->id, 'debit' => 0, 'credit' => 1000],
+        ],
+    ]);
+
+    expect($entry->fresh()->branch_id)->toBe($branch->id);
+});
+
+it('defaults branch_id to null when not provided', function () {
+    makeBranchWritePathFiscalYear();
+    $accounts = makeBranchWritePathAccounts();
+    Sanctum::actingAs(User::factory()->create());
+
+    $entry = app(CreateJournalEntryAction::class)->execute([
+        'entry_date' => '2026-03-15',
+        'description' => 'Company-wide entry',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $accounts['bank']->id, 'debit' => 1000, 'credit' => 0],
+            ['account_id' => $accounts['ap']->id, 'debit' => 0, 'credit' => 1000],
+        ],
+    ]);
+
+    expect($entry->fresh()->branch_id)->toBeNull();
+});
+
+it('posts a direct-branch source with its own branch_id', function () {
+    makeBranchWritePathFiscalYear();
+    makeBranchWritePathAccounts();
+    $branch = Branch::factory()->create();
+
+    $payment = ApPayment::factory()->confirmed()->create([
+        'branch_id' => $branch->id,
+        'payment_date' => '2026-03-15',
+        'total_amount' => 750000,
+        'journal_entry_id' => null,
+    ]);
+
+    $entry = app(PostApPaymentJournalAction::class)->execute($payment->fresh());
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->branch_id)->toBe($branch->id);
+});
+
+it('posts a warehouse-based source with the warehouse branch_id', function () {
+    makeBranchWritePathFiscalYear();
+    makeBranchWritePathAccounts();
+    $branch = Branch::factory()->create();
+    $warehouse = Warehouse::factory()->create(['branch_id' => $branch->id]);
+
+    $gr = GoodsReceipt::factory()->create([
+        'status' => 'confirmed',
+        'warehouse_id' => $warehouse->id,
+        'receipt_date' => '2026-03-15',
+        'journal_entry_id' => null,
+        'confirmed_by' => User::factory()->create()->id,
+        'confirmed_at' => now(),
+    ]);
+    GoodsReceiptItem::factory()->create([
+        'goods_receipt_id' => $gr->id,
+        'quantity_accepted' => 10,
+        'unit_price' => 50000,
+    ]);
+
+    $entry = app(PostGoodsReceiptJournalAction::class)->execute($gr->fresh());
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->branch_id)->toBe($branch->id);
+});
+
+it('leaves branch_id null when the source warehouse has no branch', function () {
+    makeBranchWritePathFiscalYear();
+    makeBranchWritePathAccounts();
+    $warehouse = Warehouse::factory()->create(['branch_id' => null]);
+
+    $gr = GoodsReceipt::factory()->create([
+        'status' => 'confirmed',
+        'warehouse_id' => $warehouse->id,
+        'receipt_date' => '2026-03-15',
+        'journal_entry_id' => null,
+        'confirmed_by' => User::factory()->create()->id,
+        'confirmed_at' => now(),
+    ]);
+    GoodsReceiptItem::factory()->create([
+        'goods_receipt_id' => $gr->id,
+        'quantity_accepted' => 10,
+        'unit_price' => 50000,
+    ]);
+
+    $entry = app(PostGoodsReceiptJournalAction::class)->execute($gr->fresh());
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->branch_id)->toBeNull();
+});


### PR DESCRIPTION
## Summary

PR3 of the financial-dashboard branch-scoping initiative. Wires the **write path** so newly-posted journal entries get `branch_id` populated from their source document. Builds on PR1 (#33, inert schema) and PR2 (#34, backfill command).

**Oracle-reviewed: GO** — plan confirmed correct and minimal before implementation.

## What it does

- **`CreateJournalEntryAction`** reads optional `branch_id` from its `$data` array (`'branch_id' => $data['branch_id'] ?? null`). No signature change — consistent with every other optional input the action already accepts. `branch_id` is captured into the transaction closure as a stable scalar **before** the `entry_number` retry loop, so retries never re-derive it.
- **7 branch-bearing posting actions** resolve and pass their source branch:

| Posting action | Resolution |
|---|---|
| ApPayment, ArReceipt, CustomerInvoice, SupplierBill | `source->branch_id` (direct) |
| GoodsReceipt, StockAdjustment, SupplierReturn | `source->warehouse->branch_id` (`warehouse_id` is NOT NULL, `branch_id` nullable; `loadMissing('warehouse')` added) |

- **BankReconciliation** posting stays null (no branch).
- **ClosePeriodAction** and **ExecuteRecurringJournalAction** bypass `CreateJournalEntryAction` and stay null by design.
- **No void/reversal paths exist** in the codebase, so there's nothing to wire there (verified).

## Deliberate deferral: manual entry path

`JournalEntryController::store` is **intentionally left null** in this PR. Adding a user-supplied `branch_id` to the manual journal request opens a cross-branch authorization surface (a branch employee posting into another branch). Per Oracle, this is the smaller long-term risk: null today is the honest current behavior, and PR3's blast radius stays confined to the automated posting path. When manual-entry branch attribution is added later, it must gate via `ResolvesBranchScope` so a branch employee cannot post cross-branch.

## Correctness notes (per Oracle)

- **Trust the source's `branch_id`** — no consistency guard. The CoA is global and the fiscal year is org-wide, so there's no independent branch signal to cross-check against.
- **No model-level branch-existence guard** — the FK already enforces referential integrity.
- **Nested `DB::transaction`** (posting action → `CreateJournalEntryAction`) uses savepoints; adding a scalar column write changes nothing about transaction semantics.

## Verification

- `sail bin phpstan analyze` — no errors.
- `sail bin duster fix` — clean.
- `sail test tests/Feature/AccountingPosting/` — **47 passed**.
- `sail test --group journal-entries` — **41 passed** (35 prior + 6 new).
- Posting controller groups all green: supplier-bills (10), customer-invoices (9), goods-receipts (24), stock-adjustments (42), supplier-returns (21), ap-payments (13), ar-receipts (9).

New tests (`tests/Feature/AccountingPosting/BranchWritePathTest.php`):
1. **`$fillable` contract guard** — pins the one silent-failure mode (a future `$fillable` prune would silently re-null every posted entry)
2. `branch_id` persisted via **mass assignment** in `CreateJournalEntryAction` (not factory override)
3. defaults null when not provided
4. direct-branch source resolution
5. warehouse-based source resolution
6. null when warehouse has no branch (warehouse present, `branch_id` null)

## Roadmap

- **PR4** — read-path scoping for **P&L / income-statement / trend metrics only** (NOT per-branch balance sheet). **Blocked on the accounting-policy decision** (Option 1 Head-Office branch vs Option 3 P&L-segment-only) documented in `task.md`.
- **Future** — manual-entry branch attribution via `ResolvesBranchScope`; reporting-side bucketing of legitimately-null entries as a visible "unscoped" category.
