### PR TITLE
feat: manual journal branch attribution + financial dashboard segment disclosure

### DIFF
--- a/app/Http/Controllers/JournalEntryController.php
+++ b/app/Http/Controllers/JournalEntryController.php
@@ -6,6 +6,7 @@ use App\Actions\JournalEntries\CreateJournalEntryAction;
 use App\Actions\JournalEntries\ExportJournalEntriesAction;
 use App\Actions\JournalEntries\IndexJournalEntriesAction;
 use App\Actions\JournalEntries\UpdateJournalEntryAction;
+use App\Http\Controllers\Concerns\ResolvesBranchScope;
 use App\Http\Requests\JournalEntries\IndexJournalEntryRequest;
 use App\Http\Requests\JournalEntries\StoreJournalEntryRequest;
 use App\Http\Requests\JournalEntries\UpdateJournalEntryRequest;
@@ -16,6 +17,8 @@ use Illuminate\Http\JsonResponse;
 
 class JournalEntryController extends Controller
 {
+    use ResolvesBranchScope;
+
     public function index(IndexJournalEntryRequest $request, IndexJournalEntriesAction $action): JsonResponse
     {
         $journalEntries = $action->execute($request);
@@ -25,7 +28,17 @@ class JournalEntryController extends Controller
 
     public function store(StoreJournalEntryRequest $request, CreateJournalEntryAction $action): JsonResponse
     {
-        $journalEntry = $action->execute($request->validated());
+        $data = $request->validated();
+
+        // Gate branch attribution: a branch-scoped employee may only post into
+        // their own branch. Users with `view_all_branches` keep the requested
+        // branch (null = company-wide). Legacy admins (no employee branch) are
+        // unscoped. This prevents a cross-branch financial-integrity hole.
+        $data['branch_id'] = $this->resolveBranchScope(
+            isset($data['branch_id']) ? (int) $data['branch_id'] : null,
+        );
+
+        $journalEntry = $action->execute($data);
 
         return (new JournalEntryResource($journalEntry))
             ->response()
@@ -34,7 +47,7 @@ class JournalEntryController extends Controller
 
     public function show(JournalEntry $journalEntry): JsonResponse
     {
-        $journalEntry->load(['lines.account', 'fiscalYear', 'createdBy', 'postedBy']);
+        $journalEntry->load(['lines.account', 'fiscalYear', 'branch', 'createdBy', 'postedBy']);
 
         return (new JournalEntryResource($journalEntry))->response();
     }

--- a/app/Http/Requests/JournalEntries/AbstractJournalEntryRequest.php
+++ b/app/Http/Requests/JournalEntries/AbstractJournalEntryRequest.php
@@ -12,6 +12,7 @@ abstract class AbstractJournalEntryRequest extends AuthorizedFormRequest
             'entry_date' => ['required', 'date'],
             'reference' => ['nullable', 'string', 'max:255'],
             'description' => ['required', 'string', 'max:255'],
+            'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
             'lines' => ['required', 'array', 'min:2'],
             'lines.*.account_id' => ['required', 'exists:accounts,id'],
             'lines.*.debit' => ['required', 'numeric', 'min:0'],

--- a/app/Http/Resources/JournalEntries/JournalEntryResource.php
+++ b/app/Http/Resources/JournalEntries/JournalEntryResource.php
@@ -25,6 +25,10 @@ class JournalEntryResource extends JsonResource
                 'id' => $this->resource->fiscal_year_id,
                 'name' => $this->resource->fiscalYear?->name,
             ],
+            'branch' => $this->resource->branch_id === null ? null : [
+                'id' => $this->resource->branch_id,
+                'name' => $this->resource->branch?->name,
+            ],
             'lines' => $this->resource->lines->map(fn ($line) => [
                 'id' => $line->id,
                 'account_id' => $line->account_id,

--- a/resources/js/components/financial-dashboard/SummaryCards.tsx
+++ b/resources/js/components/financial-dashboard/SummaryCards.tsx
@@ -26,7 +26,7 @@ function getScopePill(scope?: KpiItem['scope']) {
         return (
             <Badge
                 variant="outline"
-                className="text-[10px] font-normal text-muted-foreground px-1.5 py-0"
+                className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
             >
                 Segment
             </Badge>
@@ -35,7 +35,7 @@ function getScopePill(scope?: KpiItem['scope']) {
     return (
         <Badge
             variant="outline"
-            className="text-[10px] font-normal text-muted-foreground px-1.5 py-0"
+            className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
         >
             Company-wide
         </Badge>

--- a/resources/js/components/financial-dashboard/SummaryCards.tsx
+++ b/resources/js/components/financial-dashboard/SummaryCards.tsx
@@ -11,11 +11,35 @@ import {
     TrendingUp,
 } from 'lucide-react';
 import { memo } from 'react';
-import type { FinancialDashboardData } from '../../hooks/useFinancialDashboard';
+import type {
+    FinancialDashboardData,
+    KpiItem,
+} from '../../hooks/useFinancialDashboard';
 
 interface SummaryCardsProps {
     readonly data?: FinancialDashboardData['kpis'];
     readonly isLoading: boolean;
+}
+
+function getScopePill(scope?: KpiItem['scope']) {
+    if (scope === 'branch') {
+        return (
+            <Badge
+                variant="outline"
+                className="text-[10px] font-normal text-muted-foreground px-1.5 py-0"
+            >
+                Segment
+            </Badge>
+        );
+    }
+    return (
+        <Badge
+            variant="outline"
+            className="text-[10px] font-normal text-muted-foreground px-1.5 py-0"
+        >
+            Company-wide
+        </Badge>
+    );
 }
 
 function getChangeBadge(change: number, isExpenseOrLiability: boolean = false) {
@@ -81,6 +105,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.revenue.value,
             change: data.revenue.change,
             isExpenseOrLiability: false,
+            scope: data.revenue.scope,
         },
         {
             title: 'Expenses',
@@ -90,6 +115,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.expenses.value,
             change: data.expenses.change,
             isExpenseOrLiability: true,
+            scope: data.expenses.scope,
         },
         {
             title: 'Net Income',
@@ -99,6 +125,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.net_income.value,
             change: data.net_income.change,
             isExpenseOrLiability: false,
+            scope: data.net_income.scope,
         },
         {
             title: 'Total Assets',
@@ -108,6 +135,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.total_assets.value,
             change: data.total_assets.change,
             isExpenseOrLiability: false,
+            scope: data.total_assets.scope,
         },
         {
             title: 'Total Liabilities',
@@ -117,6 +145,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.total_liabilities.value,
             change: data.total_liabilities.change,
             isExpenseOrLiability: true,
+            scope: data.total_liabilities.scope,
         },
         {
             title: 'Equity',
@@ -126,6 +155,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.equity.value,
             change: data.equity.change,
             isExpenseOrLiability: false,
+            scope: data.equity.scope,
         },
         {
             title: 'Cash Balance',
@@ -135,6 +165,7 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             value: data.cash_balance.value,
             change: data.cash_balance.change,
             isExpenseOrLiability: false,
+            scope: data.cash_balance.scope,
         },
     ];
 
@@ -166,6 +197,9 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
                                 <span className="text-xs text-muted-foreground">
                                     vs comparison period
                                 </span>
+                            </div>
+                            <div className="mt-1.5">
+                                {getScopePill(card.scope)}
                             </div>
                         </CardContent>
                     </Card>

--- a/resources/js/hooks/useFinancialDashboard.ts
+++ b/resources/js/hooks/useFinancialDashboard.ts
@@ -5,12 +5,14 @@ export interface KpiItem {
     value: number;
     change: number;
     comparison_value: number;
+    scope: 'branch' | 'company';
 }
 
 export interface CashFlowSummary {
     inflow: number;
     outflow: number;
     net: number;
+    scope: 'branch' | 'company';
 }
 
 export interface ExpenseBreakdownItem {
@@ -34,10 +36,18 @@ export interface FiscalYear {
     status: string;
 }
 
+export interface BranchScope {
+    branch_id: number | null;
+    segment_scope: 'branch' | 'company';
+    excludes_unallocated: boolean;
+}
+
 export interface FinancialDashboardData {
     fiscal_years: FiscalYear[];
     selected_year_id: number | null;
     comparison_year_id: number | null;
+    selected_branch_id: number | null;
+    branch_scope: BranchScope;
     kpis: {
         revenue: KpiItem;
         expenses: KpiItem;
@@ -55,6 +65,7 @@ export interface FinancialDashboardData {
 interface UseFinancialDashboardParams {
     fiscalYearId?: number | null;
     comparisonYearId?: number | null;
+    branchId?: number | null;
 }
 
 export function useFinancialDashboard(params?: UseFinancialDashboardParams) {
@@ -72,6 +83,9 @@ export function useFinancialDashboard(params?: UseFinancialDashboardParams) {
                 params.comparisonYearId.toString(),
             );
         }
+        if (params?.branchId) {
+            queryParams.append('branch_id', params.branchId.toString());
+        }
 
         const queryString = queryParams.toString();
         const url = queryString
@@ -86,6 +100,7 @@ export function useFinancialDashboard(params?: UseFinancialDashboardParams) {
             'financial-dashboard',
             params?.fiscalYearId,
             params?.comparisonYearId,
+            params?.branchId,
         ],
         queryFn: fetchDashboardData,
         staleTime: 60000,

--- a/resources/js/pages/financial-dashboard/index.tsx
+++ b/resources/js/pages/financial-dashboard/index.tsx
@@ -69,8 +69,7 @@ export default function FinancialDashboard() {
         setSearchParams(newParams);
     };
 
-    const showSegmentBanner =
-        data?.branch_scope?.excludes_unallocated === true;
+    const showSegmentBanner = data?.branch_scope?.excludes_unallocated === true;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>

--- a/resources/js/pages/financial-dashboard/index.tsx
+++ b/resources/js/pages/financial-dashboard/index.tsx
@@ -2,9 +2,10 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/app-layout';
 import { BreadcrumbItem } from '@/types';
-import { AlertCircle, RefreshCw } from 'lucide-react';
+import { AlertCircle, Info, RefreshCw } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { useSearchParams } from 'react-router-dom';
+import { AsyncSelect } from '../../components/common/AsyncSelect';
 import { CashFlowSummary } from '../../components/financial-dashboard/CashFlowSummary';
 import { ExpenseBreakdown } from '../../components/financial-dashboard/ExpenseBreakdown';
 import { FiscalYearSelector } from '../../components/financial-dashboard/FiscalYearSelector';
@@ -28,10 +29,14 @@ export default function FinancialDashboard() {
     const comparisonYearId = searchParams.get('comparison_year_id')
         ? Number(searchParams.get('comparison_year_id'))
         : null;
+    const branchId = searchParams.get('branch_id')
+        ? Number(searchParams.get('branch_id'))
+        : null;
 
     const { data, isLoading, isError, error, refetch } = useFinancialDashboard({
         fiscalYearId,
         comparisonYearId,
+        branchId,
     });
 
     const handleYearChange = (yearId: number | null) => {
@@ -54,6 +59,19 @@ export default function FinancialDashboard() {
         setSearchParams(newParams);
     };
 
+    const handleBranchChange = (value: string) => {
+        const newParams = new URLSearchParams(searchParams);
+        if (value) {
+            newParams.set('branch_id', value);
+        } else {
+            newParams.delete('branch_id');
+        }
+        setSearchParams(newParams);
+    };
+
+    const showSegmentBanner =
+        data?.branch_scope?.excludes_unallocated === true;
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Helmet>
@@ -71,6 +89,18 @@ export default function FinancialDashboard() {
                         </p>
                     </div>
                     <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+                        <div className="flex flex-col gap-1.5">
+                            <label className="text-sm font-medium text-muted-foreground">
+                                Branch
+                            </label>
+                            <AsyncSelect
+                                url="/api/branches"
+                                placeholder="All Branches"
+                                value={branchId?.toString() ?? ''}
+                                onValueChange={handleBranchChange}
+                                className="w-[180px]"
+                            />
+                        </div>
                         {data?.fiscal_years && data.fiscal_years.length > 0 && (
                             <FiscalYearSelector
                                 fiscalYears={data.fiscal_years}
@@ -104,6 +134,22 @@ export default function FinancialDashboard() {
                         <AlertDescription className="mt-2 max-w-lg text-sm">
                             {error?.message ||
                                 'Failed to fetch financial dashboard data from the server. Please try refreshing.'}
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                {showSegmentBanner && (
+                    <Alert className="border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
+                        <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                        <AlertTitle className="font-semibold">
+                            Segment view — Branch P&L
+                        </AlertTitle>
+                        <AlertDescription className="mt-1 text-sm">
+                            Revenue, Expenses, and Net Income reflect this
+                            branch&apos;s segment only and exclude company-wide
+                            / unallocated entries (period-closing,
+                            depreciation). Total Assets, Liabilities, Equity,
+                            and Cash Balance remain company-wide.
                         </AlertDescription>
                     </Alert>
                 )}

--- a/tests/Feature/JournalEntries/JournalEntryBranchScopeTest.php
+++ b/tests/Feature/JournalEntries/JournalEntryBranchScopeTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Models\Account;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\FiscalYear;
+use App\Models\JournalEntry;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class)->group('journal-entries');
+
+/**
+ * @param  array<string>  $permissions
+ */
+function makeJournalUserInBranch(?int $branchId, array $permissions): User
+{
+    $user = User::factory()->create();
+    $employee = Employee::factory()->create([
+        'user_id' => $user->id,
+        'branch_id' => $branchId,
+        'department_id' => null,
+        'position_id' => null,
+    ]);
+
+    $ids = [];
+    foreach ($permissions as $name) {
+        $ids[] = Permission::firstOrCreate(
+            ['name' => $name],
+            ['display_name' => ucwords(str_replace(['.', '-'], ' ', $name))],
+        )->id;
+    }
+    $employee->permissions()->sync($ids);
+
+    return $user;
+}
+
+/**
+ * @return array{0: Account, 1: Account}
+ */
+function makeBalancedJournalLines(): array
+{
+    FiscalYear::factory()->create([
+        'status' => 'open',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+    ]);
+
+    return [Account::factory()->create(), Account::factory()->create()];
+}
+
+/**
+ * @param  array{0: Account, 1: Account}  $accounts
+ * @return array<string, mixed>
+ */
+function balancedJournalPayload(array $accounts, ?int $branchId = null): array
+{
+    $payload = [
+        'entry_date' => '2026-03-15',
+        'description' => 'Manual entry',
+        'lines' => [
+            ['account_id' => $accounts[0]->id, 'debit' => 1000, 'credit' => 0],
+            ['account_id' => $accounts[1]->id, 'debit' => 0, 'credit' => 1000],
+        ],
+    ];
+
+    if ($branchId !== null) {
+        $payload['branch_id'] = $branchId;
+    }
+
+    return $payload;
+}
+
+describe('Manual journal entry branch attribution gate', function () {
+    test('view_all_branches user keeps the requested branch_id', function () {
+        $accounts = makeBalancedJournalLines();
+        $branch = Branch::factory()->create();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create', 'view_all_branches']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts, $branch->id));
+
+        $response->assertCreated();
+        expect(JournalEntry::first()->branch_id)->toBe($branch->id);
+    });
+
+    test('view_all_branches user may post a company-wide (null) entry', function () {
+        $accounts = makeBalancedJournalLines();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create', 'view_all_branches']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts));
+
+        $response->assertCreated();
+        expect(JournalEntry::first()->branch_id)->toBeNull();
+    });
+
+    test('branch-scoped employee is forced to own branch, ignoring requested branch_id', function () {
+        $accounts = makeBalancedJournalLines();
+        $ownBranch = Branch::factory()->create();
+        $otherBranch = Branch::factory()->create();
+        $user = makeJournalUserInBranch($ownBranch->id, ['journal_entry', 'journal_entry.create']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts, $otherBranch->id));
+
+        $response->assertCreated();
+        expect(JournalEntry::first()->branch_id)->toBe($ownBranch->id);
+    });
+
+    test('branch-scoped employee posting without branch_id still lands on own branch', function () {
+        $accounts = makeBalancedJournalLines();
+        $ownBranch = Branch::factory()->create();
+        $user = makeJournalUserInBranch($ownBranch->id, ['journal_entry', 'journal_entry.create']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts));
+
+        $response->assertCreated();
+        expect(JournalEntry::first()->branch_id)->toBe($ownBranch->id);
+    });
+
+    test('legacy admin (no employee branch, no permission) stays unscoped', function () {
+        $accounts = makeBalancedJournalLines();
+        $branch = Branch::factory()->create();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts, $branch->id));
+
+        $response->assertCreated();
+        expect(JournalEntry::first()->branch_id)->toBe($branch->id);
+    });
+
+    test('rejects a branch_id that does not exist', function () {
+        $accounts = makeBalancedJournalLines();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create', 'view_all_branches']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts, 999999));
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['branch_id']);
+    });
+
+    test('store response exposes the resolved branch', function () {
+        $accounts = makeBalancedJournalLines();
+        $branch = Branch::factory()->create();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create', 'view_all_branches']);
+        actingAs($user);
+
+        $response = postJson('/api/journal-entries', balancedJournalPayload($accounts, $branch->id));
+
+        $response->assertCreated()
+            ->assertJsonPath('data.branch.id', $branch->id)
+            ->assertJsonPath('data.branch.name', $branch->name);
+    });
+});


### PR DESCRIPTION
## Summary

Closes the final two tails of the branch-scoping initiative (PR1-PR4 already shipped). Two independent commits:

### 1. Manual journal-entry branch attribution (backend)
The automated posting paths already populate `journal_entries.branch_id` (PR #35). The manual `JournalEntryController::store` path was deliberately deferred to avoid a cross-branch authorization hole. This wires it in, gated through `ResolvesBranchScope`:

- **Branch-scoped employee** → forced to own branch regardless of payload `branch_id`.
- **`view_all_branches` admin** → may post any branch, or company-wide (`null`).
- **Legacy admin** (no employee branch) → stays unscoped.

Changes: `AbstractJournalEntryRequest` validates `branch_id` (`nullable, exists:branches,id`); controller adopts the trait + eager-loads `branch` on `show`; `JournalEntryResource` exposes a null-safe `branch`.

### 2. Financial dashboard segment disclosure UI (frontend)
Consumes the per-KPI `scope` tags + `branch_scope` summary the backend already emits (Option 3 segment reporting). When a branch is selected, Revenue/Expenses/Net Income show as segment figures while balance-sheet KPIs stay company-wide — with a clear informational banner and per-card scope pills. Adds a branch selector reusing the existing `AsyncSelect` + `/api/branches`.

## Tested

- `sail test --group journal-entries` → 48 passed (incl. new `JournalEntryBranchScopeTest`, 7 cases)
- `sail test --group financial-dashboard` → 11 passed
- E2E `tests/e2e/financial-dashboard/` → 4 passed
- `phpstan` clean, `duster` clean, `npm run types` clean, `npm run lint` clean

## Notes

- No backend API contract change for the dashboard — frontend only consumes existing fields.
- `update` path intentionally untouched (never carried `branch_id`; re-scoping it is out of scope).
- Per-branch balance sheet still intentionally NOT shipped (accounting-policy blocker documented in task.md).
