### PR TITLE
feat(reports): branch selector on financial report pages (PR3/2b)

### DIFF
--- a/resources/js/components/reports/financial/FinancialReportPageShell.tsx
+++ b/resources/js/components/reports/financial/FinancialReportPageShell.tsx
@@ -1,3 +1,4 @@
+import { AsyncSelect } from '@/components/common/AsyncSelect';
 import { Badge } from '@/components/ui/badge';
 import {
     Select,
@@ -50,6 +51,8 @@ type FinancialReportPageShellProps = {
     comparisonYearId?: number;
     onYearChange: (value: string) => void;
     onComparisonChange: (value: string) => void;
+    branchId?: string | null;
+    onBranchChange?: (value: string) => void;
     headerMeta?: ReactNode;
     headerActions?: ReactNode;
     isLoading?: boolean;
@@ -66,12 +69,17 @@ export function useComparisonReportSearchParams() {
     const [searchParams, setSearchParams] = useSearchParams();
     const urlYearId = searchParams.get('fiscal_year_id');
     const urlComparisonId = searchParams.get('comparison_year_id');
+    const urlBranchId = searchParams.get('branch_id');
 
     const handleYearChange = (value: string) => {
         const params: Record<string, string> = { fiscal_year_id: value };
 
         if (urlComparisonId) {
             params.comparison_year_id = urlComparisonId;
+        }
+
+        if (urlBranchId) {
+            params.branch_id = urlBranchId;
         }
 
         setSearchParams(params);
@@ -86,14 +94,36 @@ export function useComparisonReportSearchParams() {
             params.comparison_year_id = value;
         }
 
+        if (urlBranchId) {
+            params.branch_id = urlBranchId;
+        }
+
+        setSearchParams(params);
+    };
+
+    const handleBranchChange = (value: string, selectedYearId: number) => {
+        const params: Record<string, string> = {
+            fiscal_year_id: String(selectedYearId),
+        };
+
+        if (urlComparisonId) {
+            params.comparison_year_id = urlComparisonId;
+        }
+
+        if (value) {
+            params.branch_id = value;
+        }
+
         setSearchParams(params);
     };
 
     return {
         urlYearId,
         urlComparisonId,
+        urlBranchId,
         handleYearChange,
         handleComparisonChange,
+        handleBranchChange,
     };
 }
 
@@ -102,9 +132,10 @@ export function useComparisonFinancialReportQuery<TReport>(
     endpoint: string,
     urlYearId: string | null,
     urlComparisonId: string | null,
+    urlBranchId: string | null,
 ) {
     return useQuery<ComparisonReportResponse<TReport>>({
-        queryKey: [queryKey, urlYearId, urlComparisonId],
+        queryKey: [queryKey, urlYearId, urlComparisonId, urlBranchId],
         queryFn: async () => {
             const params = new URLSearchParams();
 
@@ -114,6 +145,10 @@ export function useComparisonFinancialReportQuery<TReport>(
 
             if (urlComparisonId) {
                 params.append('comparison_year_id', urlComparisonId);
+            }
+
+            if (urlBranchId) {
+                params.append('branch_id', urlBranchId);
             }
 
             const response = await axios.get(
@@ -146,8 +181,10 @@ export function useComparisonFinancialReportPage<TReport>({
     const {
         urlYearId,
         urlComparisonId,
+        urlBranchId,
         handleYearChange,
         handleComparisonChange,
+        handleBranchChange,
     } = useComparisonReportSearchParams();
 
     const { data, isLoading, error } =
@@ -156,6 +193,7 @@ export function useComparisonFinancialReportPage<TReport>({
             endpoint,
             urlYearId,
             urlComparisonId,
+            urlBranchId,
         );
 
     const fiscalYears = data?.fiscalYears || [];
@@ -174,12 +212,14 @@ export function useComparisonFinancialReportPage<TReport>({
         fiscalYears,
         selectedYearId,
         comparisonYearId,
+        branchId: urlBranchId,
         report,
         computedSections,
         selectedFiscalYear,
         selectedComparisonFiscalYear,
         handleYearChange,
         handleComparisonChange,
+        handleBranchChange,
         isLoading,
         error,
     };
@@ -229,6 +269,8 @@ export function FinancialReportPageShell({
     comparisonYearId,
     onYearChange,
     onComparisonChange,
+    branchId,
+    onBranchChange,
     headerMeta,
     headerActions,
     isLoading = false,
@@ -312,6 +354,17 @@ export function FinancialReportPageShell({
                                 </SelectContent>
                             </Select>
                         </div>
+                        {onBranchChange && (
+                            <div className="w-full sm:w-[200px]">
+                                <AsyncSelect
+                                    url="/api/branches"
+                                    placeholder="All Branches"
+                                    value={branchId ?? ''}
+                                    onValueChange={onBranchChange}
+                                    label="Branch"
+                                />
+                            </div>
+                        )}
                         {headerActions}
                     </div>
                 </div>

--- a/resources/js/components/reports/financial/FinancialTableReportPage.tsx
+++ b/resources/js/components/reports/financial/FinancialTableReportPage.tsx
@@ -1,3 +1,4 @@
+import { AsyncSelect } from '@/components/common/AsyncSelect';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import {
@@ -66,6 +67,8 @@ type SingleYearFinancialReportPageShellProps = {
     fiscalYears: FinancialReportFiscalYear[];
     selectedYearId: number;
     onYearChange: (value: string) => void;
+    branchId?: string | null;
+    onBranchChange?: (value: string) => void;
     headerMeta?: ReactNode;
     headerActions?: ReactNode;
     preContent?: ReactNode;
@@ -95,14 +98,37 @@ const buildBreadcrumbs = (title: string, path: string): BreadcrumbItem[] => [
 export function useSingleYearReportSearchParams() {
     const [searchParams, setSearchParams] = useSearchParams();
     const urlYearId = searchParams.get('fiscal_year_id');
+    const urlBranchId = searchParams.get('branch_id');
 
     const handleYearChange = (value: string) => {
-        setSearchParams({ fiscal_year_id: value });
+        const params: Record<string, string> = { fiscal_year_id: value };
+
+        if (urlBranchId) {
+            params.branch_id = urlBranchId;
+        }
+
+        setSearchParams(params);
+    };
+
+    const handleBranchChange = (value: string) => {
+        const params: Record<string, string> = {};
+
+        if (urlYearId) {
+            params.fiscal_year_id = urlYearId;
+        }
+
+        if (value) {
+            params.branch_id = value;
+        }
+
+        setSearchParams(params);
     };
 
     return {
         urlYearId,
+        urlBranchId,
         handleYearChange,
+        handleBranchChange,
     };
 }
 
@@ -110,14 +136,19 @@ export function useSingleYearFinancialReportQuery<TReport>(
     queryKey: string,
     endpoint: string,
     urlYearId: string | null,
+    urlBranchId: string | null,
 ) {
     return useQuery<SingleYearFinancialReportResponse<TReport>>({
-        queryKey: [queryKey, urlYearId],
+        queryKey: [queryKey, urlYearId, urlBranchId],
         queryFn: async () => {
             const params = new URLSearchParams();
 
             if (urlYearId) {
                 params.append('fiscal_year_id', urlYearId);
+            }
+
+            if (urlBranchId) {
+                params.append('branch_id', urlBranchId);
             }
 
             const response = await axios.get(
@@ -141,12 +172,14 @@ export function useSingleYearFinancialReportPage<TReport>({
     endpoint,
     emptyReport,
 }: SingleYearFinancialReportPageOptions<TReport>) {
-    const { urlYearId, handleYearChange } = useSingleYearReportSearchParams();
+    const { urlYearId, urlBranchId, handleYearChange, handleBranchChange } =
+        useSingleYearReportSearchParams();
     const { data, isLoading, error } =
         useSingleYearFinancialReportQuery<TReport>(
             queryKey,
             endpoint,
             urlYearId,
+            urlBranchId,
         );
 
     const fiscalYears = Array.isArray(data?.fiscalYears)
@@ -163,10 +196,12 @@ export function useSingleYearFinancialReportPage<TReport>({
     return {
         fiscalYears,
         selectedYearId,
+        branchId: urlBranchId,
         report,
         computedSections,
         selectedFiscalYear,
         handleYearChange,
+        handleBranchChange,
         isLoading,
         error,
     };
@@ -178,6 +213,8 @@ export function SingleYearFinancialReportPageShell({
     fiscalYears,
     selectedYearId,
     onYearChange,
+    branchId,
+    onBranchChange,
     headerMeta,
     headerActions,
     preContent,
@@ -230,6 +267,17 @@ export function SingleYearFinancialReportPageShell({
                                 </SelectContent>
                             </Select>
                         </div>
+                        {onBranchChange && (
+                            <div className="w-full sm:w-[200px]">
+                                <AsyncSelect
+                                    url="/api/branches"
+                                    placeholder="All Branches"
+                                    value={branchId ?? ''}
+                                    onValueChange={onBranchChange}
+                                    label="Branch"
+                                />
+                            </div>
+                        )}
                         {headerActions}
                     </div>
                 </div>

--- a/resources/js/pages/reports/balance-sheet/index.tsx
+++ b/resources/js/pages/reports/balance-sheet/index.tsx
@@ -61,12 +61,14 @@ export default function BalanceSheet() {
         fiscalYears,
         selectedYearId,
         comparisonYearId,
+        branchId,
         report,
         computedSections,
         selectedFiscalYear,
         selectedComparisonFiscalYear,
         handleYearChange,
         handleComparisonChange,
+        handleBranchChange,
         isLoading,
         error,
     } = useComparisonFinancialReportPage<BalanceSheetResponse['report']>({
@@ -96,6 +98,10 @@ export default function BalanceSheet() {
             onComparisonChange={(value) =>
                 handleComparisonChange(value, selectedYearId)
             }
+            branchId={branchId}
+            onBranchChange={(value) =>
+                handleBranchChange(value, selectedYearId)
+            }
             isLoading={isLoading}
             hasError={!!error}
             headerMeta={
@@ -122,6 +128,7 @@ export default function BalanceSheet() {
                             ...(comparisonYearId && {
                                 comparison_year_id: String(comparisonYearId),
                             }),
+                            ...(branchId && { branch_id: branchId }),
                         })
                     }
                 >

--- a/resources/js/pages/reports/cash-flow/index.tsx
+++ b/resources/js/pages/reports/cash-flow/index.tsx
@@ -39,10 +39,12 @@ export default function CashFlow() {
     const {
         fiscalYears,
         selectedYearId,
+        branchId,
         report,
         computedSections,
         selectedFiscalYear,
         handleYearChange,
+        handleBranchChange,
         isLoading,
         error,
     } = useSingleYearFinancialReportPage<CashFlowResponse['report']>({
@@ -72,6 +74,8 @@ export default function CashFlow() {
             fiscalYears={fiscalYears}
             selectedYearId={selectedYearId}
             onYearChange={handleYearChange}
+            branchId={branchId}
+            onBranchChange={handleBranchChange}
             isLoading={isLoading}
             hasError={!!error}
             headerMeta={
@@ -85,6 +89,7 @@ export default function CashFlow() {
                     onClick={() =>
                         exportData({
                             fiscal_year_id: String(selectedYearId),
+                            ...(branchId && { branch_id: branchId }),
                         })
                     }
                 >

--- a/resources/js/pages/reports/trial-balance/index.tsx
+++ b/resources/js/pages/reports/trial-balance/index.tsx
@@ -39,10 +39,12 @@ export default function TrialBalance() {
     const {
         fiscalYears,
         selectedYearId,
+        branchId,
         report,
         computedSections,
         selectedFiscalYear,
         handleYearChange,
+        handleBranchChange,
         isLoading,
         error,
     } = useSingleYearFinancialReportPage<TrialBalanceResponse['report']>({
@@ -70,6 +72,8 @@ export default function TrialBalance() {
             fiscalYears={fiscalYears}
             selectedYearId={selectedYearId}
             onYearChange={handleYearChange}
+            branchId={branchId}
+            onBranchChange={handleBranchChange}
             isLoading={isLoading}
             hasError={!!error}
             headerMeta={
@@ -91,6 +95,7 @@ export default function TrialBalance() {
                     onClick={() =>
                         exportData({
                             fiscal_year_id: String(selectedYearId),
+                            ...(branchId && { branch_id: branchId }),
                         })
                     }
                 >

--- a/tests/e2e/per-branch-financial-reports/per-branch-financial-reports.spec.ts
+++ b/tests/e2e/per-branch-financial-reports/per-branch-financial-reports.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers';
+
+type ReportTarget = {
+    name: string;
+    route: string;
+    api: string;
+};
+
+const reports: ReportTarget[] = [
+    {
+        name: 'Balance Sheet',
+        route: '/reports/balance-sheet',
+        api: '/api/reports/balance-sheet',
+    },
+    {
+        name: 'Trial Balance',
+        route: '/reports/trial-balance',
+        api: '/api/reports/trial-balance',
+    },
+    {
+        name: 'Cash Flow',
+        route: '/reports/cash-flow',
+        api: '/api/reports/cash-flow',
+    },
+];
+
+test.describe('Per-branch financial report filter', () => {
+    test.beforeEach(async ({ page }) => {
+        await login(page, undefined, undefined, { requireDashboard: false });
+    });
+
+    for (const report of reports) {
+        test(`${report.name} scopes the report by branch`, async ({ page }) => {
+            test.setTimeout(60000);
+
+            await page.goto(report.route);
+
+            await page.waitForResponse(
+                (r) =>
+                    r.url().includes(report.api) &&
+                    !r.url().includes('/export') &&
+                    r.status() < 400,
+                { timeout: 30000 },
+            );
+
+            const branchSelect = page
+                .getByRole('combobox')
+                .filter({ hasText: 'All Branches' });
+            await expect(branchSelect).toBeVisible();
+            await branchSelect.click();
+
+            const firstBranch = page
+                .locator('ul[aria-busy="false"] button')
+                .first();
+            await expect(firstBranch).toBeVisible({ timeout: 10000 });
+
+            const scopedRequest = page.waitForResponse(
+                (r) =>
+                    r.url().includes(report.api) &&
+                    !r.url().includes('/export') &&
+                    r.url().includes('branch_id=') &&
+                    r.request().method() === 'GET' &&
+                    r.status() < 400,
+                { timeout: 15000 },
+            );
+            await firstBranch.click();
+            await scopedRequest;
+
+            await expect(page).toHaveURL(/branch_id=\d+/);
+        });
+    }
+});


### PR DESCRIPTION
## Summary
PR3 (frontend) of **per-branch financial statements** (scope **reduced 2b**). Adds an **"All Branches"** selector to the **Balance Sheet**, **Trial Balance**, and **Cash Flow** report pages so each statement can be scoped to a single branch. Builds on PR1 (#42, schema) and PR2 (#43, backend per-branch report logic).

## Changes
- **`FinancialReportPageShell`** (comparison shell, balance sheet) and **`FinancialTableReportPage`** (single-year shell, trial balance + cash flow): optional `branchId` + `onBranchChange`. The branch `AsyncSelect` (`url=/api/branches`, placeholder "All Branches") is rendered **after** the existing fiscal-year/comparison selectors so the existing report E2E specs' positional combobox indices (`nth(0)`/`nth(1)`) stay valid.
- `branch_id` is preserved in the URL search params across fiscal-year/comparison changes and threaded into the report query (`useComparison...`/`useSingleYear...` query hooks).
- The 3 report pages pass `branchId`/`onBranchChange` to the shell and include `branch_id` in the **export** payload when a branch is selected.
- Mirrors the existing **financial-dashboard** branch-filter pattern (same `AsyncSelect` usage and URL-param handling).

## Tested
- New E2E `per-branch-financial-reports` spec: for each of the 3 reports — open page, select the first branch, assert the report request carries `branch_id=` and the URL reflects the selection. **3 passed.**
- Regression: existing `balance-sheet-report`, `trial-balance-report`, `cash-flow-report` specs — **9 passed** (no positional-index regression from the new selector).
- `npm run types`, `npm run lint`, `npm run format` clean.

## Notes
- Selecting from the `AsyncSelect` sets a branch; clearing back to "All" follows the same pattern as the financial dashboard (re-navigation / removing the param). The backend treats a missing `branch_id` as company-wide (backward compatible).
