### PR TITLE
feat(reports): per-branch Income Statement & Comparative reports

### DIFF
--- a/app/Exports/ComparativeReportExport.php
+++ b/app/Exports/ComparativeReportExport.php
@@ -13,6 +13,7 @@ class ComparativeReportExport extends AbstractFinancialReportExport
         $report = app(FinancialReportService::class)->getComparativeReport(
             $this->resolveFiscalYearId(),
             $this->resolveComparisonYearId(),
+            $this->resolveBranchId(),
         );
 
         $rows = [];

--- a/app/Exports/IncomeStatementReportExport.php
+++ b/app/Exports/IncomeStatementReportExport.php
@@ -13,6 +13,7 @@ class IncomeStatementReportExport extends AbstractFinancialReportExport
         $report = app(FinancialReportService::class)->getIncomeStatement(
             $this->resolveFiscalYearId(),
             $this->resolveComparisonYearId(),
+            $this->resolveBranchId(),
         );
 
         $rows = [];

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -101,9 +101,11 @@ class ReportController extends Controller
         $report = [];
         $computedSections = [];
         if ($selectedYearId) {
+            $branchId = $this->resolveBranchId($request);
             $report = $this->reportService->getIncomeStatement(
                 $selectedYearId,
                 $comparisonYearId,
+                $branchId,
             );
             $config = $this->configurationResolver->execute(ReportConfiguration::TYPE_INCOME_STATEMENT);
             if ($config) {
@@ -162,9 +164,11 @@ class ReportController extends Controller
 
         $report = [];
         if ($selectedYearId) {
+            $branchId = $this->resolveBranchId($request);
             $report = $this->reportService->getComparativeReport(
                 $selectedYearId,
                 $comparisonYearId,
+                $branchId,
             );
         }
 

--- a/app/Http/Requests/Reports/ComparativeReportRequest.php
+++ b/app/Http/Requests/Reports/ComparativeReportRequest.php
@@ -16,6 +16,7 @@ class ComparativeReportRequest extends FormRequest
         return [
             'fiscal_year_id' => ['required', 'integer', 'exists:fiscal_years,id'],
             'comparison_year_id' => ['nullable', 'integer', 'exists:fiscal_years,id', 'different:fiscal_year_id'],
+            'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
         ];
     }
 }

--- a/app/Http/Requests/Reports/IncomeStatementReportRequest.php
+++ b/app/Http/Requests/Reports/IncomeStatementReportRequest.php
@@ -16,6 +16,7 @@ class IncomeStatementReportRequest extends FormRequest
         return [
             'fiscal_year_id' => ['required', 'integer', 'exists:fiscal_years,id'],
             'comparison_year_id' => ['nullable', 'integer', 'exists:fiscal_years,id', 'different:fiscal_year_id'],
+            'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
         ];
     }
 }

--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -242,7 +242,7 @@ class FinancialReportService
         ];
     }
 
-    public function getComparativeReport(int $fiscalYearId, ?int $comparisonFiscalYearId = null): array
+    public function getComparativeReport(int $fiscalYearId, ?int $comparisonFiscalYearId = null, ?int $branchId = null): array
     {
         $coaVersion = $this->resolveRequiredCoaVersion($fiscalYearId);
 
@@ -258,12 +258,12 @@ class FinancialReportService
         }
 
         /** @var Collection<int, Account> $accounts */
-        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId)
+        $accounts = $this->accountsWithPostedSums($coaVersion->id, $fiscalYearId, $branchId)
             ->orderBy('code')
             ->get();
 
         ['comparisonBalanceByCurrentAccountId' => $comparisonBalanceByCurrentAccountId]
