### PR TITLE
feat(financial-dashboard): branch-segment scoping for P&L metrics, Option 3 (PR4)

### DIFF
--- a/app/Actions/FinancialDashboard/GetFinancialDashboardDataAction.php
+++ b/app/Actions/FinancialDashboard/GetFinancialDashboardDataAction.php
@@ -10,11 +10,13 @@ class GetFinancialDashboardDataAction
         protected FinancialReportService $reportService,
     ) {}
 
-    public function execute(int $fiscalYearId, ?int $comparisonYearId = null): array
+    public function execute(int $fiscalYearId, ?int $comparisonYearId = null, ?int $branchId = null): array
     {
-        // Call all 3 service methods
+        // Segment reporting (Option 3): branch is a P&L dimension only.
+        // Income statement + monthly trends are branch-scoped; balance sheet and
+        // cash flow stay company-wide (cash is centrally pooled at null-branch).
         $balanceSheet = $this->reportService->getBalanceSheet($fiscalYearId, $comparisonYearId);
-        $incomeStatement = $this->reportService->getIncomeStatement($fiscalYearId, $comparisonYearId);
+        $incomeStatement = $this->reportService->getIncomeStatement($fiscalYearId, $comparisonYearId, $branchId);
         $cashFlow = $this->reportService->getCashFlow($fiscalYearId);
 
         // Extract KPIs from totals
@@ -26,51 +28,67 @@ class GetFinancialDashboardDataAction
         $cashOutflow = collect($cashFlow)->sum('outflow');
         $cashBalance = $cashInflow - $cashOutflow;
 
+        $isBranchScoped = $branchId !== null;
+        $segmentScope = $isBranchScoped ? 'branch' : 'company';
+
         return [
             'kpis' => [
                 'revenue' => [
                     'value' => $isTotals['revenue'] ?? 0,
                     'change' => $isTotals['change_percentage_revenue'] ?? 0,
                     'comparison_value' => $isTotals['comparison_revenue'] ?? 0,
+                    'scope' => $segmentScope,
                 ],
                 'expenses' => [
                     'value' => $isTotals['expense'] ?? 0,
                     'change' => $isTotals['change_percentage_expense'] ?? 0,
                     'comparison_value' => $isTotals['comparison_expense'] ?? 0,
+                    'scope' => $segmentScope,
                 ],
                 'net_income' => [
                     'value' => $isTotals['net_income'] ?? 0,
                     'change' => $isTotals['change_percentage_net_income'] ?? 0,
                     'comparison_value' => $isTotals['comparison_net_income'] ?? 0,
+                    'scope' => $segmentScope,
                 ],
                 'total_assets' => [
                     'value' => $bsTotals['assets'] ?? 0,
                     'change' => $bsTotals['change_percentage_assets'] ?? 0,
                     'comparison_value' => $bsTotals['comparison_assets'] ?? 0,
+                    'scope' => 'company',
                 ],
                 'total_liabilities' => [
                     'value' => $bsTotals['liabilities'] ?? 0,
                     'change' => $bsTotals['change_percentage_liabilities'] ?? 0,
                     'comparison_value' => $bsTotals['comparison_liabilities'] ?? 0,
+                    'scope' => 'company',
                 ],
                 'equity' => [
                     'value' => $bsTotals['equity'] ?? 0,
                     'change' => $bsTotals['change_percentage_equity'] ?? 0,
                     'comparison_value' => $bsTotals['comparison_equity'] ?? 0,
+                    'scope' => 'company',
                 ],
                 'cash_balance' => [
                     'value' => $cashBalance,
                     'change' => 0,
                     'comparison_value' => 0,
+                    'scope' => 'company',
                 ],
             ],
             'cash_flow_summary' => [
                 'inflow' => $cashInflow,
                 'outflow' => $cashOutflow,
                 'net' => $cashBalance,
+                'scope' => 'company',
             ],
             'expense_breakdown' => $this->extractTopExpenses($incomeStatement['expenses'] ?? []),
-            'monthly_trends' => $this->reportService->getMonthlyTrends($fiscalYearId),
+            'monthly_trends' => $this->reportService->getMonthlyTrends($fiscalYearId, $branchId),
+            'branch_scope' => [
+                'branch_id' => $branchId,
+                'segment_scope' => $segmentScope,
+                'excludes_unallocated' => $isBranchScoped,
+            ],
         ];
     }
 

