### PR TITLE
feat(reports): per-branch balance sheet, trial balance & cash flow (PR2/2b)

### DIFF
--- a/app/Exports/BalanceSheetReportExport.php
+++ b/app/Exports/BalanceSheetReportExport.php
@@ -13,6 +13,7 @@ class BalanceSheetReportExport extends AbstractFinancialReportExport
         $report = app(FinancialReportService::class)->getBalanceSheet(
             $this->resolveFiscalYearId(),
             $this->resolveComparisonYearId(),
+            $this->resolveBranchId(),
         );
 
         $rows = [];

--- a/app/Exports/CashFlowReportExport.php
+++ b/app/Exports/CashFlowReportExport.php
@@ -16,7 +16,11 @@ class CashFlowReportExport implements FromCollection, ShouldAutoSize, WithHeadin
 
     public function collection(): Collection
     {
-        $rows = app(FinancialReportService::class)->getCashFlow((int) $this->filters['fiscal_year_id']);
+        $branchId = isset($this->filters['branch_id']) && $this->filters['branch_id'] !== ''
+            ? (int) $this->filters['branch_id']
+            : null;
+
+        $rows = app(FinancialReportService::class)->getCashFlow((int) $this->filters['fiscal_year_id'], $branchId);
 
         return collect($rows)->map(fn (array $row): array => [
             $row['code'],

--- a/app/Exports/Concerns/AbstractFinancialReportExport.php
+++ b/app/Exports/Concerns/AbstractFinancialReportExport.php
@@ -57,4 +57,15 @@ abstract class AbstractFinancialReportExport implements FromCollection, ShouldAu
     {
         return (int) $this->filters['fiscal_year_id'];
     }
+
+    protected function resolveBranchId(): ?int
+    {
+        $branchId = $this->filters['branch_id'] ?? null;
+
+        if ($branchId === null || $branchId === '') {
+            return null;
+        }
+
+        return (int) $branchId;
+    }
 }

--- a/app/Exports/TrialBalanceFinancialReportExport.php
+++ b/app/Exports/TrialBalanceFinancialReportExport.php
@@ -16,7 +16,11 @@ class TrialBalanceFinancialReportExport implements FromCollection, ShouldAutoSiz
 
     public function collection(): Collection
     {
-        $rows = app(FinancialReportService::class)->getTrialBalance((int) $this->filters['fiscal_year_id']);
+        $branchId = isset($this->filters['branch_id']) && $this->filters['branch_id'] !== ''
+            ? (int) $this->filters['branch_id']
+            : null;
+
+        $rows = app(FinancialReportService::class)->getTrialBalance((int) $this->filters['fiscal_year_id'], $branchId);
 
         return collect($rows)->map(fn (array $row): array => [
             $row['code'],

--- a/app/Http/Controllers/Concerns/InteractsWithFinancialReportRequest.php
+++ b/app/Http/Controllers/Concerns/InteractsWithFinancialReportRequest.php
@@ -55,6 +55,17 @@ trait InteractsWithFinancialReportRequest
         return (int) $selectedYearId;
     }
 
+    protected function resolveBranchId(Request $request): ?int
+    {
+        $branchId = $request->input('branch_id');
+
+        if ($branchId === null || $branchId === '') {
+            return null;
+        }
+
+        return (int) $branchId;
+    }
+
     /**
      * @param  Collection<int, FiscalYear>  $fiscalYears
      */

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -40,7 +40,8 @@ class ReportController extends Controller
         $report = [];
         $computedSections = [];
         if ($selectedYearId) {
-            $report = $this->reportService->getTrialBalance($selectedYearId);
+            $branchId = $this->resolveBranchId($request);
+            $report = $this->reportService->getTrialBalance($selectedYearId, $branchId);
             $config = $this->configurationResolver->execute(ReportConfiguration::TYPE_TRIAL_BALANCE);
             if ($config) {
                 $computedSections = $this->evaluateSections->execute($config['sections'], $report['totals'] ?? []);
@@ -67,9 +68,11 @@ class ReportController extends Controller
         $report = [];
         $computedSections = [];
         if ($selectedYearId) {
+            $branchId = $this->resolveBranchId($request);
             $report = $this->reportService->getBalanceSheet(
                 $selectedYearId,
                 $comparisonYearId,
+                $branchId,
             );
             $config = $this->configurationResolver->execute(ReportConfiguration::TYPE_BALANCE_SHEET);
             if ($config) {
@@ -128,7 +131,8 @@ class ReportController extends Controller
         $report = [];
         $computedSections = [];
         if ($selectedYearId) {
-            $report = $this->reportService->getCashFlow($selectedYearId);
+            $branchId = $this->resolveBranchId($request);
+            $report = $this->reportService->getCashFlow($selectedYearId, $branchId);
             $config = $this->configurationResolver->execute(ReportConfiguration::TYPE_CASH_FLOW);
             if ($config) {
                 $computedSections = $this->evaluateSections->execute($config['sections'], $report['totals'] ?? []);

--- a/app/Http/Requests/Reports/BalanceSheetReportRequest.php
+++ b/app/Http/Requests/Reports/BalanceSheetReportRequest.php
@@ -16,6 +16,7 @@ class BalanceSheetReportRequest extends FormRequest
         return [
             'fiscal_year_id' => ['required', 'integer', 'exists:fiscal_years,id'],
             'comparison_year_id' => ['nullable', 'integer', 'exists:fiscal_years,id', 'different:fiscal_year_id'],
+            'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
         ];
     }
 }

--- a/app/Http/Requests/Reports/CashFlowReportRequest.php
+++ b/app/Http/Requests/Reports/CashFlowReportRequest.php
@@ -15,6 +15,7 @@ class CashFlowReportRequest extends FormRequest
     {
         return [
             'fiscal_year_id' => ['required', 'integer', 'exists:fiscal_years,id'],
+            'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
         ];
     }
 }

--- a/app/Http/Requests/Reports/TrialBalanceFinancialReportRequest.php
+++ b/app/Http/Requests/Reports/TrialBalanceFinancialReportRequest.php
@@ -15,6 +15,7 @@ class TrialBalanceFinancialReportRequest extends FormRequest
     {
         return [
             'fiscal_year_id' => ['required', 'integer', 'exists:fiscal_years,id'],
+            'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
         ];
     }
 }

--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -16,7 +16,7 @@ class FinancialReportService
     /**
      * Get Trial Balance Report
      */
-    public function getTrialBalance(int $fiscalYearId): array
+    public function getTrialBalance(int $fiscalYearId, ?int $branchId = null): array
     {
         $coaVersion = $this->resolveRequiredCoaVersion($fiscalYearId);
 
@@ -24,7 +24,7 @@ class FinancialReportService
             return [];
         }
 
-        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId)
+        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId, $branchId)
             ->orderBy('code')
             ->get();
 
@@ -40,7 +40,7 @@ class FinancialReportService
         );
     }
 
-    public function getCashFlow(int $fiscalYearId): array
+    public function getCashFlow(int $fiscalYearId, ?int $branchId = null): array
     {
         $coaVersion = $this->resolveRequiredCoaVersion($fiscalYearId);
 
@@ -48,7 +48,7 @@ class FinancialReportService
             return [];
         }
 
-        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId)
+        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId, $branchId)
             ->where('is_cash_flow', true)
             ->orderBy('code')
             ->get();
