### PR TITLE
feat(branch): shared branch-resolver registry (PR1/3 dashboard scoping)

### DIFF
--- a/app/Console/Commands/BackfillJournalEntryBranch.php
+++ b/app/Console/Commands/BackfillJournalEntryBranch.php
@@ -2,42 +2,13 @@
 
 namespace App\Console\Commands;
 
-use App\Models\ApPayment;
-use App\Models\ArReceipt;
-use App\Models\CustomerInvoice;
-use App\Models\GoodsReceipt;
+use App\Domain\Branch\BranchResolverRegistry;
 use App\Models\JournalEntry;
-use App\Models\StockAdjustment;
-use App\Models\SupplierBill;
-use App\Models\SupplierReturn;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 
 class BackfillJournalEntryBranch extends Command
 {
-    /**
-     * Source models that resolve a branch directly via their own branch_id column.
-     *
-     * @var list<class-string<Model>>
-     */
-    private const DIRECT_BRANCH_SOURCES = [
-        ApPayment::class,
-        ArReceipt::class,
-        CustomerInvoice::class,
-        SupplierBill::class,
-    ];
-
-    /**
-     * Source models that resolve a branch indirectly via warehouse->branch_id (nullable).
-     *
-     * @var list<class-string<Model>>
-     */
-    private const WAREHOUSE_BRANCH_SOURCES = [
-        GoodsReceipt::class,
-        StockAdjustment::class,
-        SupplierReturn::class,
-    ];
-
     /**
      * @var string
      */
@@ -48,7 +19,7 @@ class BackfillJournalEntryBranch extends Command
      */
     protected $description = 'Backfill journal_entries.branch_id from each entry polymorphic source. Idempotent: only touches rows where branch_id is null.';
 
-    public function handle(): int
+    public function handle(BranchResolverRegistry $registry): int
     {
         $dryRun = (bool) $this->option('dry-run');
         $chunkSize = max(1, (int) $this->option('chunk'));
@@ -57,14 +28,17 @@ class BackfillJournalEntryBranch extends Command
             $this->warn('DRY RUN — no rows will be written.');
         }
 
-        $resolvers = $this->branchResolvers();
+        $branchBearingTypes = $registry->branchBearingTypes();
 
         /** @var array<string, array{matched: int, resolved: int, unresolved: int}> $stats */
         $stats = [];
         $totalUpdated = 0;
 
-        foreach ($resolvers as $sourceType => $resolver) {
-            $relation = $this->eagerLoadFor($sourceType);
+        foreach ($branchBearingTypes as $sourceType) {
+            $relation = array_map(
+                static fn (string $relation): string => "source.{$relation}",
+                $registry->relationsFor($sourceType),
+            );
 
             $stats[$sourceType] = ['matched' => 0, 'resolved' => 0, 'unresolved' => 0];
 
@@ -72,8 +46,8 @@ class BackfillJournalEntryBranch extends Command
                 ->whereNull('branch_id')
                 ->where('source_type', $sourceType)
                 ->whereNotNull('source_id')
-                ->with($relation)
-                ->chunkById($chunkSize, function ($entries) use ($resolver, &$stats, &$totalUpdated, $sourceType, $dryRun): void {
+                ->with(array_merge(['source'], $relation))
+                ->chunkById($chunkSize, function ($entries) use ($registry, &$stats, &$totalUpdated, $sourceType, $dryRun): void {
                     foreach ($entries as $entry) {
                         $stats[$sourceType]['matched']++;
 
@@ -85,7 +59,7 @@ class BackfillJournalEntryBranch extends Command
                             continue;
                         }
 
-                        $branchId = $resolver($source);
+                        $branchId = $registry->resolve($source);
 
                         if ($branchId === null) {
                             $stats[$sourceType]['unresolved']++;
@@ -109,7 +83,7 @@ class BackfillJournalEntryBranch extends Command
 
         $nullSkipped = JournalEntry::query()
             ->whereNull('branch_id')
-            ->whereNotIn('source_type', array_keys($resolvers))
+            ->whereNotIn('source_type', $branchBearingTypes)
             ->count();
 
         $this->line('');
@@ -124,55 +98,6 @@ class BackfillJournalEntryBranch extends Command
         ));
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Map each branch-bearing source_type (FQCN) to a closure returning its branch id or null.
-     *
-     * source_type stores FQCNs (no morph map registered); keys are ::class to avoid string literals.
-     *
-     * @return array<string, callable(Model): ?int>
-     */
-    private function branchResolvers(): array
-    {
-        $resolvers = [];
-
-        foreach (self::DIRECT_BRANCH_SOURCES as $sourceClass) {
-            $resolvers[$sourceClass] = static fn (Model $source): ?int => $source->getAttribute('branch_id') !== null
-                ? (int) $source->getAttribute('branch_id')
-                : null;
-        }
-
-        foreach (self::WAREHOUSE_BRANCH_SOURCES as $sourceClass) {
-            $resolvers[$sourceClass] = static function (Model $source): ?int {
-                $warehouse = $source->getAttribute('warehouse');
-
-                if (! $warehouse instanceof Model) {
-                    return null;
-                }
-
-                return $warehouse->getAttribute('branch_id') !== null
-                    ? (int) $warehouse->getAttribute('branch_id')
-                    : null;
-            };
-        }
-
-        return $resolvers;
-    }
-
-    /**
-     * The eager-load path needed to resolve a branch for the given source_type.
-     *
-     * @param  class-string<Model>  $sourceType
-     * @return list<string>
-     */
-    private function eagerLoadFor(string $sourceType): array
-    {
-        if (in_array($sourceType, self::WAREHOUSE_BRANCH_SOURCES, true)) {
-            return ['source.warehouse'];
-        }
-
-        return ['source'];
     }
 
     /**

--- a/app/Domain/Branch/BranchResolutionStrategy.php
+++ b/app/Domain/Branch/BranchResolutionStrategy.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Domain\Branch;
+
+enum BranchResolutionStrategy
+{
+    /** The model carries its own branch_id column. */
+    case Direct;
+
+    /** Branch is reached via warehouse->branch_id (nullable). */
+    case Warehouse;
+
+    /** The type has no branch concept (intentionally unscopable). */
+    case None;
+}

--- a/app/Domain/Branch/BranchResolverRegistry.php
+++ b/app/Domain/Branch/BranchResolverRegistry.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Domain\Branch;
+
+use App\Models\ApPayment;
+use App\Models\ArReceipt;
+use App\Models\AssetDepreciationRun;
+use App\Models\BankReconciliation;
+use App\Models\CustomerInvoice;
+use App\Models\GoodsReceipt;
+use App\Models\PeriodClosing;
+use App\Models\RecurringJournal;
+use App\Models\StockAdjustment;
+use App\Models\SupplierBill;
+use App\Models\SupplierReturn;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+class BranchResolverRegistry
+{
+    /**
+     * Maps a polymorphic type to how its branch is reached. No morph map is
+     * registered, so keys are FQCNs via ::class.
+     *
+     * @var array<class-string<Model>, BranchResolutionStrategy>
+     */
+    private const STRATEGIES = [
+        ApPayment::class => BranchResolutionStrategy::Direct,
+        ArReceipt::class => BranchResolutionStrategy::Direct,
+        CustomerInvoice::class => BranchResolutionStrategy::Direct,
+        SupplierBill::class => BranchResolutionStrategy::Direct,
+        GoodsReceipt::class => BranchResolutionStrategy::Warehouse,
+        StockAdjustment::class => BranchResolutionStrategy::Warehouse,
+        SupplierReturn::class => BranchResolutionStrategy::Warehouse,
+        BankReconciliation::class => BranchResolutionStrategy::None,
+        RecurringJournal::class => BranchResolutionStrategy::None,
+        PeriodClosing::class => BranchResolutionStrategy::None,
+        AssetDepreciationRun::class => BranchResolutionStrategy::None,
+    ];
+
+    /**
+     * Resolve the branch id for a polymorphic source model, or null when it
+     * has no resolvable branch (warehouse without a branch, or a None type).
+     *
+     * @throws InvalidArgumentException when the model's type is not registered
+     */
+    public function resolve(Model $source): ?int
+    {
+        return match ($this->strategyFor($source::class)) {
+            BranchResolutionStrategy::Direct => $this->intOrNull($source->getAttribute('branch_id')),
+            BranchResolutionStrategy::Warehouse => $this->resolveViaWarehouse($source),
+            BranchResolutionStrategy::None => null,
+        };
+    }
+
+    /**
+     * The eager-load relations needed to resolve a branch for the given type.
+     *
+     * @param  class-string<Model>  $type
+     * @return list<string>
+     */
+    public function relationsFor(string $type): array
+    {
+        return match ($this->strategyFor($type)) {
+            BranchResolutionStrategy::Warehouse => ['warehouse'],
+            default => [],
+        };
+    }
+
+    /**
+     * Types that can resolve to a branch (Direct or Warehouse), excluding None.
+     *
+     * @return list<class-string<Model>>
+     */
+    public function branchBearingTypes(): array
+    {
+        return array_keys(array_filter(
+            self::STRATEGIES,
+            static fn (BranchResolutionStrategy $strategy): bool => $strategy !== BranchResolutionStrategy::None,
+        ));
+    }
+
+    public function isRegistered(string $type): bool
+    {
+        return array_key_exists($type, self::STRATEGIES);
+    }
+
+    /**
+     * @param  class-string<Model>|string  $type
+     *
+     * @throws InvalidArgumentException
+     */
+    private function strategyFor(string $type): BranchResolutionStrategy
+    {
+        if (! array_key_exists($type, self::STRATEGIES)) {
+            throw new InvalidArgumentException(
+                "No branch resolution strategy registered for [{$type}]. " .
+                'Register it in ' . self::class . '::STRATEGIES (use BranchResolutionStrategy::None for intentionally unscopable types).',
+            );
+        }
+
+        return self::STRATEGIES[$type];
+    }
+
+    private function resolveViaWarehouse(Model $source): ?int
+    {
+        $warehouse = $source->getAttribute('warehouse');
+
+        if (! $warehouse instanceof Model) {
+            return null;
+        }
+
+        return $this->intOrNull($warehouse->getAttribute('branch_id'));
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        return $value !== null ? (int) $value : null;
+    }
+}

--- a/tests/Unit/Domain/Branch/BranchResolverRegistryTest.php
+++ b/tests/Unit/Domain/Branch/BranchResolverRegistryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Domain\Branch\BranchResolutionStrategy;
+use App\Domain\Branch\BranchResolverRegistry;
+use App\Models\ApPayment;
+use App\Models\Branch;
+use App\Models\Customer;
+use App\Models\GoodsReceipt;
+use App\Models\RecurringJournal;
+use App\Models\StockAdjustment;
+use App\Models\SupplierReturn;
+use App\Models\Warehouse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('branch-resolver');
+
+beforeEach(function () {
+    $this->registry = new BranchResolverRegistry;
+});
+
+it('resolves a direct-branch source via its own branch_id', function () {
+    $payment = ApPayment::factory()->create();
+
+    expect($this->registry->resolve($payment))->toBe($payment->branch_id);
+});
+
+it('resolves a warehouse-based source via warehouse branch_id', function () {
+    $branch = Branch::factory()->create();
+    $warehouse = Warehouse::factory()->create(['branch_id' => $branch->id]);
+    $receipt = GoodsReceipt::factory()->create(['warehouse_id' => $warehouse->id]);
+
+    expect($this->registry->resolve($receipt->fresh()))->toBe($branch->id);
+});
+
+it('returns null when a warehouse-based source has no branch', function () {
+    $warehouse = Warehouse::factory()->create(['branch_id' => null]);
+    $adjustment = StockAdjustment::factory()->create(['warehouse_id' => $warehouse->id]);
+
+    expect($this->registry->resolve($adjustment->fresh()))->toBeNull();
+});
+
+it('resolves SupplierReturn via its warehouse branch', function () {
+    $branch = Branch::factory()->create();
+    $warehouse = Warehouse::factory()->create(['branch_id' => $branch->id]);
+    $return = SupplierReturn::factory()->create(['warehouse_id' => $warehouse->id]);
+
+    expect($this->registry->resolve($return->fresh()))->toBe($branch->id);
+});
+
+it('throws for an unregistered type instead of silently returning null', function () {
+    $customer = Customer::factory()->create();
+
+    expect(fn () => $this->registry->resolve($customer))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('returns null for a registered None-strategy type', function () {
+    $recurring = RecurringJournal::factory()->create();
+
+    expect($this->registry->resolve($recurring))->toBeNull();
+});
+
+it('excludes None-strategy types from branch-bearing types', function () {
+    $types = $this->registry->branchBearingTypes();
+
+    expect($types)->not->toContain(RecurringJournal::class)
+        ->and($this->registry->isRegistered(RecurringJournal::class))->toBeTrue();
+});
+
+it('reports registration status per type', function () {
+    expect($this->registry->isRegistered(ApPayment::class))->toBeTrue()
+        ->and($this->registry->isRegistered(Customer::class))->toBeFalse();
+});
+
+it('lists only branch-bearing types', function () {
+    $types = $this->registry->branchBearingTypes();
+
+    expect($types)->toContain(ApPayment::class)
+        ->and($types)->toContain(GoodsReceipt::class)
+        ->and($types)->not->toContain(Customer::class);
+});
+
+it('returns the warehouse relation only for warehouse-based types', function () {
+    expect($this->registry->relationsFor(GoodsReceipt::class))->toBe(['warehouse'])
+        ->and($this->registry->relationsFor(ApPayment::class))->toBe([]);
+});
+
+it('maps strategies to the expected enum cases', function () {
+    expect($this->registry->relationsFor(StockAdjustment::class))->toBe(['warehouse']);
+
+    expect(BranchResolutionStrategy::cases())
+        ->toContain(BranchResolutionStrategy::Direct)
+        ->toContain(BranchResolutionStrategy::Warehouse)
+        ->toContain(BranchResolutionStrategy::None);
+});


### PR DESCRIPTION
## Summary

PR1 of 3 in the Pipeline/Approval dashboard branch-scoping initiative (Oracle-designed). This is the shared foundation — **no behavior change**.

Both the pipeline dashboard and the approval monitoring dashboard aggregate over polymorphic tables (`pipeline_entity_states`, `approval_requests`) whose targets resolve to a branch differently: some carry a direct `branch_id`, some reach it via `warehouse->branch_id`, and some have no branch at all. That resolution knowledge already existed implicitly inside the `journals:backfill-branch` command (PR #34). This PR extracts it into one place so PR2/PR3 can reuse it.

## What's in this PR

- **`BranchResolutionStrategy` enum** — `Direct` | `Warehouse` | `None`.
- **`BranchResolverRegistry`** (`app/Domain/Branch/`) — the single source of truth:
  - `resolve(Model): ?int` — branch id or null (warehouse without branch, or a `None` type).
  - `relationsFor(string): array` — eager-load hints (warehouse types need `['warehouse']`).
  - `branchBearingTypes(): array` — types that can resolve a branch (excludes `None`).
  - `isRegistered(string): bool`.
  - **Throws `InvalidArgumentException` on an unregistered type** — a new polymorphic type fails loud instead of silently resolving to null. No morph map is registered, so keys are FQCNs via `::class`.
- **Refactor `journals:backfill-branch`** to delegate resolution + relations + branch-bearing list to the registry. The no-branch journal source types (`BankReconciliation`, `RecurringJournal`, `PeriodClosing`, `AssetDepreciationRun`) are now registered as `None` first-class.

## Design notes (from Oracle consult)

- `None` is first-class and explicit (intentionally unscopable), distinct from "has a branch column but it's null" (a data gap). Unknown types throw.
- Registry is a write-time / backfill concern, not a query-time abstraction. PR2/PR3 will denormalize an indexed `branch_id` column onto each polymorphic table (populated on write + backfilled via this registry), so the dashboard queries collapse to a trivial `WHERE branch_id = ?` — matching the 5 existing branch-scoped dashboards and the `journal_entries.branch_id` precedent.
- Scoping semantics for the dashboards will be **EXCLUDE** (a selected branch shows only rows that positively resolve to it).

## Tested

- `sail test --group branch-resolver` → 11 passed (new registry unit tests, incl. the throw path + `None` path)
- `sail test --group journal-entries` → 48 passed (backfill refactor — no regression)
- `phpstan` clean, `duster` clean
