### PR TITLE
test(dashboards): add branch-filter E2E coverage for pipeline + approval monitoring

### DIFF
--- a/tests/e2e/approval-monitoring/approval-monitoring.spec.ts
+++ b/tests/e2e/approval-monitoring/approval-monitoring.spec.ts
@@ -105,4 +105,27 @@ test.describe('Approval Monitoring Dashboard', () => {
             await expect(page.getByRole('columnheader', { name: 'Submitter' })).toBeVisible();
         }
     });
+
+    test('branch filter scopes the dashboard request', async ({ page }) => {
+        await page.goto('/approval-monitoring');
+        await page.waitForResponse(r => r.url().includes('/api/approval-monitoring/data') && r.status() < 400);
+
+        const branchSelect = page.getByRole('combobox').filter({ hasText: 'All Branches' });
+        await expect(branchSelect).toBeVisible();
+        await branchSelect.click();
+
+        await expect(page.getByPlaceholder('Search...')).toBeVisible();
+        const firstBranch = page.locator('ul[aria-busy="false"] button').first();
+        await expect(firstBranch).toBeVisible({ timeout: 10000 });
+
+        const scopedRequest = page.waitForResponse(
+            r =>
+                r.url().includes('/api/approval-monitoring/data') &&
+                r.url().includes('branch_id=') &&
+                r.status() < 400,
+            { timeout: 15000 },
+        );
+        await firstBranch.click();
+        await scopedRequest;
+    });
 });

--- a/tests/e2e/pipeline-dashboard/pipeline-dashboard.spec.ts
+++ b/tests/e2e/pipeline-dashboard/pipeline-dashboard.spec.ts
@@ -99,4 +99,30 @@ test.describe('Pipeline Dashboard', () => {
 
     expect(hasChart || hasLegend || hasEmpty).toBeTruthy();
   });
+
+  test('branch filter scopes the dashboard request', async ({ page }) => {
+    const dataPromise = waitForPipelineDashboardData(page);
+    await page.goto('/pipeline-dashboard');
+    await dataPromise;
+
+    const branchSelect = page
+      .getByRole('combobox')
+      .filter({ hasText: 'All Branches' });
+    await expect(branchSelect).toBeVisible({ timeout: 10000 });
+    await branchSelect.click();
+
+    await expect(page.getByPlaceholder('Search...')).toBeVisible();
+    const firstBranch = page.locator('ul[aria-busy="false"] button').first();
+    await expect(firstBranch).toBeVisible({ timeout: 10000 });
+
+    const scopedRequest = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/pipeline-dashboard/data') &&
+        response.url().includes('branch_id=') &&
+        response.status() < 400,
+      { timeout: 15000 },
+    );
+    await firstBranch.click();
+    await scopedRequest;
+  });
 });


### PR DESCRIPTION
## Summary
Adds E2E regression coverage for the branch selectors shipped in #39 (pipeline dashboard) and #40 (approval monitoring). Until now the EXCLUDE branch-scoping was only locked at the backend test layer — nothing guarded the frontend selector wiring or combobox ordering.

Each new spec:
- opens the branch combobox (placeholder "All Branches"),
- picks the first branch from the async list,
- asserts the dashboard re-fetches with a `branch_id=` query param.

## Why
Two CI failures during the #40 rollout came from the frontend layer (combobox `.first()` ordering, branch_id wiring) — exactly the class of regression backend tests cannot catch. These specs close that gap.

## Tested
- `npm run lint` clean.
- Local Playwright: `tests/e2e/approval-monitoring/` + `tests/e2e/pipeline-dashboard/` → 10 passed (incl. 2 new branch-filter cases).

## Scope
Test-only. No production code touched.