@@ -133,7 +133,7 @@ class FinancialReportService
     /**
      * Get Balance Sheet Report
      */
-    public function getBalanceSheet(int $fiscalYearId, ?int $comparisonFiscalYearId = null): array
+    public function getBalanceSheet(int $fiscalYearId, ?int $comparisonFiscalYearId = null, ?int $branchId = null): array
     {
         $coaVersion = $this->resolveRequiredCoaVersion($fiscalYearId);
 
@@ -149,7 +149,7 @@ class FinancialReportService
         // Design doc says: "Sistem akan mencoba mencocokkan akun berdasarkan kolom code."
 
         /** @var Collection<int, Account> $accounts */
-        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId)
+        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId, $branchId)
             ->whereIn('type', ['asset', 'liability', 'equity'])
             ->orderBy('code')
             ->get();
@@ -157,15 +157,15 @@ class FinancialReportService
         [
             'comparisonCoaVersion' => $comparisonCoaVersion,
             'comparisonBalanceByCurrentAccountId' => $comparisonBalanceByCurrentAccountId,
-        ] = $this->prepareComparisonContext($accounts, $comparisonFiscalYearId);
+        ] = $this->prepareComparisonContext($accounts, $comparisonFiscalYearId, $branchId);
 
         // 2. Calculate Net Income for Current Year
