### PR TITLE
feat(accounting): backfill journal_entry_lines.branch_id from header (full 2b PR1)

### DIFF
--- a/database/migrations/2026_06_21_000000_backfill_branch_id_on_journal_entry_lines.php
+++ b/database/migrations/2026_06_21_000000_backfill_branch_id_on_journal_entry_lines.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('journal_entry_lines', 'branch_id')) {
+            return;
+        }
+
+        DB::table('journal_entries')
+            ->whereNotNull('branch_id')
+            ->orderBy('id')
+            ->chunkById(500, function ($entries): void {
+                $byBranch = collect($entries)->groupBy('branch_id');
+
+                foreach ($byBranch as $branchId => $group) {
+                    DB::table('journal_entry_lines')
+                        ->whereIn('journal_entry_id', collect($group)->pluck('id'))
+                        ->whereNull('branch_id')
+                        ->update(['branch_id' => $branchId]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('journal_entry_lines', 'branch_id')) {
+            return;
+        }
+
+        DB::table('journal_entry_lines')->update(['branch_id' => null]);
+    }
+};


### PR DESCRIPTION
feat(accounting): backfill journal_entry_lines.branch_id from header (full 2b PR1)

First step of the full per-branch 2b initiative. The branch_id column + index on
journal_entry_lines already exists (inert forward-compat from reduced 2b); this
adds the data backfill that establishes the line=header branch invariant.

- New data migration sets journal_entry_lines.branch_id = parent
  journal_entries.branch_id, chunked by entry (chunkById 500) and grouped by
  branch for batched updates. Only touches lines whose branch_id is still NULL
  (idempotent / re-runnable).
- down() nulls the column back out (reversible).

Zero behavior change: all financial reports still read the header branch_id at
this stage, and on current data every journal is single-branch (line == header).
Verified: 0 line/header mismatches, rollback + re-migrate clean, reports group
45 tests green.

This invariant (every posted line resolves to its header branch) is the
foundation the later line-level report switch (PR5a) and clearing engine (PR3)
build on.
