### PR TITLE
feat(journal-lines): add nullable branch_id to journal_entry_lines (PR1/2b)

### DIFF
--- a/app/Models/JournalEntryLine.php
+++ b/app/Models/JournalEntryLine.php
@@ -12,12 +12,14 @@ use Illuminate\Support\Carbon;
  * @property int $id
  * @property int $journal_entry_id
  * @property int $account_id
+ * @property int|null $branch_id
  * @property numeric $debit
  * @property numeric $credit
  * @property string|null $memo
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Account $account
+ * @property-read Branch|null $branch
  * @property-read float $amount
  * @property-read float $net_amount
  * @property-read string $type
@@ -28,6 +30,7 @@ use Illuminate\Support\Carbon;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine whereAccountId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine whereBranchId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine whereCredit($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|JournalEntryLine whereDebit($value)
@@ -51,6 +54,7 @@ class JournalEntryLine extends Model
     protected $fillable = [
         'journal_entry_id',
         'account_id',
+        'branch_id',
         'debit',
         'credit',
         'memo',
@@ -72,6 +76,11 @@ class JournalEntryLine extends Model
     public function account(): BelongsTo
     {
         return $this->belongsTo(Account::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 
     /**

--- a/database/migrations/2026_06_20_000000_add_branch_id_to_journal_entry_lines_table.php
+++ b/database/migrations/2026_06_20_000000_add_branch_id_to_journal_entry_lines_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('journal_entry_lines', function (Blueprint $table) {
+            $table
+                ->foreignId('branch_id')
+                ->nullable()
+                ->after('account_id')
+                ->constrained('branches')
+                ->restrictOnDelete();
+
+            $table->index(
+                ['branch_id', 'account_id'],
+                'journal_entry_lines_branch_account_index'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('journal_entry_lines', function (Blueprint $table) {
+            $table->dropForeign(['branch_id']);
+            $table->dropIndex('journal_entry_lines_branch_account_index');
+            $table->dropColumn('branch_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
First step (PR1) of **per-branch financial statements** (scope 2b). Adds a nullable `branch_id` to `journal_entry_lines`:
- Migration: nullable `branch_id` FK to `branches` (`restrictOnDelete`) + composite index `(branch_id, account_id)`.
- Model: `branch_id` in `$fillable`, `branch()` relation, regenerated ide-helper PHPDoc.

**No behavior change.** Nothing populates or reads the column yet — write-path population, backfill, and report switch land in later PRs. This foundation is required by both the full and reduced 2b paths.

## Design context
Full design + staged PR plan: `.sisyphus/plans/per-branch-financial-statements-2b.md` (Oracle-designed, Momus-reviewed). Detection counts on current data show zero cross-branch journals, so the later clearing engine may be dormant — scope decision pending. PR1 is safe and needed regardless.

## Migration note
`down()` drops the FK **before** the index: MariaDB uses the composite `(branch_id, account_id)` index (branch_id leftmost) to satisfy the foreign key, so the index can't be dropped while the FK exists.

## Tested
- `migrate` up + `migrate:rollback` + re-migrate: clean.
- `phpstan` (model): no errors. `duster fix`: clean.
- `sail test`: journal-entries 48, posting-journals 3, reports 31 — all pass (zero regression).
