### PR TITLE
feat(accounting): inter-branch clearing engine (full 2b PR3)

### DIFF
--- a/app/Actions/JournalEntries/CreateJournalEntryAction.php
+++ b/app/Actions/JournalEntries/CreateJournalEntryAction.php
@@ -4,6 +4,7 @@ namespace App\Actions\JournalEntries;
 
 use App\Models\FiscalYear;
 use App\Models\JournalEntry;
+use App\Services\InterBranchClearingService;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Auth;
@@ -12,6 +13,10 @@ use Illuminate\Validation\ValidationException;
 
 class CreateJournalEntryAction
 {
+    public function __construct(
+        private InterBranchClearingService $clearing,
+    ) {}
+
     /**
      * Create a journal entry with its lines.
      *
@@ -106,9 +111,26 @@ class CreateJournalEntryAction
 
                     $journalEntry = JournalEntry::create($attributes);
 
-                    foreach ($data['lines'] as $lineData) {
+                    $headerBranchId = $data['branch_id'] ?? null;
+                    $resolvedLines = array_map(
+                        fn (array $line): array => [
+                            'account_id' => $line['account_id'],
+                            'branch_id' => $line['branch_id'] ?? $headerBranchId,
+                            'debit' => $line['debit'],
+                            'credit' => $line['credit'],
+                            'memo' => $line['memo'] ?? null,
+                        ],
+                        $data['lines'],
+                    );
+
+                    $clearingAccountId = $this->clearing->resolveAccountIdForFiscalYear($fiscalYear->id);
+                    $resolvedLines = $this->clearing->inject($resolvedLines, $clearingAccountId);
+                    $this->clearing->assertBalancedPerBranch($resolvedLines);
+
+                    foreach ($resolvedLines as $lineData) {
                         $journalEntry->lines()->create([
                             'account_id' => $lineData['account_id'],
+                            'branch_id' => $lineData['branch_id'] ?? null,
                             'debit' => $lineData['debit'],
                             'credit' => $lineData['credit'],
                             'memo' => $lineData['memo'] ?? null,

--- a/app/Actions/JournalEntries/UpdateJournalEntryAction.php
+++ b/app/Actions/JournalEntries/UpdateJournalEntryAction.php
@@ -4,11 +4,16 @@ namespace App\Actions\JournalEntries;
 
 use App\Models\FiscalYear;
 use App\Models\JournalEntry;
+use App\Services\InterBranchClearingService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class UpdateJournalEntryAction
 {
+    public function __construct(
+        private InterBranchClearingService $clearing,
+    ) {}
+
     public function execute(JournalEntry $journalEntry, array $data): JournalEntry
     {
         if ($journalEntry->status === 'posted' || $journalEntry->status === 'void') {
@@ -51,34 +56,28 @@ class UpdateJournalEntryAction
                 'description' => $data['description'],
             ]);
 
-            // Sync Lines
-            // 1. Get existing line IDs
-            $existingLines = $journalEntry->lines->keyBy('id');
-            $newLinesData = collect($data['lines']);
-
-            // 2. Identify IDs to keep/update
-            $linesToUpdate = $newLinesData->whereNotNull('id'); // Assuming frontend sends ID for existing lines?
-            // Wait, standard FE might send all lines. If ID exists, update. If not, create.
-            // But we don't have ID in StoreRequest/UpdateRequests rules for lines.
-            // We should assume complete replacement or smart diff.
-            // Easier: Delete all and recreate? Or diff by content?
-            // "Sync" by ID is safest if FE sends it.
-
-            // Let's assume we delete all and recreate for simplicity in this iteration,
-            // unless we want to preserve IDs.
-            // Preserving IDs is better.
-            // Let's update lines.* request rule to include ID if possible
-
-            // Re-visiting UpdateJournalEntryRequest...
-            // I didn't verify if I added ID there. I didn't.
-            // So for now, I will DELETE ALL and RECREATE lines.
-            // This is acceptable for simple Journal Entry CRUD where lines are child entities.
-
             $journalEntry->lines()->delete();
 
-            foreach ($data['lines'] as $lineData) {
+            $headerBranchId = $journalEntry->branch_id;
+            $resolvedLines = array_map(
+                fn (array $line): array => [
+                    'account_id' => $line['account_id'],
+                    'branch_id' => $line['branch_id'] ?? $headerBranchId,
+                    'debit' => $line['debit'],
+                    'credit' => $line['credit'],
+                    'memo' => $line['memo'] ?? null,
+                ],
+                $data['lines'],
+            );
+
+            $clearingAccountId = $this->clearing->resolveAccountIdForFiscalYear($journalEntry->fiscal_year_id);
+            $resolvedLines = $this->clearing->inject($resolvedLines, $clearingAccountId);
+            $this->clearing->assertBalancedPerBranch($resolvedLines);
+
+            foreach ($resolvedLines as $lineData) {
                 $journalEntry->lines()->create([
                     'account_id' => $lineData['account_id'],
+                    'branch_id' => $lineData['branch_id'] ?? null,
                     'debit' => $lineData['debit'],
                     'credit' => $lineData['credit'],
                     'memo' => $lineData['memo'] ?? null,

--- a/app/Actions/PeriodClosings/ClosePeriodAction.php
+++ b/app/Actions/PeriodClosings/ClosePeriodAction.php
@@ -7,6 +7,7 @@ use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\JournalEntry;
 use App\Models\PeriodClosing;
+use App\Services\InterBranchClearingService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -14,6 +15,7 @@ class ClosePeriodAction
 {
     public function __construct(
         private RecalculateAccountBalancesAction $recalculate,
+        private InterBranchClearingService $clearing,
     ) {}
 
     public function execute(PeriodClosing $periodClosing): PeriodClosing
@@ -73,6 +75,7 @@ class ClosePeriodAction
             'posted_at' => now(),
         ]);
         $netIncome = 0.0;
+        $lines = [];
 
         foreach ($accounts as $account) {
             $balance = (float) AccountBalance::query()
@@ -85,20 +88,37 @@ class ClosePeriodAction
                 continue;
             }
             $netIncome += $account->type === 'revenue' ? $balance : -$balance;
-            $entry->lines()->create([
+            $lines[] = [
                 'account_id' => $account->id,
+                'branch_id' => null,
                 'debit' => $account->type === 'revenue' ? abs($balance) : 0,
                 'credit' => $account->type === 'expense' ? abs($balance) : 0,
                 'memo' => 'Close ' . $account->name,
-            ]);
+            ];
         }
 
-        $entry->lines()->create([
+        $lines[] = [
             'account_id' => $periodClosing->retained_earnings_account_id,
+            'branch_id' => null,
             'debit' => $netIncome < 0 ? abs($netIncome) : 0,
             'credit' => $netIncome > 0 ? $netIncome : 0,
             'memo' => 'Close net income to retained earnings',
-        ]);
+        ];
+
+        $clearingAccountId = $this->clearing->resolveAccountIdForFiscalYear($periodClosing->fiscal_year_id);
+        $lines = $this->clearing->inject($lines, $clearingAccountId);
+        $this->clearing->assertBalancedPerBranch($lines);
+
+        foreach ($lines as $line) {
+            $entry->lines()->create([
+                'account_id' => $line['account_id'],
+                'branch_id' => $line['branch_id'] ?? null,
+                'debit' => $line['debit'],
+                'credit' => $line['credit'],
+                'memo' => $line['memo'] ?? null,
+            ]);
+        }
+
         $periodClosing->update(['net_income' => $netIncome]);
 
         return $entry;

--- a/app/Actions/RecurringJournals/ExecuteRecurringJournalAction.php
+++ b/app/Actions/RecurringJournals/ExecuteRecurringJournalAction.php
@@ -4,12 +4,17 @@ namespace App\Actions\RecurringJournals;
 
 use App\Models\JournalEntry;
 use App\Models\RecurringJournal;
+use App\Services\InterBranchClearingService;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class ExecuteRecurringJournalAction
 {
+    public function __construct(
+        private InterBranchClearingService $clearing,
+    ) {}
+
     public function execute(RecurringJournal $recurringJournal): JournalEntry
     {
         return DB::transaction(function () use ($recurringJournal): JournalEntry {
@@ -38,12 +43,25 @@ class ExecuteRecurringJournalAction
                 'posted_at' => $recurringJournal->auto_post ? now() : null,
             ]);
 
-            foreach ($recurringJournal->lines as $line) {
+            $resolvedLines = $recurringJournal->lines->map(fn ($line): array => [
+                'account_id' => $line->account_id,
+                'branch_id' => $line->branch_id ?? null,
+                'debit' => $line->debit,
+                'credit' => $line->credit,
+                'memo' => $line->memo,
+            ])->all();
+
+            $clearingAccountId = $this->clearing->resolveAccountIdForFiscalYear($recurringJournal->fiscal_year_id);
+            $resolvedLines = $this->clearing->inject($resolvedLines, $clearingAccountId);
+            $this->clearing->assertBalancedPerBranch($resolvedLines);
+
+            foreach ($resolvedLines as $line) {
                 $entry->lines()->create([
-                    'account_id' => $line->account_id,
-                    'debit' => $line->debit,
-                    'credit' => $line->credit,
-                    'memo' => $line->memo,
+                    'account_id' => $line['account_id'],
+                    'branch_id' => $line['branch_id'] ?? null,
+                    'debit' => $line['debit'],
+                    'credit' => $line['credit'],
+                    'memo' => $line['memo'] ?? null,
                 ]);
             }
 

--- a/app/Services/InterBranchClearingService.php
+++ b/app/Services/InterBranchClearingService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Account;
+use App\Models\CoaVersion;
+use RuntimeException;
+
+class InterBranchClearingService
+{
+    public const CLEARING_CODE = '1999-IBC';
+
+    public const CLEARING_MEMO = 'Inter-branch clearing (auto)';
+
+    /**
+     * @param  list<array<string, mixed>>  $lines
+     * @return list<array<string, mixed>>
+     */
+    public function inject(array $lines, ?int $clearingAccountId): array
+    {
+        if ($clearingAccountId !== null) {
+            $lines = array_values(array_filter(
+                $lines,
+                fn (array $line): bool => ($line['account_id'] ?? null) !== $clearingAccountId,
+            ));
+        }
+
+        $netByBranch = [];
+        $hasNullBranch = false;
+        foreach ($lines as $line) {
+            $branchId = $line['branch_id'] ?? null;
+            $key = $branchId === null ? '__null__' : (string) $branchId;
+            if ($branchId === null) {
+                $hasNullBranch = true;
+            }
+            $netByBranch[$key] = ($netByBranch[$key] ?? 0)
+                + $this->toCents($line['debit'] ?? 0)
+                - $this->toCents($line['credit'] ?? 0);
+        }
+
+        if (count($netByBranch) <= 1) {
+            return $lines;
+        }
+
+        if ($hasNullBranch) {
+            throw new RuntimeException(
+                'Cannot inject inter-branch clearing: a journal line has an unresolved branch '
+                . 'while the entry spans multiple branches.',
+            );
+        }
+
+        if ($clearingAccountId === null) {
+            throw new RuntimeException(
+                'Cannot inject inter-branch clearing: clearing account (' . self::CLEARING_CODE . ') '
+                . 'is not configured for this fiscal year.',
+            );
+        }
+
+        $branchIds = array_map('intval', array_keys($netByBranch));
+        sort($branchIds);
+
+        $injected = [];
+        foreach ($branchIds as $branchId) {
+            $net = $netByBranch[(string) $branchId];
+            if ($net === 0) {
+                continue;
+            }
+
+            $injected[] = [
+                'account_id' => $clearingAccountId,
+                'branch_id' => $branchId,
+                'debit' => $net < 0 ? $this->fromCents(-$net) : '0.00',
+                'credit' => $net > 0 ? $this->fromCents($net) : '0.00',
+                'memo' => self::CLEARING_MEMO,
+            ];
+        }
+
+        return array_merge($lines, $injected);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $lines
+     */
+    public function assertBalancedPerBranch(array $lines): void
+    {
+        $netByBranch = [];
+        foreach ($lines as $line) {
+            $branchId = $line['branch_id'] ?? null;
+            $key = $branchId === null ? '__null__' : (string) $branchId;
+            $netByBranch[$key] = ($netByBranch[$key] ?? 0)
+                + $this->toCents($line['debit'] ?? 0)
+                - $this->toCents($line['credit'] ?? 0);
+        }
+
+        foreach ($netByBranch as $key => $net) {
+            if ($net !== 0) {
+                throw new RuntimeException(
+                    "Per-branch balance guard failed for branch [{$key}]: net {$net} cents.",
+                );
+            }
+        }
+    }
+
+    public function resolveAccountIdForFiscalYear(int $fiscalYearId): ?int
+    {
+        $coaVersion = CoaVersion::query()
+            ->where('fiscal_year_id', $fiscalYearId)
+            ->orderByRaw("CASE status WHEN 'active' THEN 0 WHEN 'archived' THEN 1 WHEN 'draft' THEN 2 ELSE 3 END")
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $coaVersion) {
+            return null;
+        }
+
+        $id = Account::query()
+            ->where('coa_version_id', $coaVersion->id)
+            ->where('code', self::CLEARING_CODE)
+            ->value('id');
+
+        return $id !== null ? (int) $id : null;
+    }
+
+    private function toCents(mixed $value): int
+    {
+        return (int) round(((float) $value) * 100);
+    }
+
+    private function fromCents(int $cents): string
+    {
+        return number_format($cents / 100, 2, '.', '');
+    }
+}