-        $netIncome = $this->calculateNetIncome($fiscalYearId, $coaVersion->id);
+        $netIncome = $this->calculateNetIncome($fiscalYearId, $coaVersion->id, $branchId);
 
         // 3. Calculate Net Income for Comparison Year (if exists)
         $comparisonNetIncome = 0;
         if ($comparisonFiscalYearId && $comparisonCoaVersion) {
-            $comparisonNetIncome = $this->calculateNetIncome($comparisonFiscalYearId, $comparisonCoaVersion->id);
+            $comparisonNetIncome = $this->calculateNetIncome($comparisonFiscalYearId, $comparisonCoaVersion->id, $branchId);
         }
 
         ['buckets' => $buckets, 'totals' => $totals] = $this->collectAccountBuckets(
@@ -335,10 +335,10 @@ class FinancialReportService
         ];
     }
 
-    private function calculateNetIncome(int $fiscalYearId, int $coaVersionId): float
+    private function calculateNetIncome(int $fiscalYearId, int $coaVersionId, ?int $branchId = null): float
     {
         /** @var Collection<int, Account> $accounts */
-        $accounts = $this->accountsWithPostedSums($coaVersionId, $fiscalYearId)
+        $accounts = $this->accountsWithPostedSums($coaVersionId, $fiscalYearId, $branchId)
             ->whereIn('type', ['revenue', 'expense'])
             ->get();
 

--- a/tests/Feature/Reports/PerBranchFinancialReportTest.php
+++ b/tests/Feature/Reports/PerBranchFinancialReportTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature\Reports;
+
+use App\Models\Account;
+use App\Models\Branch;
+use App\Models\CoaVersion;
+use App\Models\FiscalYear;
+use App\Models\JournalEntry;
+use App\Models\JournalEntryLine;
+use App\Models\User;
+use App\Services\FinancialReportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\seed;
+
+uses(RefreshDatabase::class)->group('reports');
+
+beforeEach(function () {
+    seed();
+
+    $this->fiscalYear = FiscalYear::where('status', 'open')->firstOrFail();
+    /** @var CoaVersion $coaVersion */
+    $coaVersion = $this->fiscalYear->coaVersions()->where('status', 'active')->firstOrFail();
+    $this->coaVersion = $coaVersion;
+    $this->accountMap = Account::where('coa_version_id', $coaVersion->id)
+        ->pluck('id', 'code')
+        ->toArray();
+
+    $this->user = User::firstOrFail();
+    $this->branchA = Branch::factory()->create(['name' => 'Branch A']);
+    $this->branchB = Branch::factory()->create(['name' => 'Branch B']);
+
+    $this->service = app(FinancialReportService::class);
+});
+
+/**
+ * @param  list<array{0: string, 1: int, 2: int}>  $lines
+ */
+function seedBranchJournal(FiscalYear $fiscalYear, array $accountMap, User $user, ?int $branchId, string $entryNumber, array $lines): void
+{
+    $journal = JournalEntry::create([
+        'fiscal_year_id' => $fiscalYear->id,
+        'entry_number' => $entryNumber,
+        'entry_date' => '2026-02-01',
+        'reference' => $entryNumber,
+        'description' => 'Per-branch invariant fixture',
+        'status' => 'posted',
+        'branch_id' => $branchId,
+        'created_by' => $user->id,
+        'posted_by' => $user->id,
+        'posted_at' => now(),
+    ]);
+
+    foreach ($lines as [$code, $debit, $credit]) {
+        JournalEntryLine::create([
+            'journal_entry_id' => $journal->id,
+            'account_id' => $accountMap[$code],
+            'debit' => $debit,
+            'credit' => $credit,
+            'memo' => 'fixture',
+        ]);
+    }
+}
+
+function seedTwoBranchFixtures(object $ctx): void
+{
+    // Branch A: assets 1,400,000 = liabilities 400,000 + net income 1,000,000
+    seedBranchJournal($ctx->fiscalYear, $ctx->accountMap, $ctx->user, $ctx->branchA->id, 'JV-A-1', [
+        ['11110', 1000000, 0],
+        ['41000', 0, 1000000],
+    ]);
+    seedBranchJournal($ctx->fiscalYear, $ctx->accountMap, $ctx->user, $ctx->branchA->id, 'JV-A-2', [
+        ['11300', 400000, 0],
+        ['21100', 0, 400000],
+    ]);
+
+    // Branch B: assets 400,000 = liabilities 0 + net income 400,000
+    seedBranchJournal($ctx->fiscalYear, $ctx->accountMap, $ctx->user, $ctx->branchB->id, 'JV-B-1', [
+        ['11110', 600000, 0],
+        ['41000', 0, 600000],
+    ]);
+    seedBranchJournal($ctx->fiscalYear, $ctx->accountMap, $ctx->user, $ctx->branchB->id, 'JV-B-2', [
+        ['52000', 200000, 0],
+        ['11110', 0, 200000],
+    ]);
+}
+
+test('per-branch trial balance self-balances (total debit == total credit)', function () {
+    seedTwoBranchFixtures($this);
+
+    foreach ([$this->branchA->id, $this->branchB->id] as $branchId) {
+        $rows = $this->service->getTrialBalance($this->fiscalYear->id, $branchId);
+
+        $totalDebit = collect($rows)->sum('debit');
+        $totalCredit = collect($rows)->sum('credit');
+
+        expect(round($totalDebit, 2))->toBe(round($totalCredit, 2));
+    }
+});
+
+test('per-branch balance sheet balances (assets == liabilities + equity) with per-branch CYE', function () {
+    seedTwoBranchFixtures($this);
+
+    $reportA = $this->service->getBalanceSheet($this->fiscalYear->id, null, $this->branchA->id);
+    expect(round($reportA['totals']['assets'], 2))->toBe(1400000.0);
+    expect(round($reportA['totals']['liabilities'], 2))->toBe(400000.0);
+    expect(round($reportA['totals']['equity'], 2))->toBe(1000000.0);
+    expect(round($reportA['totals']['assets'], 2))
+        ->toBe(round($reportA['totals']['liabilities'] + $reportA['totals']['equity'], 2));
+
+    $reportB = $this->service->getBalanceSheet($this->fiscalYear->id, null, $this->branchB->id);
+    expect(round($reportB['totals']['assets'], 2))->toBe(400000.0);
+    expect(round($reportB['totals']['liabilities'], 2))->toBe(0.0);
+    expect(round($reportB['totals']['equity'], 2))->toBe(400000.0);
+    expect(round($reportB['totals']['assets'], 2))
+        ->toBe(round($reportB['totals']['liabilities'] + $reportB['totals']['equity'], 2));
+});
+
+test('balance sheet CYE row equals per-branch net income', function () {
+    seedTwoBranchFixtures($this);
+
+    $reportA = $this->service->getBalanceSheet($this->fiscalYear->id, null, $this->branchA->id);
+
+    $cye = collect($reportA['equity'])->firstWhere('code', '9999-CYE');
+    expect($cye)->not->toBeNull();
+    expect(round($cye['balance'], 2))->toBe(1000000.0);
+});
+
+test('omitting branchId reproduces company-wide behavior (backward compatible)', function () {
+    seedTwoBranchFixtures($this);
+
+    $companyWide = $this->service->getBalanceSheet($this->fiscalYear->id);
+
+    // Seeded NULL-branch journals: assets 8,000,000 / liabilities 3,000,000 / equity (CYE) 5,000,000.
+    // Plus branch fixtures: assets +1,800,000, liabilities +400,000, net income +1,400,000.
+    expect(round($companyWide['totals']['assets'], 2))->toBe(9800000.0);
+    expect(round($companyWide['totals']['liabilities'], 2))->toBe(3400000.0);
+    expect(round($companyWide['totals']['equity'], 2))->toBe(6400000.0);
+});
+
+test('null-branch journals do not break per-branch balancing', function () {
+    seedTwoBranchFixtures($this);
+
+    $reportA = $this->service->getBalanceSheet($this->fiscalYear->id, null, $this->branchA->id);
+
+    expect(round($reportA['totals']['assets'], 2))
+        ->toBe(round($reportA['totals']['liabilities'] + $reportA['totals']['equity'], 2));
+
+    expect(round($reportA['totals']['assets'], 2))->toBe(1400000.0);
+});
+
+test('balance sheet endpoint accepts branch_id and scopes the report', function () {
+    seedTwoBranchFixtures($this);
+    $user = createTestUserWithPermissions(['balance_sheet_report']);
+
+    Sanctum::actingAs($user, ['*']);
+    $this->getJson('/api/reports/balance-sheet?fiscal_year_id=' . $this->fiscalYear->id . '&branch_id=' . $this->branchA->id)
+        ->assertOk()
+        ->assertJsonPath('report.totals.assets', 1400000)
+        ->assertJsonPath('report.totals.liabilities', 400000)
+        ->assertJsonPath('report.totals.equity', 1000000);
+});
+
+test('balance sheet export validates branch_id', function () {
+    $user = createTestUserWithPermissions(['balance_sheet_report']);
+
+    Sanctum::actingAs($user, ['*']);
+    $this->postJson('/api/reports/balance-sheet/export', [
+        'fiscal_year_id' => $this->fiscalYear->id,
+        'branch_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['branch_id']);
+});


### PR DESCRIPTION
## Summary
PR2 of **per-branch financial statements** (scope **reduced 2b**, user-confirmed). Adds optional per-branch scoping to the **Balance Sheet**, **Trial Balance**, and **Cash Flow** reports.

Under the single-branch invariant (every GL-posting journal is single-branch — verified by detection: zero cross-branch journals), filtering the existing header `journal_entries.branch_id` is mathematically identical to line-level filtering. So **no clearing engine and no journal write-path change is needed** — this is Oracle's "Option B", the minimal correct path.

## Changes
- **FinancialReportService**: `getTrialBalance` / `getCashFlow` / `getBalanceSheet` / `calculateNetIncome` gain a nullable `branchId`. `getBalanceSheet` now injects a **per-branch** Current Year Earnings (`calculateNetIncome(branchId)`) so each branch's sheet balances (A = L + E). `branchId = null` preserves the prior company-wide behavior byte-for-byte.
- **ReportController + `InteractsWithFinancialReportRequest`**: the trial-balance, balance-sheet, and cash-flow endpoints accept `branch_id` and pass it through (new `resolveBranchId` helper).
- **Requests**: `branch_id` is `nullable|integer|exists:branches,id`.
- **Exports**: `branch_id` threaded into the three financial report exports (`resolveBranchId` on the abstract export; inline for the two standalone exports).

## Correctness notes
- The highest-risk line (per Oracle) is CYE injection: filtering A/L/E by branch while leaving CYE company-wide would guarantee imbalance. This PR makes CYE per-branch — covered by a dedicated test.
- NULL-branch (manual/closing) journals are excluded from a selected branch and form an implicit "unassigned" bucket; they do **not** break per-branch balancing because every excluded journal is itself balanced. Covered by a test.
- The PR1 `journal_entry_lines.branch_id` column stays as forward-compat for a future cross-branch clearing engine; it is **not** read here.

## Tested
- New `PerBranchFinancialReportTest` (7 tests, 24 assertions): per-branch TB self-balances; per-branch BS balances with per-branch CYE; CYE equals per-branch net income; null-branch robustness; omitting `branchId` reproduces company-wide totals; endpoint accepts `branch_id`; export validates `branch_id`.
- Full `--group reports`: **38 passed** (31 prior + 7 new) — zero regression.
- `duster fix` + `phpstan` (app/) clean.

## Follow-up
- PR3 (frontend): branch selector in the three report shells + E2E.
