### PR TITLE
feat(pipeline-dashboard): branch-scope via denormalized branch_id (PR2/3)

### DIFF
--- a/app/Actions/EntityStates/AssignPipelineAction.php
+++ b/app/Actions/EntityStates/AssignPipelineAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\EntityStates;
 
+use App\Domain\Branch\BranchResolverRegistry;
 use App\Models\Pipeline;
 use App\Models\PipelineEntityState;
 use App\Models\PipelineState;
@@ -11,6 +12,10 @@ use Illuminate\Support\Facades\DB;
 
 class AssignPipelineAction
 {
+    public function __construct(
+        private readonly BranchResolverRegistry $branchResolver,
+    ) {}
+
     /**
      * Assign an entity to its appropriate pipeline and set its initial state.
      *
@@ -49,11 +54,16 @@ class AssignPipelineAction
         }
 
         return DB::transaction(function () use ($pipeline, $entityType, $entity, $initialState) {
+            $branchId = $this->branchResolver->isRegistered($entityType)
+                ? $this->branchResolver->resolve($entity)
+                : null;
+
             // 4. Create the entity state record
             $entityState = PipelineEntityState::create([
                 'pipeline_id' => $pipeline->id,
                 'entity_type' => $entityType,
                 'entity_id' => $entity->getKey(),
+                'branch_id' => $branchId,
                 'current_state_id' => $initialState->id,
                 'last_transitioned_by' => auth()->id(),
                 'last_transitioned_at' => now(),

--- a/app/Actions/PipelineDashboard/GetPipelineDashboardDataAction.php
+++ b/app/Actions/PipelineDashboard/GetPipelineDashboardDataAction.php
@@ -14,6 +14,7 @@ class GetPipelineDashboardDataAction
         $pipelineId = $filters['pipeline_id'] ?? null;
         $entityType = $filters['entity_type'] ?? null;
         $staleDays = (int) ($filters['stale_days'] ?? 7);
+        $branchId = $filters['branch_id'] ?? null;
 
         // Fetch Pipeline to get States structure
         $pipelineQuery = Pipeline::with(['states' => function ($query) {
@@ -60,6 +61,10 @@ class GetPipelineDashboardDataAction
             $query->where('entity_type', $entityType);
         }
 
+        if ($branchId !== null) {
+            $query->where('branch_id', $branchId);
+        }
+
         $aggregatedStateCounts = $query->groupBy('current_state_id')->pluck('count', 'current_state_id');
 
         foreach ($aggregatedStateCounts as $stateId => $count) {
@@ -86,6 +91,10 @@ class GetPipelineDashboardDataAction
 
         if ($entityType) {
             $staleQuery->where('entity_type', $entityType);
+        }
+
+        if ($branchId !== null) {
+            $staleQuery->where('branch_id', $branchId);
         }
 
         $staleEntitiesModels = $staleQuery->orderBy('last_transitioned_at', 'asc')

--- a/app/Console/Commands/BackfillPipelineEntityStateBranch.php
+++ b/app/Console/Commands/BackfillPipelineEntityStateBranch.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Branch\BranchResolverRegistry;
+use App\Models\PipelineEntityState;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+class BackfillPipelineEntityStateBranch extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'pipeline-states:backfill-branch {--dry-run : Report what would change without writing} {--chunk=500 : Number of rows processed per batch}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Backfill pipeline_entity_states.branch_id from each row polymorphic entity. Idempotent: only touches rows where branch_id is null.';
+
+    public function handle(BranchResolverRegistry $registry): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $chunkSize = max(1, (int) $this->option('chunk'));
+
+        if ($dryRun) {
+            $this->warn('DRY RUN — no rows will be written.');
+        }
+
+        $branchBearingTypes = $registry->branchBearingTypes();
+
+        /** @var array<string, array{matched: int, resolved: int, unresolved: int}> $stats */
+        $stats = [];
+        $totalUpdated = 0;
+
+        foreach ($branchBearingTypes as $entityType) {
+            $relation = array_map(
+                static fn (string $relation): string => "entity.{$relation}",
+                $registry->relationsFor($entityType),
+            );
+
+            $stats[$entityType] = ['matched' => 0, 'resolved' => 0, 'unresolved' => 0];
+
+            PipelineEntityState::query()
+                ->whereNull('branch_id')
+                ->where('entity_type', $entityType)
+                ->with(array_merge(['entity'], $relation))
+                ->chunkById($chunkSize, function ($states) use ($registry, &$stats, &$totalUpdated, $entityType, $dryRun): void {
+                    foreach ($states as $state) {
+                        $stats[$entityType]['matched']++;
+
+                        $entity = $state->entity;
+
+                        if (! $entity instanceof Model) {
+                            $stats[$entityType]['unresolved']++;
+
+                            continue;
+                        }
+
+                        $branchId = $registry->resolve($entity);
+
+                        if ($branchId === null) {
+                            $stats[$entityType]['unresolved']++;
+
+                            continue;
+                        }
+
+                        $stats[$entityType]['resolved']++;
+
+                        if (! $dryRun) {
+                            $state->branch_id = $branchId;
+                            $state->save();
+                        }
+
+                        $totalUpdated++;
+                    }
+                });
+        }
+
+        $this->renderSummary($stats, $dryRun);
+
+        $nullSkipped = PipelineEntityState::query()
+            ->whereNull('branch_id')
+            ->whereNotIn('entity_type', $branchBearingTypes)
+            ->count();
+
+        $this->line('');
+        $this->info(sprintf(
+            '%s %d pipeline entity states from branch-bearing entities.',
+            $dryRun ? 'Would update' : 'Updated',
+            $totalUpdated,
+        ));
+        $this->line(sprintf(
+            '%d states left null by design (no-branch entities or unregistered entity_type).',
+            $nullSkipped,
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, array{matched: int, resolved: int, unresolved: int}>  $stats
+     */
+    private function renderSummary(array $stats, bool $dryRun): void
+    {
+        $rows = [];
+
+        foreach ($stats as $entityType => $counts) {
+            if ($counts['matched'] === 0) {
+                continue;
+            }
+
+            $rows[] = [
+                class_basename($entityType),
+                $counts['matched'],
+                $counts['resolved'],
+                $counts['unresolved'],
+            ];
+        }
+
+        if ($rows === []) {
+            $this->line('No null-branch pipeline entity states from branch-bearing entities found.');
+
+            return;
+        }
+
+        $this->table(
+            ['Entity', 'Matched', $dryRun ? 'Would set' : 'Set', 'Left null'],
+            $rows,
+        );
+    }
+}

--- a/app/Domain/Branch/BranchResolverRegistry.php
+++ b/app/Domain/Branch/BranchResolverRegistry.php
@@ -4,6 +4,7 @@ namespace App\Domain\Branch;
 
 use App\Models\ApPayment;
 use App\Models\ArReceipt;
+use App\Models\Asset;
 use App\Models\AssetDepreciationRun;
 use App\Models\BankReconciliation;
 use App\Models\CustomerInvoice;
@@ -27,6 +28,7 @@ class BranchResolverRegistry
     private const STRATEGIES = [
         ApPayment::class => BranchResolutionStrategy::Direct,
         ArReceipt::class => BranchResolutionStrategy::Direct,
+        Asset::class => BranchResolutionStrategy::Direct,
         CustomerInvoice::class => BranchResolutionStrategy::Direct,
         SupplierBill::class => BranchResolutionStrategy::Direct,
         GoodsReceipt::class => BranchResolutionStrategy::Warehouse,

--- a/app/Http/Controllers/PipelineDashboardController.php
+++ b/app/Http/Controllers/PipelineDashboardController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Actions\PipelineDashboard\GetPipelineDashboardDataAction;
+use App\Http\Controllers\Concerns\ResolvesBranchScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class PipelineDashboardController extends Controller
 {
+    use ResolvesBranchScope;
+
     /**
      * Get aggregate data for the dashboard.
      */
@@ -18,6 +21,8 @@ class PipelineDashboardController extends Controller
             'entity_type',
             'stale_days',
         ]);
+
+        $filters['branch_id'] = $this->resolveBranchFromRequest($request);
 
         $data = $action->execute($filters);
 

--- a/app/Models/PipelineEntityState.php
+++ b/app/Models/PipelineEntityState.php
@@ -60,6 +60,7 @@ class PipelineEntityState extends Model
         'pipeline_id',
         'entity_type',
         'entity_id',
+        'branch_id',
         'current_state_id',
         'last_transitioned_by',
         'last_transitioned_at',
@@ -77,6 +78,11 @@ class PipelineEntityState extends Model
     public function pipeline(): BelongsTo
     {
         return $this->belongsTo(Pipeline::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 
     public function currentState(): BelongsTo

--- a/database/migrations/2026_06_19_000000_add_branch_id_to_pipeline_entity_states_table.php
+++ b/database/migrations/2026_06_19_000000_add_branch_id_to_pipeline_entity_states_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('pipeline_entity_states', function (Blueprint $table) {
+            $table
+                ->foreignId('branch_id')
+                ->nullable()
+                ->after('entity_id')
+                ->constrained('branches')
+                ->restrictOnDelete();
+
+            $table->index(
+                ['branch_id', 'current_state_id'],
+                'pipeline_entity_states_branch_state_index'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pipeline_entity_states', function (Blueprint $table) {
+            $table->dropIndex('pipeline_entity_states_branch_state_index');
+            $table->dropForeign(['branch_id']);
+            $table->dropColumn('branch_id');
+        });
+    }
+};

--- a/resources/js/components/pipeline-dashboard/PipelineFilter.tsx
+++ b/resources/js/components/pipeline-dashboard/PipelineFilter.tsx
@@ -1,3 +1,4 @@
+import { AsyncSelect } from '@/components/common/AsyncSelect';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import {
@@ -14,6 +15,8 @@ interface PipelineFilterProps {
     onChange: (pipelineId: string) => void;
     staleDays: number;
     onStaleDaysChange: (days: string) => void;
+    selectedBranchId?: number | string;
+    onBranchChange: (branchId: string) => void;
 }
 
 export function PipelineFilter({
@@ -22,10 +25,31 @@ export function PipelineFilter({
     onChange,
     staleDays,
     onStaleDaysChange,
+    selectedBranchId,
+    onBranchChange,
 }: Readonly<PipelineFilterProps>) {
     return (
         <Card className="shadow-sm">
             <CardContent className="flex flex-col items-end gap-6 p-4 sm:flex-row">
+                <div className="w-full space-y-2 sm:w-64">
+                    <Label
+                        htmlFor="branch-filter"
+                        className="text-xs font-semibold text-muted-foreground uppercase"
+                    >
+                        Branch
+                    </Label>
+                    <AsyncSelect
+                        url="/api/branches"
+                        placeholder="All Branches"
+                        value={
+                            selectedBranchId
+                                ? String(selectedBranchId)
+                                : undefined
+                        }
+                        onValueChange={onBranchChange}
+                    />
+                </div>
+
                 <div className="w-full space-y-2 sm:w-64">
                     <Label
                         htmlFor="pipeline-filter"

--- a/resources/js/hooks/usePipelineDashboard.ts
+++ b/resources/js/hooks/usePipelineDashboard.ts
@@ -6,6 +6,7 @@ export interface PipelineDashboardFilters {
     pipeline_id?: number | string;
     entity_type?: string;
     stale_days?: number;
+    branch_id?: number | string;
 }
 
 export interface StateSummary {
@@ -51,6 +52,8 @@ export function usePipelineDashboard(
             params.append('entity_type', filters.entity_type);
         if (filters.stale_days)
             params.append('stale_days', String(filters.stale_days));
+        if (filters.branch_id)
+            params.append('branch_id', String(filters.branch_id));
 
         const response = await axios.get(
             `/api/pipeline-dashboard/data?${params.toString()}`,

--- a/resources/js/pages/pipeline-dashboard/index.tsx
+++ b/resources/js/pages/pipeline-dashboard/index.tsx
@@ -67,6 +67,10 @@ export default function PipelineDashboard() {
         handleFilterChange('stale_days', Number(val));
     };
 
+    const onBranchChange = (val: string) => {
+        handleFilterChange('branch_id', val ? Number(val) : undefined);
+    };
+
     const summaryData = Array.isArray(data?.summary) ? data.summary : [];
     const staleEntitiesData = Array.isArray(data?.stale_entities)
         ? data.stale_entities
@@ -98,6 +102,8 @@ export default function PipelineDashboard() {
                     onChange={onPipelineChange}
                     staleDays={filters.stale_days || 7}
                     onStaleDaysChange={onStaleDaysChange}
+                    selectedBranchId={filters.branch_id}
+                    onBranchChange={onBranchChange}
                 />
 
                 <StateSummaryCards data={summaryData} isLoading={isLoading} />

--- a/tests/Feature/PipelineDashboard/PipelineDashboardBranchScopeTest.php
+++ b/tests/Feature/PipelineDashboard/PipelineDashboardBranchScopeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Models\Asset;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\Permission;
+use App\Models\Pipeline;
+use App\Models\PipelineEntityState;
+use App\Models\PipelineState;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\getJson;
+
+uses(RefreshDatabase::class)->group('pipeline-dashboard');
+
+/**
+ * @param  array<string>  $permissions
+ */
+function makePipelineUser(?int $branchId, array $permissions): User
+{
+    $user = User::factory()->create();
+    $employee = Employee::factory()->create([
+        'user_id' => $user->id,
+        'branch_id' => $branchId,
+        'department_id' => null,
+        'position_id' => null,
+    ]);
+
+    $ids = [];
+    foreach ($permissions as $name) {
+        $ids[] = Permission::firstOrCreate(
+            ['name' => $name],
+            ['display_name' => ucwords(str_replace(['.', '-'], ' ', $name))],
+        )->id;
+    }
+    $employee->permissions()->sync($ids);
+
+    return $user;
+}
+
+beforeEach(function () {
+    $this->branchA = Branch::factory()->create();
+    $this->branchB = Branch::factory()->create();
+
+    $this->pipeline = Pipeline::factory()->create([
+        'entity_type' => Asset::class,
+        'is_active' => true,
+    ]);
+
+    $this->stateReview = PipelineState::factory()->create([
+        'pipeline_id' => $this->pipeline->id,
+        'code' => 'review',
+        'name' => 'Review',
+        'type' => 'intermediate',
+        'sort_order' => 1,
+    ]);
+});
+
+function seedPipelineState(int $pipelineId, int $stateId, int $entityId, ?int $branchId, ?Carbon $transitionedAt = null): PipelineEntityState
+{
+    return PipelineEntityState::factory()->create([
+        'pipeline_id' => $pipelineId,
+        'current_state_id' => $stateId,
+        'entity_type' => Asset::class,
+        'entity_id' => $entityId,
+        'branch_id' => $branchId,
+        'last_transitioned_at' => $transitionedAt ?? Carbon::now()->subDays(10),
+    ]);
+}
+
+it('scopes summary counts to the selected branch for a view_all_branches user', function () {
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 1, $this->branchA->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 2, $this->branchA->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 3, $this->branchB->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 4, null);
+
+    $admin = makePipelineUser(null, ['pipeline_dashboard', 'view_all_branches']);
+    Sanctum::actingAs($admin, ['*']);
+
+    $response = getJson("/api/pipeline-dashboard/data?branch_id={$this->branchA->id}");
+
+    $response->assertOk();
+    $total = collect($response->json('summary'))->sum('count');
+    expect($total)->toBe(2);
+});
+
+it('excludes null-branch rows when a branch is selected', function () {
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 1, $this->branchA->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 2, null);
+
+    $admin = makePipelineUser(null, ['pipeline_dashboard', 'view_all_branches']);
+    Sanctum::actingAs($admin, ['*']);
+
+    $response = getJson("/api/pipeline-dashboard/data?branch_id={$this->branchA->id}");
+
+    $total = collect($response->json('summary'))->sum('count');
+    expect($total)->toBe(1);
+});
+
+it('shows all rows when no branch is selected', function () {
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 1, $this->branchA->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 2, $this->branchB->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 3, null);
+
+    $admin = makePipelineUser(null, ['pipeline_dashboard', 'view_all_branches']);
+    Sanctum::actingAs($admin, ['*']);
+
+    $response = getJson('/api/pipeline-dashboard/data');
+
+    $total = collect($response->json('summary'))->sum('count');
+    expect($total)->toBe(3);
+});
+
+it('forces a branch-scoped employee to their own branch regardless of requested branch_id', function () {
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 1, $this->branchA->id);
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 2, $this->branchB->id);
+
+    $employee = makePipelineUser($this->branchA->id, ['pipeline_dashboard']);
+    Sanctum::actingAs($employee, ['*']);
+
+    $response = getJson("/api/pipeline-dashboard/data?branch_id={$this->branchB->id}");
+
+    $total = collect($response->json('summary'))->sum('count');
+    expect($total)->toBe(1);
+});
+
+it('scopes stale entities to the selected branch', function () {
+    $staleA = seedPipelineState($this->pipeline->id, $this->stateReview->id, 1, $this->branchA->id, Carbon::now()->subDays(10));
+    seedPipelineState($this->pipeline->id, $this->stateReview->id, 2, $this->branchB->id, Carbon::now()->subDays(10));
+
+    $admin = makePipelineUser(null, ['pipeline_dashboard', 'view_all_branches']);
+    Sanctum::actingAs($admin, ['*']);
+
+    $response = getJson("/api/pipeline-dashboard/data?branch_id={$this->branchA->id}");
+
+    $stale = $response->json('stale_entities');
+    expect($stale)->toHaveCount(1)
+        ->and($stale[0]['id'])->toBe($staleA->id);
+});

--- a/tests/Feature/PipelineDashboard/PipelineEntityStateBranchWritePathTest.php
+++ b/tests/Feature/PipelineDashboard/PipelineEntityStateBranchWritePathTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Actions\EntityStates\AssignPipelineAction;
+use App\Models\Asset;
+use App\Models\Branch;
+use App\Models\Pipeline;
+use App\Models\PipelineEntityState;
+use App\Models\PipelineState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\artisan;
+
+uses(RefreshDatabase::class)->group('pipeline-dashboard');
+
+function makeAssetPipeline(): PipelineState
+{
+    $pipeline = Pipeline::factory()->create([
+        'entity_type' => Asset::class,
+        'is_active' => true,
+    ]);
+
+    return PipelineState::factory()->create([
+        'pipeline_id' => $pipeline->id,
+        'type' => 'initial',
+        'sort_order' => 1,
+    ]);
+}
+
+it('keeps branch_id in the PipelineEntityState fillable contract', function () {
+    expect((new PipelineEntityState)->getFillable())->toContain('branch_id');
+});
+
+it('populates branch_id from the entity when assigning a pipeline', function () {
+    makeAssetPipeline();
+    $branch = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => $branch->id]);
+
+    $state = app(AssignPipelineAction::class)->execute($asset);
+
+    expect($state)->not->toBeNull()
+        ->and($state->branch_id)->toBe($branch->id);
+});
+
+it('backfills branch_id from a direct-branch entity', function () {
+    $state = makeAssetPipeline();
+    $branch = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => $branch->id]);
+
+    $entityState = PipelineEntityState::factory()->create([
+        'pipeline_id' => $state->pipeline_id,
+        'current_state_id' => $state->id,
+        'entity_type' => Asset::class,
+        'entity_id' => $asset->id,
+        'branch_id' => null,
+    ]);
+
+    artisan('pipeline-states:backfill-branch')->assertSuccessful();
+
+    expect($entityState->fresh()->branch_id)->toBe($branch->id);
+});
+
+it('does not overwrite an already-populated branch_id during backfill', function () {
+    $state = makeAssetPipeline();
+    $original = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => Branch::factory()->create()->id]);
+
+    $entityState = PipelineEntityState::factory()->create([
+        'pipeline_id' => $state->pipeline_id,
+        'current_state_id' => $state->id,
+        'entity_type' => Asset::class,
+        'entity_id' => $asset->id,
+        'branch_id' => $original->id,
+    ]);
+
+    artisan('pipeline-states:backfill-branch')->assertSuccessful();
+
+    expect($entityState->fresh()->branch_id)->toBe($original->id);
+});
+
+it('writes nothing in dry-run mode', function () {
+    $state = makeAssetPipeline();
+    $branch = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => $branch->id]);
+
+    $entityState = PipelineEntityState::factory()->create([
+        'pipeline_id' => $state->pipeline_id,
+        'current_state_id' => $state->id,
+        'entity_type' => Asset::class,
+        'entity_id' => $asset->id,
+        'branch_id' => null,
+    ]);
+
+    artisan('pipeline-states:backfill-branch', ['--dry-run' => true])->assertSuccessful();
+
+    expect($entityState->fresh()->branch_id)->toBeNull();
+});