--- a/tests/Feature/JournalEntries/InterBranchClearingEngineTest.php
+++ b/tests/Feature/JournalEntries/InterBranchClearingEngineTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\JournalEntries;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\Account;
+use App\Models\Branch;
+use App\Models\CoaVersion;
+use App\Models\FiscalYear;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\seed;
+
+uses(RefreshDatabase::class)->group('inter-branch-clearing');
+
+beforeEach(function () {
+    seed();
+
+    $this->fiscalYear = FiscalYear::where('status', 'open')->firstOrFail();
+    /** @var CoaVersion $coaVersion */
+    $coaVersion = $this->fiscalYear->coaVersions()->where('status', 'active')->firstOrFail();
+    $this->accountMap = Account::where('coa_version_id', $coaVersion->id)
+        ->pluck('id', 'code')
+        ->toArray();
+    $this->clearingId = (int) $this->accountMap['1999-IBC'];
+
+    $this->user = User::firstOrFail();
+    $this->branchA = Branch::factory()->create(['name' => 'Branch A']);
+    $this->branchB = Branch::factory()->create(['name' => 'Branch B']);
+
+    $this->action = app(CreateJournalEntryAction::class);
+});
+
+test('single-branch posted entry persists no clearing line (dormant)', function () {
+    $entry = $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Single-branch entry',
+        'status' => 'posted',
+        'branch_id' => $this->branchA->id,
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'debit' => 1000, 'credit' => 0],
+            ['account_id' => $this->accountMap['41000'], 'debit' => 0, 'credit' => 1000],
+        ],
+    ]);
+
+    $lines = $entry->lines()->get();
+    expect($lines)->toHaveCount(2);
+    expect($lines->where('account_id', $this->clearingId))->toHaveCount(0);
+    expect($lines->every(fn ($l) => (int) $l->branch_id === $this->branchA->id))->toBeTrue();
+});
+
+test('multi-branch posted entry injects per-branch clearing lines', function () {
+    $entry = $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Inter-branch cash transfer A -> B',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500],
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchB->id, 'debit' => 500, 'credit' => 0],
+        ],
+    ]);
+
+    $lines = $entry->lines()->get();
+
+    $clearing = $lines->where('account_id', $this->clearingId);
+    expect($clearing)->toHaveCount(2);
+
+    foreach ([$this->branchA->id, $this->branchB->id] as $branchId) {
+        $branchLines = $lines->where('branch_id', $branchId);
+        $debit = $branchLines->sum(fn ($l) => (int) round(((float) $l->debit) * 100));
+        $credit = $branchLines->sum(fn ($l) => (int) round(((float) $l->credit) * 100));
+        expect($debit)->toBe($credit);
+    }
+
+    $clearingNet = $clearing->sum(fn ($l) => (int) round(((float) $l->debit) * 100) - (int) round(((float) $l->credit) * 100));
+    expect($clearingNet)->toBe(0);
+});
+
+test('multi-branch entry remains globally balanced after injection', function () {
+    $entry = $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'HQ centralized payment for A and B',
+        'status' => 'posted',
+        'branch_id' => null,
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 300],
+            ['account_id' => $this->accountMap['52000'], 'branch_id' => $this->branchA->id, 'debit' => 100, 'credit' => 0],
+            ['account_id' => $this->accountMap['52000'], 'branch_id' => $this->branchB->id, 'debit' => 200, 'credit' => 0],
+        ],
+    ]);
+
+    $lines = $entry->lines()->get();
+    $totalDebit = $lines->sum(fn ($l) => (int) round(((float) $l->debit) * 100));
+    $totalCredit = $lines->sum(fn ($l) => (int) round(((float) $l->credit) * 100));
+    expect($totalDebit)->toBe($totalCredit);
+});

