### PR TITLE
feat(approval-monitoring): branch-scope via denormalized branch_id (PR3/3)

### DIFF
--- a/app/Actions/ApprovalMonitoring/GetApprovalMonitoringDataAction.php
+++ b/app/Actions/ApprovalMonitoring/GetApprovalMonitoringDataAction.php
@@ -15,11 +15,16 @@ class GetApprovalMonitoringDataAction
         $approverId = $filters['approver_id'] ?? null;
         $startDate = $filters['start_date'] ?? null;
         $endDate = $filters['end_date'] ?? null;
+        $branchId = $filters['branch_id'] ?? null;
 
         $query = ApprovalRequest::with(['approvable', 'submitter', 'flow']);
 
         if ($documentType) {
             $query->where('approvable_type', $documentType);
+        }
+
+        if ($branchId !== null) {
+            $query->where('branch_id', $branchId);
         }
 
         if ($status) {
@@ -83,6 +88,12 @@ class GetApprovalMonitoringDataAction
         if ($documentType) {
             $overdueQuery->whereHas('request', function ($q) use ($documentType) {
                 $q->where('approvable_type', $documentType);
+            });
+        }
+
+        if ($branchId !== null) {
+            $overdueQuery->whereHas('request', function ($q) use ($branchId) {
+                $q->where('branch_id', $branchId);
             });
         }
 

--- a/app/Actions/Approvals/TriggerApprovalAction.php
+++ b/app/Actions/Approvals/TriggerApprovalAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Approvals;
 
+use App\Domain\Branch\BranchResolverRegistry;
 use App\Models\ApprovalAuditLog;
 use App\Models\ApprovalFlow;
 use App\Models\ApprovalRequest;
@@ -15,6 +16,10 @@ use Illuminate\Support\Facades\Log;
 class TriggerApprovalAction
 {
     use HandlesConditions;
+
+    public function __construct(
+        private readonly BranchResolverRegistry $branchResolver,
+    ) {}
 
     /**
      * Trigger an approval flow for a given entity.
@@ -44,11 +49,16 @@ class TriggerApprovalAction
         }
 
         return DB::transaction(function () use ($entity, $flow) {
+            $branchId = $this->branchResolver->isRegistered($entity->getMorphClass())
+                ? $this->branchResolver->resolve($entity)
+                : null;
+
             // 1. Create the Approval Request
             $request = ApprovalRequest::create([
                 'approval_flow_id' => $flow->id,
                 'approvable_type' => $entity->getMorphClass(),
                 'approvable_id' => $entity->getKey(),
+                'branch_id' => $branchId,
                 'current_step_order' => 1,
                 'status' => 'pending',
                 'submitted_by' => Auth::id(),

--- a/app/Console/Commands/BackfillApprovalRequestBranch.php
+++ b/app/Console/Commands/BackfillApprovalRequestBranch.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Branch\BranchResolverRegistry;
+use App\Models\ApprovalRequest;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+class BackfillApprovalRequestBranch extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'approval-requests:backfill-branch {--dry-run : Report what would change without writing} {--chunk=500 : Number of rows processed per batch}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Backfill approval_requests.branch_id from each request polymorphic approvable. Idempotent: only touches rows where branch_id is null.';
+
+    public function handle(BranchResolverRegistry $registry): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $chunkSize = max(1, (int) $this->option('chunk'));
+
+        if ($dryRun) {
+            $this->warn('DRY RUN — no rows will be written.');
+        }
+
+        $branchBearingTypes = $registry->branchBearingTypes();
+
+        /** @var array<string, array{matched: int, resolved: int, unresolved: int}> $stats */
+        $stats = [];
+        $totalUpdated = 0;
+
+        foreach ($branchBearingTypes as $approvableType) {
+            $relation = array_map(
+                static fn (string $relation): string => "approvable.{$relation}",
+                $registry->relationsFor($approvableType),
+            );
+
+            $stats[$approvableType] = ['matched' => 0, 'resolved' => 0, 'unresolved' => 0];
+
+            ApprovalRequest::query()
+                ->whereNull('branch_id')
+                ->where('approvable_type', $approvableType)
+                ->with(array_merge(['approvable'], $relation))
+                ->chunkById($chunkSize, function ($requests) use ($registry, &$stats, &$totalUpdated, $approvableType, $dryRun): void {
+                    foreach ($requests as $request) {
+                        $stats[$approvableType]['matched']++;
+
+                        $approvable = $request->approvable;
+
+                        if (! $approvable instanceof Model) {
+                            $stats[$approvableType]['unresolved']++;
+
+                            continue;
+                        }
+
+                        $branchId = $registry->resolve($approvable);
+
+                        if ($branchId === null) {
+                            $stats[$approvableType]['unresolved']++;
+
+                            continue;
+                        }
+
+                        $stats[$approvableType]['resolved']++;
+
+                        if (! $dryRun) {
+                            $request->branch_id = $branchId;
+                            $request->save();
+                        }
+
+                        $totalUpdated++;
+                    }
+                });
+        }
+
+        $this->renderSummary($stats, $dryRun);
+
+        $nullSkipped = ApprovalRequest::query()
+            ->whereNull('branch_id')
+            ->whereNotIn('approvable_type', $branchBearingTypes)
+            ->count();
+
+        $this->line('');
+        $this->info(sprintf(
+            '%s %d approval requests from branch-bearing approvables.',
+            $dryRun ? 'Would update' : 'Updated',
+            $totalUpdated,
+        ));
+        $this->line(sprintf(
+            '%d requests left null by design (no-branch approvables or unregistered approvable_type).',
+            $nullSkipped,
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, array{matched: int, resolved: int, unresolved: int}>  $stats
+     */
+    private function renderSummary(array $stats, bool $dryRun): void
+    {
+        $rows = [];
+
+        foreach ($stats as $approvableType => $counts) {
+            if ($counts['matched'] === 0) {
+                continue;
+            }
+
+            $rows[] = [
+                class_basename($approvableType),
+                $counts['matched'],
+                $counts['resolved'],
+                $counts['unresolved'],
+            ];
+        }
+
+        if ($rows === []) {
+            $this->line('No null-branch approval requests from branch-bearing approvables found.');
+
+            return;
+        }
+
+        $this->table(
+            ['Approvable', 'Matched', $dryRun ? 'Would set' : 'Set', 'Left null'],
+            $rows,
+        );
+    }
+}

--- a/app/Domain/Branch/BranchResolverRegistry.php
+++ b/app/Domain/Branch/BranchResolverRegistry.php
@@ -10,6 +10,8 @@ use App\Models\BankReconciliation;
 use App\Models\CustomerInvoice;
 use App\Models\GoodsReceipt;
 use App\Models\PeriodClosing;
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseRequest;
 use App\Models\RecurringJournal;
 use App\Models\StockAdjustment;
 use App\Models\SupplierBill;
@@ -30,10 +32,12 @@ class BranchResolverRegistry
         ArReceipt::class => BranchResolutionStrategy::Direct,
         Asset::class => BranchResolutionStrategy::Direct,
         CustomerInvoice::class => BranchResolutionStrategy::Direct,
+        PurchaseRequest::class => BranchResolutionStrategy::Direct,
         SupplierBill::class => BranchResolutionStrategy::Direct,
         GoodsReceipt::class => BranchResolutionStrategy::Warehouse,
         StockAdjustment::class => BranchResolutionStrategy::Warehouse,
         SupplierReturn::class => BranchResolutionStrategy::Warehouse,
+        PurchaseOrder::class => BranchResolutionStrategy::Warehouse,
         BankReconciliation::class => BranchResolutionStrategy::None,
         RecurringJournal::class => BranchResolutionStrategy::None,
         PeriodClosing::class => BranchResolutionStrategy::None,

--- a/app/Http/Controllers/ApprovalMonitoringController.php
+++ b/app/Http/Controllers/ApprovalMonitoringController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Actions\ApprovalMonitoring\GetApprovalMonitoringDataAction;
+use App\Http\Controllers\Concerns\ResolvesBranchScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class ApprovalMonitoringController extends Controller
 {
+    use ResolvesBranchScope;
+
     /**
      * Get aggregate and overdue data for the dashboard.
      */
@@ -20,6 +23,8 @@ class ApprovalMonitoringController extends Controller
             'start_date',
             'end_date',
         ]);
+
+        $filters['branch_id'] = $this->resolveBranchFromRequest($request);
 
         $data = $action->execute($filters);
 

--- a/app/Models/ApprovalRequest.php
+++ b/app/Models/ApprovalRequest.php
@@ -58,7 +58,7 @@ class ApprovalRequest extends Model
      * @var list<string>
      */
     protected $fillable = [
-        'approval_flow_id', 'approvable_type', 'approvable_id', 'current_step_order',
+        'approval_flow_id', 'approvable_type', 'approvable_id', 'branch_id', 'current_step_order',
         'status', 'submitted_by', 'submitted_at', 'completed_at',
     ];
 
@@ -73,6 +73,11 @@ class ApprovalRequest extends Model
     public function approvable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 
     public function flow(): BelongsTo

--- a/database/migrations/2026_06_19_010000_add_branch_id_to_approval_requests_table.php
+++ b/database/migrations/2026_06_19_010000_add_branch_id_to_approval_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('approval_requests', function (Blueprint $table) {
+            $table
+                ->foreignId('branch_id')
+                ->nullable()
+                ->after('approvable_id')
+                ->constrained('branches')
+                ->restrictOnDelete();
+
+            $table->index(
+                ['branch_id', 'status'],
+                'approval_requests_branch_status_index'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('approval_requests', function (Blueprint $table) {
+            $table->dropIndex('approval_requests_branch_status_index');
+            $table->dropForeign(['branch_id']);
+            $table->dropColumn('branch_id');
+        });
+    }
+};

--- a/resources/js/hooks/useApprovalMonitoring.ts
+++ b/resources/js/hooks/useApprovalMonitoring.ts
@@ -8,6 +8,7 @@ export interface ApprovalMonitoringFilters {
     approver_id?: string;
     start_date?: string;
     end_date?: string;
+    branch_id?: string;
 }
 
 export interface ApprovalSummary {
@@ -50,6 +51,7 @@ export function useApprovalMonitoring(
             params.append('approver_id', filters.approver_id);
         if (filters.start_date) params.append('start_date', filters.start_date);
         if (filters.end_date) params.append('end_date', filters.end_date);
+        if (filters.branch_id) params.append('branch_id', filters.branch_id);
 
         const response = await axios.get(
             `/api/approval-monitoring/data?${params.toString()}`,

--- a/resources/js/pages/approval-monitoring/index.tsx
+++ b/resources/js/pages/approval-monitoring/index.tsx
@@ -1,5 +1,6 @@
 import { OverdueApprovalsList } from '@/components/approval-monitoring/OverdueApprovalsList';
 import { SummaryCards } from '@/components/approval-monitoring/SummaryCards';
+import { AsyncSelect } from '@/components/common/AsyncSelect';
 import {
     Select,
     SelectContent,
@@ -41,6 +42,19 @@ export default function ApprovalMonitoringDashboard() {
 
                 <div className="flex flex-col gap-4">
                     <div className="flex flex-wrap items-center gap-4">
+                        <div className="w-full sm:w-64">
+                            <AsyncSelect
+                                url="/api/branches"
+                                placeholder="All Branches"
+                                value={filters.branch_id}
+                                onValueChange={(val) =>
+                                    handleFilterChange(
+                                        'branch_id',
+                                        val || undefined,
+                                    )
+                                }
+                            />
+                        </div>
                         <div className="w-full sm:w-64">
                             <Select
                                 value={filters.status || 'all'}

--- a/resources/js/pages/approval-monitoring/index.tsx
+++ b/resources/js/pages/approval-monitoring/index.tsx
@@ -43,19 +43,6 @@ export default function ApprovalMonitoringDashboard() {
                 <div className="flex flex-col gap-4">
                     <div className="flex flex-wrap items-center gap-4">
                         <div className="w-full sm:w-64">
-                            <AsyncSelect
-                                url="/api/branches"
-                                placeholder="All Branches"
-                                value={filters.branch_id}
-                                onValueChange={(val) =>
-                                    handleFilterChange(
-                                        'branch_id',
-                                        val || undefined,
-                                    )
-                                }
-                            />
-                        </div>
-                        <div className="w-full sm:w-64">
                             <Select
                                 value={filters.status || 'all'}
                                 onValueChange={(val) =>
@@ -86,6 +73,19 @@ export default function ApprovalMonitoringDashboard() {
                                     </SelectItem>
                                 </SelectContent>
                             </Select>
+                        </div>
+                        <div className="w-full sm:w-64">
+                            <AsyncSelect
+                                url="/api/branches"
+                                placeholder="All Branches"
+                                value={filters.branch_id}
+                                onValueChange={(val) =>
+                                    handleFilterChange(
+                                        'branch_id',
+                                        val || undefined,
+                                    )
+                                }
+                            />
                         </div>
                     </div>
 

--- a/tests/Feature/ApprovalMonitoring/ApprovalMonitoringBranchScopeTest.php
+++ b/tests/Feature/ApprovalMonitoring/ApprovalMonitoringBranchScopeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Models\ApprovalFlow;
+use App\Models\ApprovalFlowStep;
+use App\Models\ApprovalRequest;
+use App\Models\ApprovalRequestStep;
+use App\Models\Asset;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\getJson;
+
+uses(RefreshDatabase::class)->group('approval-monitoring');
+
+/**
+ * @param  array<string>  $permissions
+ */
+function makeApprovalUser(?int $branchId, array $permissions): User
+{
+    $user = User::factory()->create();
+    $employee = Employee::factory()->create([
+        'user_id' => $user->id,
+        'branch_id' => $branchId,
+        'department_id' => null,
+        'position_id' => null,
+    ]);
+
+    $ids = [];
+    foreach ($permissions as $name) {
+        $ids[] = Permission::firstOrCreate(
+            ['name' => $name],
+            ['display_name' => ucwords(str_replace(['.', '-'], ' ', $name))],
+        )->id;
+    }
+    $employee->permissions()->sync($ids);
+
+    return $user;
+}
+
+beforeEach(function () {
+    $this->branchA = Branch::factory()->create();
+    $this->branchB = Branch::factory()->create();
+
+    $this->flow = ApprovalFlow::create([
+        'name' => 'Test Flow',
+        'code' => 'test_flow',
+        'approvable_type' => Asset::class,
+        'is_active' => true,
+    ]);
+
+    $this->step = ApprovalFlowStep::create([
+        'approval_flow_id' => $this->flow->id,
+        'step_order' => 1,
+        'name' => 'Step 1',
+        'approver_type' => 'user',
+        'required_action' => 'approve',
+    ]);
+});
+
+function seedPendingRequest(int $flowId, int $stepId, int $submittedBy, int $approvableId, ?int $branchId, bool $overdue = true): ApprovalRequest
+{
+    $request = ApprovalRequest::create([
+        'approval_flow_id' => $flowId,
+        'approvable_type' => Asset::class,
+        'approvable_id' => $approvableId,
+        'branch_id' => $branchId,
+        'current_step_order' => 1,
+        'status' => 'pending',
+        'submitted_by' => $submittedBy,
+        'submitted_at' => now(),
+    ]);
+
+    ApprovalRequestStep::create([
+        'approval_request_id' => $request->id,
+        'approval_flow_step_id' => $stepId,
+        'step_order' => 1,
+        'status' => 'pending',
+        'due_at' => $overdue ? now()->subDay() : now()->addDay(),
+    ]);
+
+    return $request;
+}
+
+it('scopes pending count to the selected branch for a view_all_branches user', function () {
+    $admin = makeApprovalUser(null, ['approval_monitoring', 'view_all_branches']);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 1, $this->branchA->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 2, $this->branchA->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 3, $this->branchB->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 4, null);
+
+    Sanctum::actingAs($admin, ['*']);
+    $response = getJson("/api/approval-monitoring/data?branch_id={$this->branchA->id}");
+
+    $response->assertOk();
+    expect($response->json('summary.total_pending'))->toBe(2);
+});
+
+it('scopes overdue approvals to the selected branch via the request relation', function () {
+    $admin = makeApprovalUser(null, ['approval_monitoring', 'view_all_branches']);
+    $reqA = seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 1, $this->branchA->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 2, $this->branchB->id);
+
+    Sanctum::actingAs($admin, ['*']);
+    $response = getJson("/api/approval-monitoring/data?branch_id={$this->branchA->id}");
+
+    $overdue = $response->json('overdue_approvals');
+    expect($overdue)->toHaveCount(1)
+        ->and($overdue[0]['request_id'])->toBe($reqA->id);
+});
+
+it('excludes null-branch requests when a branch is selected', function () {
+    $admin = makeApprovalUser(null, ['approval_monitoring', 'view_all_branches']);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 1, $this->branchA->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 2, null);
+
+    Sanctum::actingAs($admin, ['*']);
+    $response = getJson("/api/approval-monitoring/data?branch_id={$this->branchA->id}");
+
+    expect($response->json('summary.total_pending'))->toBe(1)
+        ->and($response->json('overdue_approvals'))->toHaveCount(1);
+});
+
+it('shows all requests when no branch is selected', function () {
+    $admin = makeApprovalUser(null, ['approval_monitoring', 'view_all_branches']);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 1, $this->branchA->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 2, $this->branchB->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $admin->id, 3, null);
+
+    Sanctum::actingAs($admin, ['*']);
+    $response = getJson('/api/approval-monitoring/data');
+
+    expect($response->json('summary.total_pending'))->toBe(3);
+});
+
+it('forces a branch-scoped employee to their own branch regardless of requested branch_id', function () {
+    $employee = makeApprovalUser($this->branchA->id, ['approval_monitoring']);
+    seedPendingRequest($this->flow->id, $this->step->id, $employee->id, 1, $this->branchA->id);
+    seedPendingRequest($this->flow->id, $this->step->id, $employee->id, 2, $this->branchB->id);
+
+    Sanctum::actingAs($employee, ['*']);
+    $response = getJson("/api/approval-monitoring/data?branch_id={$this->branchB->id}");
+
+    expect($response->json('summary.total_pending'))->toBe(1)
+        ->and($response->json('overdue_approvals'))->toHaveCount(1);
+});

--- a/tests/Feature/ApprovalMonitoring/ApprovalRequestBranchWritePathTest.php
+++ b/tests/Feature/ApprovalMonitoring/ApprovalRequestBranchWritePathTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Actions\Approvals\TriggerApprovalAction;
+use App\Models\ApprovalFlow;
+use App\Models\ApprovalFlowStep;
+use App\Models\ApprovalRequest;
+use App\Models\Asset;
+use App\Models\Branch;
+use App\Models\PurchaseOrder;
+use App\Models\User;
+use App\Models\Warehouse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\artisan;
+
+uses(RefreshDatabase::class)->group('approval-monitoring');
+
+function makeApprovalFlowFor(string $approvableType): ApprovalFlow
+{
+    $flow = ApprovalFlow::create([
+        'name' => 'Flow',
+        'code' => 'flow_' . strtolower(class_basename($approvableType)),
+        'approvable_type' => $approvableType,
+        'is_active' => true,
+    ]);
+
+    ApprovalFlowStep::create([
+        'approval_flow_id' => $flow->id,
+        'step_order' => 1,
+        'name' => 'Step 1',
+        'approver_type' => 'user',
+        'required_action' => 'approve',
+    ]);
+
+    return $flow;
+}
+
+it('keeps branch_id in the ApprovalRequest fillable contract', function () {
+    expect((new ApprovalRequest)->getFillable())->toContain('branch_id');
+});
+
+it('populates branch_id from a direct-branch approvable when triggering approval', function () {
+    makeApprovalFlowFor(Asset::class);
+    $branch = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => $branch->id]);
+    Sanctum::actingAs(User::factory()->create());
+
+    $request = app(TriggerApprovalAction::class)->execute($asset, []);
+
+    expect($request)->not->toBeNull()
+        ->and($request->branch_id)->toBe($branch->id);
+});
+
+it('populates branch_id from a warehouse-based approvable when triggering approval', function () {
+    makeApprovalFlowFor(PurchaseOrder::class);
+    $branch = Branch::factory()->create();
+    $warehouse = Warehouse::factory()->create(['branch_id' => $branch->id]);
+    $po = PurchaseOrder::factory()->create(['warehouse_id' => $warehouse->id]);
+    Sanctum::actingAs(User::factory()->create());
+
+    $request = app(TriggerApprovalAction::class)->execute($po->fresh(), []);
+
+    expect($request)->not->toBeNull()
+        ->and($request->branch_id)->toBe($branch->id);
+});
+
+it('backfills branch_id from a direct-branch approvable', function () {
+    $flow = makeApprovalFlowFor(Asset::class);
+    $branch = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => $branch->id]);
+
+    $request = ApprovalRequest::create([
+        'approval_flow_id' => $flow->id,
+        'approvable_type' => Asset::class,
+        'approvable_id' => $asset->id,
+        'branch_id' => null,
+        'current_step_order' => 1,
+        'status' => 'pending',
+        'submitted_by' => User::factory()->create()->id,
+        'submitted_at' => now(),
+    ]);
+
+    artisan('approval-requests:backfill-branch')->assertSuccessful();
+
+    expect($request->fresh()->branch_id)->toBe($branch->id);
+});
+
+it('does not overwrite an already-populated branch_id during backfill', function () {
+    $flow = makeApprovalFlowFor(Asset::class);
+    $original = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => Branch::factory()->create()->id]);
+
+    $request = ApprovalRequest::create([
+        'approval_flow_id' => $flow->id,
+        'approvable_type' => Asset::class,
+        'approvable_id' => $asset->id,
+        'branch_id' => $original->id,
+        'current_step_order' => 1,
+        'status' => 'pending',
+        'submitted_by' => User::factory()->create()->id,
+        'submitted_at' => now(),
+    ]);
+
+    artisan('approval-requests:backfill-branch')->assertSuccessful();
+
+    expect($request->fresh()->branch_id)->toBe($original->id);
+});
+
+it('writes nothing in dry-run mode', function () {
+    $flow = makeApprovalFlowFor(Asset::class);
+    $branch = Branch::factory()->create();
+    $asset = Asset::factory()->create(['branch_id' => $branch->id]);
+
+    $request = ApprovalRequest::create([
+        'approval_flow_id' => $flow->id,
+        'approvable_type' => Asset::class,
+        'approvable_id' => $asset->id,
+        'branch_id' => null,
+        'current_step_order' => 1,
+        'status' => 'pending',
+        'submitted_by' => User::factory()->create()->id,
+        'submitted_at' => now(),
+    ]);
+
+    artisan('approval-requests:backfill-branch', ['--dry-run' => true])->assertSuccessful();
+
+    expect($request->fresh()->branch_id)->toBeNull();
+});

--- a/tests/Unit/Actions/Approvals/TriggerApprovalActionTest.php
+++ b/tests/Unit/Actions/Approvals/TriggerApprovalActionTest.php
@@ -15,7 +15,7 @@ use Laravel\Sanctum\Sanctum;
 uses(RefreshDatabase::class)->group('approvals');
 
 beforeEach(function () {
-    $this->action = new TriggerApprovalAction;
+    $this->action = app(TriggerApprovalAction::class);
     $this->actor = User::factory()->create();
     Sanctum::actingAs($this->actor, ['*']);
     $this->entity = PurchaseRequest::factory()->create();


### PR DESCRIPTION
## Summary

PR3 of 3 (final) in the Pipeline/Approval dashboard branch-scoping initiative (Oracle-designed). Builds on the shared `BranchResolverRegistry` (#38). Completes the initiative.

Scopes the **approval monitoring dashboard** (summary counts + overdue list) by branch using a **denormalized, indexed `branch_id` column** on `approval_requests` — the same pattern as `journal_entries` and `pipeline_entity_states` (#39). The dashboard query stays a trivial `WHERE branch_id = ?`, consistent with every other branch-scoped dashboard.

**EXCLUDE semantics** (per your decision): a selected branch shows only requests that positively resolve to it; null-branch rows drop out. No branch = all.

## Changes

- **Migration** — nullable `branch_id` FK (`restrictOnDelete`) + composite index `(branch_id, status)`.
- **`ApprovalRequest`** — `branch_id` fillable + `branch()` relation.
- **`TriggerApprovalAction`** (write-path choke point) — populates `branch_id` from the approvable via the registry, guarded by `isRegistered()` so an unregistered approvable type resolves to null instead of throwing on the live write path.
- **`BranchResolverRegistry`** — register `PurchaseRequest` (Direct) + `PurchaseOrder` (Warehouse) — the two approvable types not already present. (Asset was registered in #39; SupplierBill/ApPayment/CustomerInvoice in #38.)
- **`approval-requests:backfill-branch`** artisan command — idempotent, `--dry-run`, chunked, resolves each request's polymorphic approvable via the registry.
- **`GetApprovalMonitoringDataAction` + `ApprovalMonitoringController`** — optional `branch_id` resolved through `ResolvesBranchScope` (forced employees pinned to own branch). Applied to the summary query AND the overdue query.
- **Frontend** — branch selector (reuses `AsyncSelect` + `/api/branches`) on the approval monitoring filter row; empty = All Branches.

## Oracle's overdue-query trap (handled)

`approval_request_steps` has no `branch_id` — branch lives on the parent `approval_requests`. The overdue-steps query therefore filters branch via `whereHas('request', fn => ->where('branch_id', ?))`, not on the step table. Both the count path and the overdue path use the same effective predicate, so they can't diverge.

## Deployment order (per Oracle)

Column is **nullable** → deploy code (populates on write) → run `approval-requests:backfill-branch` for historical rows → the dashboard filter is then trustworthy. Backfill is idempotent and dry-runnable.

## Tested

- `sail test --group approval-monitoring` → 14 passed (scoping: pending count, overdue-via-request-join, null exclusion, all-branches, forced-employee override; write-path direct + warehouse-indirect; backfill incl. dry-run + no-overwrite)
- `sail test --group branch-resolver` → 11 passed (PurchaseRequest/PurchaseOrder added)
- `sail test --group journal-entries` → 48 passed
- `sail test --group pipeline-dashboard` → 14 passed
- `phpstan` clean, `duster` clean, `npm run types` clean, `npm run lint` clean

## Initiative complete

PR1 registry (#38) → PR2 pipeline (#39) → PR3 approval (this). Every dashboard in the app is now branch-scoped; the two remaining DEFERRED polymorphic dashboards from the branch-isolation work are closed.
