### PR TITLE
feat(accounting): switch financial reports to line-level branch_id (full 2b PR5a)

### DIFF
--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -86,7 +86,7 @@ class FinancialReportService
             ->where('journal_entries.status', 'posted')
             ->where('accounts.coa_version_id', $coaVersion->id)
             ->whereIn('accounts.type', ['revenue', 'expense'])
-            ->when($branchId !== null, fn ($query) => $query->where('journal_entries.branch_id', $branchId))
+            ->when($branchId !== null, fn ($query) => $query->where('journal_entry_lines.branch_id', $branchId))
             ->select([
                 'journal_entries.entry_date as entry_date',
                 'accounts.type as account_type',
@@ -723,7 +723,7 @@ class FinancialReportService
             ->join('journal_entries', 'journal_entries.id', '=', 'journal_entry_lines.journal_entry_id')
             ->where('journal_entries.fiscal_year_id', $fiscalYearId)
             ->where('journal_entries.status', 'posted')
-            ->when($branchId !== null, fn ($q) => $q->where('journal_entries.branch_id', $branchId))
+            ->when($branchId !== null, fn ($q) => $q->where('journal_entry_lines.branch_id', $branchId))
             ->groupBy('journal_entry_lines.account_id')
             ->select('journal_entry_lines.account_id')
             ->selectRaw('SUM(journal_entry_lines.debit) as posted_debit_sum')

--- a/tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php
+++ b/tests/Feature/FinancialDashboard/FinancialDashboardControllerTest.php
@@ -292,6 +292,7 @@ describe('Financial Dashboard API', function () {
         JournalEntryLine::factory()->create([
             'journal_entry_id' => $branchEntry->id,
             'account_id' => $revenueAccount->id,
+            'branch_id' => $branch->id,
             'debit' => 0,
             'credit' => 400000,
         ]);
@@ -304,6 +305,7 @@ describe('Financial Dashboard API', function () {
         JournalEntryLine::factory()->create([
             'journal_entry_id' => $companyWideEntry->id,
             'account_id' => $revenueAccount->id,
+            'branch_id' => null,
             'debit' => 0,
             'credit' => 600000,
         ]);

--- a/tests/Feature/Reports/PerBranchFinancialReportTest.php
+++ b/tests/Feature/Reports/PerBranchFinancialReportTest.php
@@ -57,6 +57,7 @@ function seedBranchJournal(FiscalYear $fiscalYear, array $accountMap, User $user
         JournalEntryLine::create([
             'journal_entry_id' => $journal->id,
             'account_id' => $accountMap[$code],
+            'branch_id' => $branchId,
             'debit' => $debit,
             'credit' => $credit,
             'memo' => 'fixture',
@@ -161,6 +162,47 @@ test('balance sheet endpoint accepts branch_id and scopes the report', function 
         ->assertJsonPath('report.totals.assets', 1400000)
         ->assertJsonPath('report.totals.liabilities', 400000)
         ->assertJsonPath('report.totals.equity', 1000000);
+});
+
+test('reports filter by line-level branch, not header branch', function () {
+    $journal = JournalEntry::create([
+        'fiscal_year_id' => $this->fiscalYear->id,
+        'entry_number' => 'JV-SPLIT-1',
+        'entry_date' => '2026-02-01',
+        'reference' => 'JV-SPLIT-1',
+        'description' => 'Header A, lines split A/B',
+        'status' => 'posted',
+        'branch_id' => $this->branchA->id,
+        'created_by' => $this->user->id,
+        'posted_by' => $this->user->id,
+        'posted_at' => now(),
+    ]);
+
+    JournalEntryLine::create([
+        'journal_entry_id' => $journal->id,
+        'account_id' => $this->accountMap['11110'],
+        'branch_id' => $this->branchB->id,
+        'debit' => 700000,
+        'credit' => 0,
+        'memo' => 'split line to B',
+    ]);
+    JournalEntryLine::create([
+        'journal_entry_id' => $journal->id,
+        'account_id' => $this->accountMap['41000'],
+        'branch_id' => $this->branchA->id,
+        'debit' => 0,
+        'credit' => 700000,
+        'memo' => 'split line to A',
+    ]);
+
+    $reportB = $this->service->getTrialBalance($this->fiscalYear->id, $this->branchB->id);
+    $cashRowB = collect($reportB)->firstWhere('code', '11110');
+    expect($cashRowB)->not->toBeNull();
+    expect(round($cashRowB['debit'], 2))->toBe(700000.0);
+
+    $reportA = $this->service->getTrialBalance($this->fiscalYear->id, $this->branchA->id);
+    $cashRowA = collect($reportA)->firstWhere('code', '11110');
+    expect(round((float) ($cashRowA['debit'] ?? 0), 2))->toBe(0.0);
 });
 
 test('balance sheet export validates branch_id', function () {


### PR DESCRIPTION
feat(accounting): switch financial reports to line-level branch_id (full 2b PR5a)

Activates the line-level branch dimension for financial reports. The two GL
aggregation methods that powered per-branch filtering by HEADER branch_id now
filter by LINE branch_id (journal_entry_lines.branch_id):

- FinancialReportService::accountsWithPostedSums (backs trial balance, balance
  sheet, income statement, comparative, calculateNetIncome)
- FinancialReportService::getMonthlyTrends (backs financial dashboard)

Because PR1 backfilled line.branch_id = header branch_id and PR3's clearing
engine keeps every posted journal self-balancing per branch, this is
byte-identical for all single-branch data (the entirety of current data). The
switch only changes behavior for genuinely multi-branch journals, where each
line is now attributed to its OWN branch rather than the header's.

Tests:
- New regression test 'reports filter by line-level branch, not header branch':
  a journal with header=A but lines split A/B proves branch B sees its line and
  branch A does not — exactly the shape PR3's engine produces. This would have
  passed spuriously under header-level filtering.
- Updated PerBranchFinancialReportTest fixture + FinancialDashboard branch-scope
  fixture to tag line branch_id (mirroring the post-PR3 reality where the engine
  sets line branch = header). These previously relied on header-only attribution.

Verified: reports group 46 green, financial-dashboard 11 green, aging-dashboard
15 green. Duster + PHPStan clean.

Note: the synthetic balance-sheet CYE is still computed company-wide-per-branch
via calculateNetIncome (already line-level now). Clearing-account sign
reclassification (Due-From/Due-To presentation) lands in PR5b.