--- a/tests/Unit/Services/InterBranchClearingServiceTest.php
+++ b/tests/Unit/Services/InterBranchClearingServiceTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\InterBranchClearingService;
+use RuntimeException;
+
+uses()->group('inter-branch-clearing');
+
+beforeEach(function () {
+    $this->service = new InterBranchClearingService;
+    $this->clearingId = 999;
+});
+
+function netByBranch(array $lines): array
+{
+    $net = [];
+    foreach ($lines as $line) {
+        $key = $line['branch_id'] === null ? 'null' : (string) $line['branch_id'];
+        $net[$key] = ($net[$key] ?? 0)
+            + (int) round(((float) $line['debit']) * 100)
+            - (int) round(((float) $line['credit']) * 100);
+    }
+
+    return $net;
+}
+
+test('single-branch balanced entry injects nothing', function () {
+    $lines = [
+        ['account_id' => 1, 'branch_id' => 5, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 2, 'branch_id' => 5, 'debit' => 0, 'credit' => 100, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, $this->clearingId);
+
+    expect($result)->toHaveCount(2);
+    expect(collect($result)->where('account_id', $this->clearingId))->toHaveCount(0);
+});
+
+test('null-branch single-group entry injects nothing (current data)', function () {
+    $lines = [
+        ['account_id' => 1, 'branch_id' => null, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 2, 'branch_id' => null, 'debit' => 0, 'credit' => 100, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, $this->clearingId);
+
+    expect($result)->toHaveCount(2);
+});
+
+test('two-branch cash transfer injects balancing clearing lines', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 0, 'credit' => 500, 'memo' => null],
+        ['account_id' => 10, 'branch_id' => 2, 'debit' => 500, 'credit' => 0, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, $this->clearingId);
+
+    $net = netByBranch($result);
+    expect($net['1'])->toBe(0);
+    expect($net['2'])->toBe(0);
+
+    $clearing = collect($result)->where('account_id', $this->clearingId)->values();
+    expect($clearing)->toHaveCount(2);
+    $totalDebitCents = collect($result)->sum(fn ($l) => (int) round(((float) $l['debit']) * 100));
+    $totalCreditCents = collect($result)->sum(fn ($l) => (int) round(((float) $l['credit']) * 100));
+    expect($totalDebitCents)->toBe($totalCreditCents);
+});
+
+test('HQ centralized payment for two branches', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 9, 'debit' => 0, 'credit' => 300, 'memo' => null],
+        ['account_id' => 50, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 50, 'branch_id' => 2, 'debit' => 200, 'credit' => 0, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, $this->clearingId);
+
+    $net = netByBranch($result);
+    expect($net['9'])->toBe(0);
+    expect($net['1'])->toBe(0);
+    expect($net['2'])->toBe(0);
+
+    $clearing = collect($result)->where('account_id', $this->clearingId);
+    $clearingNetCents = $clearing->sum(fn ($l) => (int) round(((float) $l['debit']) * 100) - (int) round(((float) $l['credit']) * 100));
+    expect($clearingNetCents)->toBe(0);
+});
+
+test('three branches with one zero-net branch', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 11, 'branch_id' => 1, 'debit' => 0, 'credit' => 100, 'memo' => null],
+        ['account_id' => 12, 'branch_id' => 2, 'debit' => 0, 'credit' => 400, 'memo' => null],
+        ['account_id' => 13, 'branch_id' => 3, 'debit' => 400, 'credit' => 0, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, $this->clearingId);
+
+    $net = netByBranch($result);
+    expect($net['1'])->toBe(0);
+    expect($net['2'])->toBe(0);
+    expect($net['3'])->toBe(0);
+
+    $clearing = collect($result)->where('account_id', $this->clearingId);
+    expect($clearing)->toHaveCount(2);
+});
+
+test('one-cent residual distributes without drift', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 9, 'debit' => 0, 'credit' => 100, 'memo' => null],
+        ['account_id' => 50, 'branch_id' => 1, 'debit' => 33.33, 'credit' => 0, 'memo' => null],
+        ['account_id' => 50, 'branch_id' => 2, 'debit' => 33.33, 'credit' => 0, 'memo' => null],
+        ['account_id' => 50, 'branch_id' => 3, 'debit' => 33.34, 'credit' => 0, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, $this->clearingId);
+
+    foreach (netByBranch($result) as $net) {
+        expect($net)->toBe(0);
+    }
+
+    $clearingNetCents = collect($result)
+        ->where('account_id', $this->clearingId)
+        ->sum(fn ($l) => (int) round(((float) $l['debit']) * 100) - (int) round(((float) $l['credit']) * 100));
+    expect($clearingNetCents)->toBe(0);
+});
+
+test('injection is idempotent (run twice equals once)', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 0, 'credit' => 500, 'memo' => null],
+        ['account_id' => 10, 'branch_id' => 2, 'debit' => 500, 'credit' => 0, 'memo' => null],
+    ];
+
+    $once = $this->service->inject($lines, $this->clearingId);
+    $twice = $this->service->inject($once, $this->clearingId);
+
+    expect($twice)->toEqual($once);
+});
+
+test('throws when multi-branch entry has an unresolved branch line', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 11, 'branch_id' => null, 'debit' => 0, 'credit' => 100, 'memo' => null],
+    ];
+
+    expect(fn () => $this->service->inject($lines, $this->clearingId))
+        ->toThrow(RuntimeException::class);
+});
+
+test('throws when multi-branch entry has no clearing account configured', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 0, 'credit' => 500, 'memo' => null],
+        ['account_id' => 10, 'branch_id' => 2, 'debit' => 500, 'credit' => 0, 'memo' => null],
+    ];
+
+    expect(fn () => $this->service->inject($lines, null))
+        ->toThrow(RuntimeException::class);
+});
+
+test('guard throws on per-branch imbalance', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 11, 'branch_id' => 2, 'debit' => 0, 'credit' => 100, 'memo' => null],
+    ];
+
+    expect(fn () => $this->service->assertBalancedPerBranch($lines))
+        ->toThrow(RuntimeException::class);
+});
+
+test('guard passes on balanced single-branch set', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 11, 'branch_id' => 1, 'debit' => 0, 'credit' => 100, 'memo' => null],
+    ];
+
+    $this->service->assertBalancedPerBranch($lines);
+    expect(true)->toBeTrue();
+});
+
+test('property: random balanced multi-branch sets self-balance per branch', function () {
+    for ($i = 0; $i < 50; $i++) {
+        $branchCount = random_int(1, 4);
+        $lines = [];
+        $globalCents = 0;
+        for ($b = 1; $b <= $branchCount; $b++) {
+            $amount = random_int(1, 100000);
+            $lines[] = ['account_id' => 10, 'branch_id' => $b, 'debit' => $amount / 100, 'credit' => 0, 'memo' => null];
+            $globalCents += $amount;
+        }
+        $lines[] = ['account_id' => 20, 'branch_id' => 1, 'debit' => 0, 'credit' => $globalCents / 100, 'memo' => null];
+
+        $result = $this->service->inject($lines, $this->clearingId);
+
+        foreach (netByBranch($result) as $net) {
+            expect($net)->toBe(0);
+        }
+
+        $clearingNetCents = collect($result)
+            ->where('account_id', $this->clearingId)
+            ->sum(fn ($l) => (int) round(((float) $l['debit']) * 100) - (int) round(((float) $l['credit']) * 100));
+        expect($clearingNetCents)->toBe(0);
+    }
+});