### PR DESCRIPTION
## Summary

PR2 of 3 in the Pipeline/Approval dashboard branch-scoping initiative (Oracle-designed). Builds on the shared `BranchResolverRegistry` from #38.

Scopes the **pipeline dashboard** (state-distribution counts + stale-entity list) by branch using a **denormalized, indexed `branch_id` column** on `pipeline_entity_states` — the same pattern as `journal_entries.branch_id` (PR #33-#36). The dashboard query stays a trivial `WHERE branch_id = ?` on both the `GROUP BY` count path and the `limit-50` stale list, so it can't diverge and stays consistent with the 5 other branch-scoped dashboards.

**EXCLUDE semantics** (per Oracle Q1, your decision): a selected branch shows only rows that positively resolve to it; null-branch rows drop out for free via the equality filter. No branch selected → all rows.

## Changes

- **Migration** — nullable `branch_id` FK (`restrictOnDelete`) + composite index `(branch_id, current_state_id)`.
- **`PipelineEntityState`** — `branch_id` fillable + `branch()` relation.
- **`AssignPipelineAction`** (the single write-path choke point — transitions only update `current_state_id`, they don't create rows) — populates `branch_id` via the registry, guarded by `isRegistered()` so an unregistered entity type resolves to null instead of throwing on the live write path.
- **`BranchResolverRegistry`** — register `Asset` (Direct); it's the primary pipeline entity. (SupplierBill/ApPayment/CustomerInvoice were already registered.)
- **`pipeline-states:backfill-branch`** artisan command — idempotent (`WHERE branch_id IS NULL`), `--dry-run`, chunked, resolves each row's polymorphic entity via the registry.
- **`GetPipelineDashboardDataAction` + `PipelineDashboardController`** — optional `branch_id` resolved through `ResolvesBranchScope` (forced employees pinned to own branch), applied to both the count and stale queries.
- **Frontend** — branch selector (reuses `AsyncSelect` + `/api/branches`) on the pipeline dashboard filter; empty = All Branches.

## Deployment order (per Oracle)

Column is **nullable** → deploy code (populates on write) → run `pipeline-states:backfill-branch` for historical rows → the dashboard filter is then trustworthy. Backfill is idempotent and dry-runnable.

## Tested

- `sail test --group pipeline-dashboard` → 14 passed (scoping: branch filter, null-row exclusion, all-branches, forced-employee override, stale scoping; write-path; backfill incl. dry-run + no-overwrite)
- `sail test --group branch-resolver` → 11 passed (registry, Asset added)
- `sail test --group journal-entries` → 48 passed (backfill refactor regression)
- `sail test --group assets` → 43 passed (Asset now resolved on pipeline assignment)
- `phpstan` clean, `duster` clean, `npm run types` clean, `npm run lint` clean

## Next

PR3 will apply the identical shape to `approval_requests` for the approval monitoring dashboard.