--- a/app/Http/Controllers/FinancialDashboardController.php
+++ b/app/Http/Controllers/FinancialDashboardController.php
@@ -4,17 +4,21 @@ namespace App\Http\Controllers;
 
 use App\Actions\FinancialDashboard\GetFinancialDashboardDataAction;
 use App\Http\Controllers\Concerns\InteractsWithFinancialReportRequest;
+use App\Http\Controllers\Concerns\ResolvesBranchScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class FinancialDashboardController extends Controller
 {
     use InteractsWithFinancialReportRequest;
+    use ResolvesBranchScope;
 
     public function __invoke(
         Request $request,
         GetFinancialDashboardDataAction $action,
     ): JsonResponse {
+        $branchId = $this->resolveBranchFromRequest($request);
+
         [
             'fiscalYears' => $fiscalYears,
             'selectedYearId' => $selectedYearId,
@@ -23,13 +27,14 @@ class FinancialDashboardController extends Controller
 
         $data = [];
         if ($selectedYearId) {
-            $data = $action->execute($selectedYearId, $comparisonYearId);
+            $data = $action->execute($selectedYearId, $comparisonYearId, $branchId);
         }
 
         return response()->json([
             'fiscal_years' => $fiscalYears,
             'selected_year_id' => $selectedYearId,
             'comparison_year_id' => $comparisonYearId,
+            'selected_branch_id' => $branchId,
             ...$data,
         ]);
     }

--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -68,7 +68,7 @@ class FinancialReportService
      *
      * @return array<int, array{month: int, label: string, revenue: float, expenses: float, net_income: float}>
      */
-    public function getMonthlyTrends(int $fiscalYearId): array
+    public function getMonthlyTrends(int $fiscalYearId, ?int $branchId = null): array
     {
         $fiscalYear = FiscalYear::findOrFail($fiscalYearId);
         $coaVersion = $this->resolveCoaVersionForFiscalYear($fiscalYear);
@@ -86,6 +86,7 @@ class FinancialReportService
             ->where('journal_entries.status', 'posted')
             ->where('accounts.coa_version_id', $coaVersion->id)
             ->whereIn('accounts.type', ['revenue', 'expense'])
+            ->when($branchId !== null, fn ($query) => $query->where('journal_entries.branch_id', $branchId))
             ->select([
                 'journal_entries.entry_date as entry_date',
                 'accounts.type as account_type',
@@ -202,7 +203,7 @@ class FinancialReportService
         ];
     }
 
-    public function getIncomeStatement(int $fiscalYearId, ?int $comparisonFiscalYearId = null): array
+    public function getIncomeStatement(int $fiscalYearId, ?int $comparisonFiscalYearId = null, ?int $branchId = null): array
     {
         $coaVersion = $this->resolveRequiredCoaVersion($fiscalYearId);
 
@@ -211,13 +212,13 @@ class FinancialReportService
         }
 
         /** @var Collection<int, Account> $accounts */
-        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId)
+        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId, $branchId)
             ->whereIn('type', ['revenue', 'expense'])
             ->orderBy('code')
             ->get();
 
         ['comparisonBalanceByCurrentAccountId' => $comparisonBalanceByCurrentAccountId]
-            = $this->prepareComparisonContext($accounts, $comparisonFiscalYearId);
+            = $this->prepareComparisonContext($accounts, $comparisonFiscalYearId, $branchId);
 
         ['buckets' => $buckets, 'totals' => $totals] = $this->collectAccountBuckets(
             $accounts,
@@ -345,8 +346,8 @@ class FinancialReportService
         $expense = 0;
 
         foreach ($accounts as $account) {
-            $debit = $account->total_debit ?? 0;
-            $credit = $account->total_credit ?? 0;
+            $debit = $account->posted_debit_sum ?? 0;
+            $credit = $account->posted_credit_sum ?? 0;
 
             if ($account->type === 'revenue') {
                 // Revenue is Credit normal
@@ -395,7 +396,8 @@ class FinancialReportService
     private function resolveComparisonBalanceMap(
         Collection $accounts,
         ?int $comparisonFiscalYearId,
-        ?CoaVersion $comparisonCoaVersion
+        ?CoaVersion $comparisonCoaVersion,
+        ?int $branchId = null
     ): array {
         if (! $comparisonFiscalYearId || ! $comparisonCoaVersion) {
             return [];
@@ -404,7 +406,8 @@ class FinancialReportService
         return $this->buildComparisonBalanceMap(
             $accounts,
             $comparisonFiscalYearId,
-            $comparisonCoaVersion
+            $comparisonCoaVersion,
+            $branchId
         );
     }
 
@@ -412,7 +415,7 @@ class FinancialReportService
      * @param  Collection<int, Account>  $accounts
      * @return array{comparisonCoaVersion: ?CoaVersion, comparisonBalanceByCurrentAccountId: array<int, float|int>}
      */
-    private function prepareComparisonContext(Collection $accounts, ?int $comparisonFiscalYearId): array
+    private function prepareComparisonContext(Collection $accounts, ?int $comparisonFiscalYearId, ?int $branchId = null): array
     {
         $comparisonCoaVersion = $this->resolveComparisonCoaVersion($comparisonFiscalYearId);
 
@@ -422,6 +425,7 @@ class FinancialReportService
                 $accounts,
                 $comparisonFiscalYearId,
                 $comparisonCoaVersion,
+                $branchId,
             ),
         ];
     }
@@ -456,8 +460,8 @@ class FinancialReportService
     private function mapAccountsWithNetMovement(Collection $accounts, callable $rowBuilder): array
     {
         return $accounts->map(function (Account $account) use ($rowBuilder) {
-            $debit = (float) ($account->total_debit ?? 0);
-            $credit = (float) ($account->total_credit ?? 0);
+            $debit = (float) ($account->posted_debit_sum ?? 0);
+            $credit = (float) ($account->posted_credit_sum ?? 0);
 
             ['debit' => $netDebit, 'credit' => $netCredit] = $this->splitNetByNormalBalance(
                 $account->normal_balance,
@@ -496,8 +500,8 @@ class FinancialReportService
                 continue;
             }
 
-            $debit = $account->total_debit ?? 0;
-            $credit = $account->total_credit ?? 0;
+            $debit = $account->posted_debit_sum ?? 0;
+            $credit = $account->posted_credit_sum ?? 0;
             $balance = $this->computeAccountBalance($account->normal_balance, $debit, $credit);
             $comparisonBalance = $comparisonFiscalYearId
                 ? (float) ($comparisonBalanceByCurrentAccountId[$account->id] ?? 0)
@@ -547,8 +551,8 @@ class FinancialReportService
     {
         return $this->computeAccountBalance(
             $account->normal_balance,
-            $account->total_debit ?? 0,
-            $account->total_credit ?? 0
+            $account->posted_debit_sum ?? 0,
+            $account->posted_credit_sum ?? 0
         );
     }
 
@@ -601,14 +605,15 @@ class FinancialReportService
     private function buildComparisonBalanceMap(
         Collection $currentAccounts,
         int $comparisonFiscalYearId,
-        CoaVersion $comparisonCoaVersion
+        CoaVersion $comparisonCoaVersion,
+        ?int $branchId = null
     ): array {
         $currentAccounts = $currentAccounts->values();
         $currentIds = $currentAccounts->pluck('id')->all();
         $codes = $currentAccounts->pluck('code')->unique()->values()->all();
 
         /** @var Collection<int, Account> $comparisonAccounts */
-        $comparisonAccounts = $this->accountsWithPostedSums($comparisonCoaVersion->id, $comparisonFiscalYearId)
+        $comparisonAccounts = $this->accountsWithPostedSums($comparisonCoaVersion->id, $comparisonFiscalYearId, $branchId)
             ->whereIn('code', $codes)
             ->get();
 
@@ -629,7 +634,7 @@ class FinancialReportService
 
         $sourceIds = $mappings->pluck('source_account_id')->unique()->values()->all();
         /** @var Collection<int, Account> $sourceAccounts */
-        $sourceAccounts = $this->accountsWithPostedSums($comparisonCoaVersion->id, $comparisonFiscalYearId)
+        $sourceAccounts = $this->accountsWithPostedSums($comparisonCoaVersion->id, $comparisonFiscalYearId, $branchId)
             ->whereIn('id', $sourceIds)
             ->get();
 
@@ -709,21 +714,25 @@ class FinancialReportService
         return $chain;
     }
 
-    private function accountsWithPostedSums(int $coaVersionId, int $fiscalYearId): Builder
+    private function accountsWithPostedSums(int $coaVersionId, int $fiscalYearId, ?int $branchId = null): Builder
     {
-        return Account::where('coa_version_id', $coaVersionId)
-            ->withSum(['journalLines as total_debit' => function ($query) use ($fiscalYearId) {
-                $query->whereHas('journalEntry', function ($q) use ($fiscalYearId) {
-                    $q->where('fiscal_year_id', $fiscalYearId)
-                        ->where('status', 'posted');
-                });
-            }], 'debit')
-            ->withSum(['journalLines as total_credit' => function ($query) use ($fiscalYearId) {
-                $query->whereHas('journalEntry', function ($q) use ($fiscalYearId) {
-                    $q->where('fiscal_year_id', $fiscalYearId)
-                        ->where('status', 'posted');
-                });
-            }], 'credit');
+        // Alias columns to posted_*_sum (NOT total_debit/total_credit): the Account
+        // model defines getTotalDebitAttribute/getTotalCreditAttribute accessors that
+        // recompute unfiltered sums and would shadow any query column of that name.
+        $postedSums = JournalEntryLine::query()
+            ->join('journal_entries', 'journal_entries.id', '=', 'journal_entry_lines.journal_entry_id')
+            ->where('journal_entries.fiscal_year_id', $fiscalYearId)
+            ->where('journal_entries.status', 'posted')
+            ->when($branchId !== null, fn ($q) => $q->where('journal_entries.branch_id', $branchId))
+            ->groupBy('journal_entry_lines.account_id')
+            ->select('journal_entry_lines.account_id')
+            ->selectRaw('SUM(journal_entry_lines.debit) as posted_debit_sum')
+            ->selectRaw('SUM(journal_entry_lines.credit) as posted_credit_sum');
+
+        return Account::query()
+            ->where('accounts.coa_version_id', $coaVersionId)
+            ->leftJoinSub($postedSums, 'posted_sums', 'posted_sums.account_id', '=', 'accounts.id')
+            ->select('accounts.*', 'posted_sums.posted_debit_sum', 'posted_sums.posted_credit_sum');
     }
 
     /**

--- a/tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php
+++ b/tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Account;
+use App\Models\Branch;
 use App\Models\CoaVersion;
 use App\Models\FiscalYear;
 use App\Models\JournalEntry;
@@ -28,18 +29,20 @@ describe('Financial Dashboard API', function () {
                 'fiscal_years',
                 'selected_year_id',
                 'comparison_year_id',
+                'selected_branch_id',
                 'kpis' => [
-                    'revenue' => ['value', 'change', 'comparison_value'],
-                    'expenses' => ['value', 'change', 'comparison_value'],
-                    'net_income' => ['value', 'change', 'comparison_value'],
-                    'total_assets' => ['value', 'change', 'comparison_value'],
-                    'total_liabilities' => ['value', 'change', 'comparison_value'],
-                    'equity' => ['value', 'change', 'comparison_value'],
-                    'cash_balance' => ['value', 'change', 'comparison_value'],
+                    'revenue' => ['value', 'change', 'comparison_value', 'scope'],
+                    'expenses' => ['value', 'change', 'comparison_value', 'scope'],
+                    'net_income' => ['value', 'change', 'comparison_value', 'scope'],
+                    'total_assets' => ['value', 'change', 'comparison_value', 'scope'],
+                    'total_liabilities' => ['value', 'change', 'comparison_value', 'scope'],
+                    'equity' => ['value', 'change', 'comparison_value', 'scope'],
+                    'cash_balance' => ['value', 'change', 'comparison_value', 'scope'],
                 ],
                 'cash_flow_summary' => ['inflow', 'outflow', 'net'],
                 'expense_breakdown',
                 'monthly_trends',
+                'branch_scope' => ['branch_id', 'segment_scope', 'excludes_unallocated'],
             ]);
     });
 
@@ -263,5 +266,116 @@ describe('Financial Dashboard API', function () {
             ->and((float) $trends[2]['revenue'])->toBe(100000.0)
             ->and((float) $trends[2]['expenses'])->toBe(0.0)
             ->and((float) $trends[2]['net_income'])->toBe(100000.0);
+    });
+
+    test('branch filter scopes P&L to the branch and excludes null-branch entries', function () {
+        $branch = Branch::factory()->create();
+        $fiscalYear = FiscalYear::factory()->create(['status' => 'open']);
+        $coaVersion = CoaVersion::factory()->create([
+            'fiscal_year_id' => $fiscalYear->id,
+            'status' => 'active',
+        ]);
+
+        $revenueAccount = Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'type' => 'revenue',
+            'normal_balance' => 'credit',
+            'level' => 1,
+            'parent_id' => null,
+        ]);
+
+        $branchEntry = JournalEntry::factory()->create([
+            'fiscal_year_id' => $fiscalYear->id,
+            'status' => 'posted',
+            'branch_id' => $branch->id,
+        ]);
+        JournalEntryLine::factory()->create([
+            'journal_entry_id' => $branchEntry->id,
+            'account_id' => $revenueAccount->id,
+            'debit' => 0,
+            'credit' => 400000,
+        ]);
+
+        $companyWideEntry = JournalEntry::factory()->create([
+            'fiscal_year_id' => $fiscalYear->id,
+            'status' => 'posted',
+            'branch_id' => null,
+        ]);
+        JournalEntryLine::factory()->create([
+            'journal_entry_id' => $companyWideEntry->id,
+            'account_id' => $revenueAccount->id,
+            'debit' => 0,
+            'credit' => 600000,
+        ]);
+
+        $unscoped = getJson("/api/financial-dashboard?fiscal_year_id={$fiscalYear->id}");
+        $unscoped->assertOk();
+        expect((float) $unscoped->json('kpis.revenue.value'))->toBe(1000000.0)
+            ->and($unscoped->json('kpis.revenue.scope'))->toBe('company')
+            ->and($unscoped->json('selected_branch_id'))->toBeNull()
+            ->and($unscoped->json('branch_scope.excludes_unallocated'))->toBeFalse();
+
+        $scoped = getJson("/api/financial-dashboard?fiscal_year_id={$fiscalYear->id}&branch_id={$branch->id}");
+        $scoped->assertOk();
+        expect((float) $scoped->json('kpis.revenue.value'))->toBe(400000.0)
+            ->and($scoped->json('kpis.revenue.scope'))->toBe('branch')
+            ->and($scoped->json('selected_branch_id'))->toBe($branch->id)
+            ->and($scoped->json('branch_scope.excludes_unallocated'))->toBeTrue();
+    });
+
+    test('balance sheet KPIs stay company-wide and unchanged under a branch filter', function () {
+        $branch = Branch::factory()->create();
+        $fiscalYear = FiscalYear::factory()->create(['status' => 'open']);
+        $coaVersion = CoaVersion::factory()->create([
+            'fiscal_year_id' => $fiscalYear->id,
+            'status' => 'active',
+        ]);
+
+        $assetAccount = Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'type' => 'asset',
+            'normal_balance' => 'debit',
+            'level' => 1,
+            'parent_id' => null,
+        ]);
+        $equityAccount = Account::factory()->create([
+            'coa_version_id' => $coaVersion->id,
+            'type' => 'equity',
+            'normal_balance' => 'credit',
+            'level' => 1,
+            'parent_id' => null,
+        ]);
+
+        $companyWideEntry = JournalEntry::factory()->create([
+            'fiscal_year_id' => $fiscalYear->id,
+            'status' => 'posted',
+            'branch_id' => null,
+        ]);
+        JournalEntryLine::factory()->create([
+            'journal_entry_id' => $companyWideEntry->id,
+            'account_id' => $assetAccount->id,
+            'debit' => 800000,
+            'credit' => 0,
+        ]);
+        JournalEntryLine::factory()->create([
+            'journal_entry_id' => $companyWideEntry->id,
+            'account_id' => $equityAccount->id,
+            'debit' => 0,
+            'credit' => 800000,
+        ]);
+
+        $unscoped = getJson("/api/financial-dashboard?fiscal_year_id={$fiscalYear->id}");
+        $scoped = getJson("/api/financial-dashboard?fiscal_year_id={$fiscalYear->id}&branch_id={$branch->id}");
+
+        $unscoped->assertOk();
+        $scoped->assertOk();
+
+        expect((float) $scoped->json('kpis.total_assets.value'))
+            ->toBe((float) $unscoped->json('kpis.total_assets.value'))
+            ->and((float) $scoped->json('kpis.total_assets.value'))->toBe(800000.0)
+            ->and($scoped->json('kpis.total_assets.scope'))->toBe('company')
+            ->and($scoped->json('kpis.equity.scope'))->toBe('company')
+            ->and((float) $scoped->json('cash_flow_summary.net'))
+            ->toBe((float) $unscoped->json('cash_flow_summary.net'));
     });
 });


### PR DESCRIPTION
## Summary

PR4 (final) of the financial-dashboard branch-scoping initiative. Implements **Option 3 — segment reporting** (the accounting-policy decision): branch is a P&L dimension only. Branch-filtered income statement + monthly trends are exposed as management views with a disclosure that company-wide figures are excluded from the segment. **No per-branch balance sheet** (policy decision — a naive one would balance but mislead). Oracle-reviewed GO.

Builds on PR1 (#33 schema), PR2 (#34 backfill), PR3 (#35 write-path).

## What it does

- **`FinancialDashboardController`** adopts `ResolvesBranchScope` (Pattern A, like `AgingDashboardController`): resolves `branch_id` from the request through the branch-scope policy, returns `selected_branch_id`.
- **`GetFinancialDashboardDataAction`** accepts `?int $branchId` and passes it to **income statement + monthly trends only**. Balance sheet and cash flow stay **company-wide**.
- **Per-KPI scope tags**: `revenue` / `expenses` / `net_income` are tagged `scope: 'branch'` when filtered; `total_assets` / `total_liabilities` / `equity` / `cash_balance` are always `scope: 'company'`. A `branch_scope` summary (`{ branch_id, segment_scope, excludes_unallocated }`) drives the disclosure banner. This prevents implying company-wide KPIs are branch-specific.
- **`FinancialReportService`** threads `?int $branchId` through `getIncomeStatement`, `getMonthlyTrends`, and the comparison chain (`prepareComparisonContext` → `resolveComparisonBalanceMap` → `buildComparisonBalanceMap`) so YoY change% is apples-to-apples (same-branch). `getBalanceSheet` / `getCashFlow` / `getTrialBalance` / `getComparativeReport` / `calculateNetIncome` stay company-wide via the default null arg.

### Why cash flow + balance sheet stay company-wide (Oracle)

Cash is centrally pooled and frequently booked at `branch_id = NULL` (treasury/corporate). The additive segment model (a specific branch excludes null-branch rows) would therefore exclude most real cash movement, producing a misleading per-branch cash flow — the same leakage class as a per-branch balance sheet, which Option 3 explicitly rejected. Cash flow is balance-sheet-adjacent, not P&L, so it's out of scope for branch filtering.

### Additive segment model

A specific `branch_id` **excludes** null-branch (company-wide) entries; `null` branchId **includes all**. `->where('branch_id', $id)` gives this for free (a concrete-int predicate never matches NULL in SQL).

## Root-cause fix (was blocking)

The branch filter initially **silently no-opped** (scoped revenue returned the full company-wide total). Root cause — **not** a binding bug as first suspected: the `Account` model defines `getTotalDebitAttribute()` / `getTotalCreditAttribute()` accessors that recompute **unfiltered** sums (`status=posted` only). In Eloquent, a defined accessor **shadows** a query column of the same name on property access, so the `withSum`/SELECT alias `total_debit`/`total_credit` was always overridden by the unfiltered accessor value. (This also meant fiscal-year scoping via these aliases was latently broken — masked because existing tests use a single fiscal year.)

Fixed by:
1. Rewriting `accountsWithPostedSums` as a pre-grouped `leftJoinSub` (removes the correlated subquery; LEFT JOIN preserves zero-line accounts with NULL sums, byte-for-byte the prior observable behavior).
2. Aliasing to **`posted_debit_sum`** / **`posted_credit_sum`** (non-colliding names) and reading those at all 4 call sites.

Only `FinancialReportService` consumes these columns (verified), so the rename's blast radius is contained.

## Verification

- `phpstan` — no errors. `duster` — clean.
- `financial-dashboard` — **11 passed** (incl. 2 new branch-segment tests: P&L scoped + null-branch excluded; BS/cash-flow identical with/without the filter).
- Regression across all 6 callers of `accountsWithPostedSums`: **42 financial report tests** (balance-sheet, income-statement, cash-flow, comparative, trial-balance, general-ledger, FinancialReports) + the **31-test `reports` group** all green.

## Roadmap (initiative complete after this)

PR1–PR4 land the full branch-scoping initiative. Optional future work (out of scope): per-branch cash flow (needs line-level branch tagging or a documented treasury-allocation method); manual-entry branch attribution (PR3 deferral, gated via `ResolvesBranchScope`); frontend two-section disclosure rendering using the per-KPI `scope` tags.