### PR DESCRIPTION
feat(accounting): inter-branch clearing engine (full 2b PR3)

The riskiest PR of the per-branch 2b initiative. Makes every posted journal
SELF-BALANCE PER BRANCH by auto-injecting balancing lines to the single
Inter-Branch Clearing account (1999-IBC, seeded in PR2). Reviewed by Oracle
before implementation.

## New: InterBranchClearingService (pure, DB-free core)
- `inject(lines, clearingAccountId)`: strips existing clearing lines
  (idempotent), groups by resolved branch_id, computes per-branch net in
  INTEGER CENTS (exact — clearing nets to 0 company-wide by construction),
  injects one clearing line per imbalanced branch (sorted by id for
  deterministic output). Single-branch / single-group input => zero injected
  lines (engine is dormant on all current data). Fail-closed: throws if a line
  has an unresolved branch while the entry spans multiple branches, or if no
  clearing account is configured.
- `assertBalancedPerBranch(lines)`: post-injection guard, integer-cent, throws
  to roll back the transaction on any per-branch imbalance. This is the
  anti-ledger-corruption safety net.
- `resolveAccountIdForFiscalYear()`: DB lookup of 1999-IBC within the fiscal
  year's COA version (version-safe), kept out of the pure methods.

## Wiring (all 4 write paths route through the service)
- CreateJournalEntryAction: threads per-line branch_id (line -> header ->
  default), injects + guards INSIDE the transaction after entry creation,
  persists branch_id on each line. Injection is side-effect-free so it stays
  safe inside the existing entry_number retry loop.