-            = $this->prepareComparisonContext($accounts, $comparisonFiscalYearId);
+            = $this->prepareComparisonContext($accounts, $comparisonFiscalYearId, $branchId);
 
         ['buckets' => $buckets, 'totals' => $totals] = $this->collectAccountBuckets(
             $accounts,

--- a/resources/js/components/reports/financial/FinancialReportExportButton.tsx
+++ b/resources/js/components/reports/financial/FinancialReportExportButton.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/ui/button';
+import { Download, Loader2 } from 'lucide-react';
+
+type FinancialReportExportButtonProps = {
+    exporting: boolean;
+    selectedYearId: number;
+    comparisonYearId?: number;
+    branchId?: string | null;
+    onExport: (payload: Record<string, string>) => void;
+};
+
+export function FinancialReportExportButton({
+    exporting,
+    selectedYearId,
+    comparisonYearId,
+    branchId,
+    onExport,
+}: FinancialReportExportButtonProps) {
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            disabled={!selectedYearId || exporting}
+            onClick={() =>
+                onExport({
+                    fiscal_year_id: String(selectedYearId),
+                    ...(comparisonYearId && {
+                        comparison_year_id: String(comparisonYearId),
+                    }),
+                    ...(branchId && { branch_id: branchId }),
+                })
+            }
+        >
+            {exporting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+                <Download className="mr-2 h-4 w-4" />
+            )}
+            {exporting ? 'Exporting...' : 'Export'}
+        </Button>
+    );
+}

--- a/resources/js/pages/reports/balance-sheet/index.tsx
+++ b/resources/js/pages/reports/balance-sheet/index.tsx
@@ -1,4 +1,5 @@
 import { ComputedSectionsCard } from '@/components/reports/financial/ComputedSectionsCard';
+import { FinancialReportExportButton } from '@/components/reports/financial/FinancialReportExportButton';
 import {
     FinancialReportHeaderMeta,
     FinancialReportPageShell,
@@ -16,11 +17,10 @@ import {
     FinancialSummaryCard,
 } from '@/components/reports/financial/FinancialSummaryCard';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useExport } from '@/hooks/useExport';
 import { formatCurrency } from '@/lib/utils';
-import { AlertTriangle, Download, Loader2 } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 
 interface BalanceSheetResponse {
     fiscalYears: FinancialReportFiscalYear[];
@@ -118,27 +118,13 @@ export default function BalanceSheet() {
                 </FinancialReportHeaderMeta>
             }
             headerActions={
-                <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!selectedYearId || exporting}
-                    onClick={() =>
-                        exportData({
-                            fiscal_year_id: String(selectedYearId),
-                            ...(comparisonYearId && {
-                                comparison_year_id: String(comparisonYearId),
-                            }),
-                            ...(branchId && { branch_id: branchId }),
-                        })
-                    }
-                >
-                    {exporting ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                        <Download className="mr-2 h-4 w-4" />
-                    )}
-                    {exporting ? 'Exporting...' : 'Export'}
-                </Button>
+                <FinancialReportExportButton
+                    exporting={exporting}
+                    selectedYearId={selectedYearId}
+                    comparisonYearId={comparisonYearId}
+                    branchId={branchId}
+                    onExport={exportData}
+                />
             }
         >
             <div className="grid gap-6">

--- a/resources/js/pages/reports/cash-flow/index.tsx
+++ b/resources/js/pages/reports/cash-flow/index.tsx
@@ -1,4 +1,5 @@
 import { ComputedSectionsCard } from '@/components/reports/financial/ComputedSectionsCard';
+import { FinancialReportExportButton } from '@/components/reports/financial/FinancialReportExportButton';
 import {
     FinancialReportHeaderMeta,
     type FinancialReportFiscalYear,
@@ -9,11 +10,9 @@ import {
     useSingleYearFinancialReportPage,
     type FinancialTableRow,
 } from '@/components/reports/financial/FinancialTableReportPage';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useExport } from '@/hooks/useExport';
 import { formatCurrency } from '@/lib/utils';
-import { Download, Loader2 } from 'lucide-react';
 
 interface CashFlowItem extends FinancialTableRow {
     id: number;
@@ -82,24 +81,12 @@ export default function CashFlow() {
                 <FinancialReportHeaderMeta fiscalYear={selectedFiscalYear} />
             }
             headerActions={
-                <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!selectedYearId || exporting}
-                    onClick={() =>
-                        exportData({
-                            fiscal_year_id: String(selectedYearId),
-                            ...(branchId && { branch_id: branchId }),
-                        })
-                    }
-                >
-                    {exporting ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                        <Download className="mr-2 h-4 w-4" />
-                    )}
-                    {exporting ? 'Exporting...' : 'Export'}
-                </Button>
+                <FinancialReportExportButton
+                    exporting={exporting}
+                    selectedYearId={selectedYearId}
+                    branchId={branchId}
+                    onExport={exportData}
+                />
             }
             preContent={
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">

--- a/resources/js/pages/reports/comparative/index.tsx
+++ b/resources/js/pages/reports/comparative/index.tsx
@@ -1,3 +1,4 @@
+import { FinancialReportExportButton } from '@/components/reports/financial/FinancialReportExportButton';
 import {
     FinancialReportHeaderMeta,
     FinancialReportPageShell,
@@ -9,9 +10,7 @@ import {
     financialPositionSectionConfigs,
     type ReportAccountNode,
 } from '@/components/reports/financial/FinancialReportSection';
-import { Button } from '@/components/ui/button';
 import { useExport } from '@/hooks/useExport';
-import { Download, Loader2 } from 'lucide-react';
 interface ComparativeReportResponse {
     fiscalYears: FinancialReportFiscalYear[];
     selectedYearId: number;
@@ -116,27 +115,13 @@ export default function ComparativeReport() {
                 />
             }
             headerActions={
-                <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!selectedYearId || exporting}
-                    onClick={() =>
-                        exportData({
-                            fiscal_year_id: String(selectedYearId),
-                            ...(comparisonYearId && {
-                                comparison_year_id: String(comparisonYearId),
-                            }),
-                            ...(branchId && { branch_id: branchId }),
-                        })
-                    }
-                >
-                    {exporting ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                        <Download className="mr-2 h-4 w-4" />
-                    )}
-                    {exporting ? 'Exporting...' : 'Export'}
-                </Button>
+                <FinancialReportExportButton
+                    exporting={exporting}
+                    selectedYearId={selectedYearId}
+                    comparisonYearId={comparisonYearId}
+                    branchId={branchId}
+                    onExport={exportData}
+                />
             }
         >
             <div className="grid gap-6">

--- a/resources/js/pages/reports/comparative/index.tsx
+++ b/resources/js/pages/reports/comparative/index.tsx
@@ -72,11 +72,13 @@ export default function ComparativeReport() {
         fiscalYears,
         selectedYearId,
         comparisonYearId,
+        branchId,
         report,
         selectedFiscalYear,
         selectedComparisonFiscalYear,
         handleYearChange,
         handleComparisonChange,
+        handleBranchChange,
         isLoading,
         error,
     } = useComparisonFinancialReportPage<ComparativeReportResponse['report']>({
@@ -100,6 +102,10 @@ export default function ComparativeReport() {
             onComparisonChange={(value) =>
                 handleComparisonChange(value, selectedYearId)
             }
+            branchId={branchId}
+            onBranchChange={(value) =>
+                handleBranchChange(value, selectedYearId)
+            }
             isLoading={isLoading}
             hasError={!!error}
             headerMeta={
@@ -120,6 +126,7 @@ export default function ComparativeReport() {
                             ...(comparisonYearId && {
                                 comparison_year_id: String(comparisonYearId),
                             }),
+                            ...(branchId && { branch_id: branchId }),
                         })
                     }
                 >

--- a/resources/js/pages/reports/income-statement/index.tsx
+++ b/resources/js/pages/reports/income-statement/index.tsx
@@ -1,4 +1,5 @@
 import { ComputedSectionsCard } from '@/components/reports/financial/ComputedSectionsCard';
+import { FinancialReportExportButton } from '@/components/reports/financial/FinancialReportExportButton';
 import {
     FinancialReportHeaderMeta,
     FinancialReportPageShell,
@@ -14,11 +15,9 @@ import {
     FinancialStatusBadge,
     FinancialSummaryCard,
 } from '@/components/reports/financial/FinancialSummaryCard';
-import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useExport } from '@/hooks/useExport';
 import { cn, formatCurrency } from '@/lib/utils';
-import { Download, Loader2 } from 'lucide-react';
 
 interface IncomeStatementResponse {
     fiscalYears: FinancialReportFiscalYear[];
@@ -114,27 +113,13 @@ export default function IncomeStatement() {
                 </FinancialReportHeaderMeta>
             }
             headerActions={
-                <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!selectedYearId || exporting}
-                    onClick={() =>
-                        exportData({
-                            fiscal_year_id: String(selectedYearId),
-                            ...(comparisonYearId && {
-                                comparison_year_id: String(comparisonYearId),
-                            }),
-                            ...(branchId && { branch_id: branchId }),
-                        })
-                    }
-                >
-                    {exporting ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                        <Download className="mr-2 h-4 w-4" />
-                    )}
-                    {exporting ? 'Exporting...' : 'Export'}
-                </Button>
+                <FinancialReportExportButton
+                    exporting={exporting}
+                    selectedYearId={selectedYearId}
+                    comparisonYearId={comparisonYearId}
+                    branchId={branchId}
+                    onExport={exportData}
+                />
             }
         >
             <div className="grid gap-6">

--- a/resources/js/pages/reports/income-statement/index.tsx
+++ b/resources/js/pages/reports/income-statement/index.tsx
@@ -55,12 +55,14 @@ export default function IncomeStatement() {
         fiscalYears,
         selectedYearId,
         comparisonYearId,
+        branchId,
         report,
         computedSections,
         selectedFiscalYear,
         selectedComparisonFiscalYear,
         handleYearChange,
         handleComparisonChange,
+        handleBranchChange,
         isLoading,
         error,
     } = useComparisonFinancialReportPage<IncomeStatementResponse['report']>({
@@ -92,6 +94,10 @@ export default function IncomeStatement() {
             onComparisonChange={(value) =>
                 handleComparisonChange(value, selectedYearId)
             }
+            branchId={branchId}
+            onBranchChange={(value) =>
+                handleBranchChange(value, selectedYearId)
+            }
             isLoading={isLoading}
             hasError={!!error}
             headerMeta={
@@ -118,6 +124,7 @@ export default function IncomeStatement() {
                             ...(comparisonYearId && {
                                 comparison_year_id: String(comparisonYearId),
                             }),
+                            ...(branchId && { branch_id: branchId }),
                         })
                     }
                 >

--- a/resources/js/pages/reports/trial-balance/index.tsx
+++ b/resources/js/pages/reports/trial-balance/index.tsx
@@ -1,4 +1,5 @@
 import { ComputedSectionsCard } from '@/components/reports/financial/ComputedSectionsCard';
+import { FinancialReportExportButton } from '@/components/reports/financial/FinancialReportExportButton';
 import {
     FinancialReportHeaderMeta,
     type FinancialReportFiscalYear,
@@ -10,10 +11,8 @@ import {
     useSingleYearFinancialReportPage,
     type FinancialTableRow,
 } from '@/components/reports/financial/FinancialTableReportPage';
-import { Button } from '@/components/ui/button';
 import { useExport } from '@/hooks/useExport';
 import { formatCurrency } from '@/lib/utils';
-import { Download, Loader2 } from 'lucide-react';
 
 interface AccountItem extends FinancialTableRow {
     id: number;
@@ -88,24 +87,12 @@ export default function TrialBalance() {
                 </FinancialReportHeaderMeta>
             }
             headerActions={
-                <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!selectedYearId || exporting}
-                    onClick={() =>
-                        exportData({
-                            fiscal_year_id: String(selectedYearId),
-                            ...(branchId && { branch_id: branchId }),
-                        })
-                    }
-                >
-                    {exporting ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                        <Download className="mr-2 h-4 w-4" />
-                    )}
-                    {exporting ? 'Exporting...' : 'Export'}
-                </Button>
+                <FinancialReportExportButton
+                    exporting={exporting}
+                    selectedYearId={selectedYearId}
+                    branchId={branchId}
+                    onExport={exportData}
+                />
             }
         >
             <FinancialTableCard

--- a/tests/Feature/Reports/PerBranchFinancialReportTest.php
+++ b/tests/Feature/Reports/PerBranchFinancialReportTest.php
@@ -174,3 +174,91 @@ test('balance sheet export validates branch_id', function () {
         ->assertUnprocessable()
         ->assertJsonValidationErrors(['branch_id']);
 });
+
+test('per-branch income statement scopes revenue, expense, and net income', function () {
+    seedTwoBranchFixtures($this);
+
+    $reportA = $this->service->getIncomeStatement($this->fiscalYear->id, null, $this->branchA->id);
+    expect(round($reportA['totals']['revenue'], 2))->toBe(1000000.0);
+    expect(round($reportA['totals']['expense'], 2))->toBe(0.0);
+    expect(round($reportA['totals']['net_income'], 2))->toBe(1000000.0);
+
+    $reportB = $this->service->getIncomeStatement($this->fiscalYear->id, null, $this->branchB->id);
+    expect(round($reportB['totals']['revenue'], 2))->toBe(600000.0);
+    expect(round($reportB['totals']['expense'], 2))->toBe(200000.0);
+    expect(round($reportB['totals']['net_income'], 2))->toBe(400000.0);
+});
+
+test('per-branch comparative report scopes all sections', function () {
+    seedTwoBranchFixtures($this);
+
+    $reportA = $this->service->getComparativeReport($this->fiscalYear->id, null, $this->branchA->id);
+    expect(round($reportA['totals']['assets'], 2))->toBe(1400000.0);
+    expect(round($reportA['totals']['liabilities'], 2))->toBe(400000.0);
+    expect(round($reportA['totals']['revenues'], 2))->toBe(1000000.0);
+    expect(round($reportA['totals']['expenses'], 2))->toBe(0.0);
+
+    $reportB = $this->service->getComparativeReport($this->fiscalYear->id, null, $this->branchB->id);
+    expect(round($reportB['totals']['assets'], 2))->toBe(400000.0);
+    expect(round($reportB['totals']['revenues'], 2))->toBe(600000.0);
+    expect(round($reportB['totals']['expenses'], 2))->toBe(200000.0);
+});
+
+test('omitting branchId reproduces company-wide income statement', function () {
+    seedTwoBranchFixtures($this);
+
+    $scopedSum = $this->service->getIncomeStatement($this->fiscalYear->id, null, $this->branchA->id)['totals']['net_income']
+        + $this->service->getIncomeStatement($this->fiscalYear->id, null, $this->branchB->id)['totals']['net_income'];
+    $companyWide = $this->service->getIncomeStatement($this->fiscalYear->id);
+
+    // Branch fixtures contribute net income 1,400,000; company-wide also includes NULL-branch journals.
+    expect(round($companyWide['totals']['net_income'], 2))
+        ->toBeGreaterThanOrEqual(round($scopedSum, 2));
+});
+
+test('income statement endpoint accepts branch_id and scopes the report', function () {
+    seedTwoBranchFixtures($this);
+    $user = createTestUserWithPermissions(['income_statement_report']);
+
+    Sanctum::actingAs($user, ['*']);
+    $this->getJson('/api/reports/income-statement?fiscal_year_id=' . $this->fiscalYear->id . '&branch_id=' . $this->branchA->id)
+        ->assertOk()
+        ->assertJsonPath('report.totals.revenue', 1000000)
+        ->assertJsonPath('report.totals.expense', 0)
+        ->assertJsonPath('report.totals.net_income', 1000000);
+});
+
+test('comparative endpoint accepts branch_id and scopes the report', function () {
+    seedTwoBranchFixtures($this);
+    $user = createTestUserWithPermissions(['comparative_report']);
+
+    Sanctum::actingAs($user, ['*']);
+    $this->getJson('/api/reports/comparative?fiscal_year_id=' . $this->fiscalYear->id . '&branch_id=' . $this->branchB->id)
+        ->assertOk()
+        ->assertJsonPath('report.totals.revenues', 600000)
+        ->assertJsonPath('report.totals.expenses', 200000);
+});
+
+test('income statement export validates branch_id', function () {
+    $user = createTestUserWithPermissions(['income_statement_report']);
+
+    Sanctum::actingAs($user, ['*']);
+    $this->postJson('/api/reports/income-statement/export', [
+        'fiscal_year_id' => $this->fiscalYear->id,
+        'branch_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['branch_id']);
+});
+
+test('comparative export validates branch_id', function () {
+    $user = createTestUserWithPermissions(['comparative_report']);
+
+    Sanctum::actingAs($user, ['*']);
+    $this->postJson('/api/reports/comparative/export', [
+        'fiscal_year_id' => $this->fiscalYear->id,
+        'branch_id' => 999999,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['branch_id']);
+});

--- a/tests/e2e/per-branch-financial-reports/per-branch-financial-reports.spec.ts
+++ b/tests/e2e/per-branch-financial-reports/per-branch-financial-reports.spec.ts
@@ -23,6 +23,16 @@ const reports: ReportTarget[] = [
         route: '/reports/cash-flow',
         api: '/api/reports/cash-flow',
     },
+    {
+        name: 'Income Statement',
+        route: '/reports/income-statement',
+        api: '/api/reports/income-statement',
+    },
+    {
+        name: 'Comparative Report',
+        route: '/reports/comparative',
+        api: '/api/reports/comparative',
+    },
 ];
 
 test.describe('Per-branch financial report filter', () => {


### PR DESCRIPTION
feat(reports): per-branch Income Statement & Comparative reports

Extend the per-branch financial filtering (shipped for Balance Sheet / Trial
Balance / Cash Flow in #43/#44) to the Income Statement and Comparative report
pages, closing the UX gap where those two reports could not be scoped by branch.

Backend:
- ReportController::incomeStatement/comparative now resolve branch_id and pass it
  to the service (mirrors balanceSheet/cashFlow).
- FinancialReportService::getComparativeReport gains ?branchId and threads it into
  accountsWithPostedSums + prepareComparisonContext. getIncomeStatement already
  accepted branchId; it is now actually wired from the controller/export.
- IncomeStatement/Comparative report requests validate branch_id
  (nullable|integer|exists:branches,id).
- IncomeStatement/Comparative exports thread resolveBranchId().

Frontend:
- income-statement and comparative pages pass branchId + onBranchChange into the
  shared FinancialReportPageShell (branch AsyncSelect already built in), and
  include branch_id in the export payload + URL params. Selector renders after the
  existing fiscal-year/comparison selectors (no positional-index regression).

Tests:
- PerBranchFinancialReportTest: 7 new invariant + endpoint + export-validation
  tests for income statement and comparative. Full reports group 45 green.
- per-branch-financial-reports E2E extended to cover both new pages (5 green).

Semantics unchanged vs prior PRs: branchId=null preserves byte-identical
company-wide behavior; specific branch filters by header journal_entries.branch_id.