- UpdateJournalEntryAction (draft-only): same strip-and-regenerate on
  delete/recreate. Also removed a stale block of developer-musing comments.
- ExecuteRecurringJournalAction + ClosePeriodAction (the 2 funnel bypasses):
  routed through the service. Both are single-branch today => provable no-op,
  but inherit the per-branch guard. Per-branch period closing (correct RE
  attribution) is deferred to PR6 per Oracle; PR3 keeps closing single-branch
  so the engine no-ops and the per-branch trial-balance invariant holds.

## Design decisions (user-confirmed)
- Single clearing account + balance-sheet sign reclassification (Due-From /
  Due-To) — reclassification lands in PR5b.
- Manual multi-branch journals: auto-insert clearing (UI preview in PR7).
- Clearing account resolved by CODE per COA version (not a settings id) —
  version-safe; documented deviation from plan §3-Q1.

## Tests
- Unit (InterBranchClearingServiceTest, 12 tests / 209 assertions): single &
  null-branch no-op, two-branch transfer, HQ centralized payment, 3-branch with
  zero-net branch, 1-cent residual, idempotency, fail-closed cases, guard, and a
  50-iteration property test (every branch balances, global balance preserved,
  clearing nets to 0, injection count == #nonzero-net branches).
- Feature (InterBranchClearingEngineTest, 3 tests): engine fires through real
  persistence (clearing lines created in DB, each branch balances, global
  balance preserved) + single-branch dormancy.

## Verified (local)
Zero behavior change on current single-branch data. Green: clearing unit 12,
engine feature 3, journal-entries 48, recurring-journals 17, period-closings 13,
posting-journals 3, reports 45. Duster + PHPStan clean on all changed files.
