### PR TITLE
feat(accounting): per-branch clearing reclassification on balance sheet (full 2b PR5b)

### DIFF
--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -168,6 +168,14 @@ class FinancialReportService
             $comparisonNetIncome = $this->calculateNetIncome($comparisonFiscalYearId, $comparisonCoaVersion->id, $branchId);
         }
 
+        $clearingReclass = $this->extractClearingReclassification(
+            $accounts,
+            $branchId,
+            $comparisonFiscalYearId,
+            $comparisonBalanceByCurrentAccountId,
+        );
+        $accounts = $clearingReclass['accounts'];
+
         ['buckets' => $buckets, 'totals' => $totals] = $this->collectAccountBuckets(
             $accounts,
             $comparisonFiscalYearId,
@@ -178,6 +186,13 @@ class FinancialReportService
                 'equity' => ['bucket' => 'equity', 'total' => 'equity'],
             ]
         );
+
+        if ($clearingReclass['item'] !== null) {
+            $bucket = $clearingReclass['bucket'];
+            $buckets[$bucket][] = $clearingReclass['item'];
+            $totals[$bucket] += $clearingReclass['item']['balance'];
+            $totals["comparison_{$bucket}"] += $clearingReclass['item']['comparison_balance'];
+        }
 
         // Add Current Year Earnings to Equity
         $buckets['equity'][] = [
@@ -427,6 +442,65 @@ class FinancialReportService
                 $comparisonCoaVersion,
                 $branchId,
             ),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Account>  $accounts
+     * @param  array<int, float>  $comparisonBalanceByCurrentAccountId
+     * @return array{accounts: Collection<int, Account>, item: array<string, mixed>|null, bucket: string}
+     */
+    private function extractClearingReclassification(
+        Collection $accounts,
+        ?int $branchId,
+        ?int $comparisonFiscalYearId,
+        array $comparisonBalanceByCurrentAccountId,
+    ): array {
+        if ($branchId === null) {
+            return ['accounts' => $accounts, 'item' => null, 'bucket' => 'assets'];
+        }
+
+        /** @var Account|null $clearing */
+        $clearing = $accounts->firstWhere('code', InterBranchClearingService::CLEARING_CODE);
+
+        if (! $clearing) {
+            return ['accounts' => $accounts, 'item' => null, 'bucket' => 'assets'];
+        }
+
+        $remaining = $accounts->reject(
+            fn (Account $account): bool => $account->code === InterBranchClearingService::CLEARING_CODE,
+        )->values();
+
+        $balance = $this->computeAccountBalance(
+            $clearing->normal_balance,
+            $clearing->posted_debit_sum ?? 0,
+            $clearing->posted_credit_sum ?? 0,
+        );
+        $comparisonBalance = $comparisonFiscalYearId
+            ? (float) ($comparisonBalanceByCurrentAccountId[$clearing->id] ?? 0)
+            : 0.0;
+
+        if (round($balance, 2) === 0.0 && round($comparisonBalance, 2) === 0.0) {
+            return ['accounts' => $remaining, 'item' => null, 'bucket' => 'assets'];
+        }
+
+        $isDueFrom = $balance >= 0;
+
+        $item = [
+            'id' => $clearing->id,
+            'code' => $clearing->code,
+            'name' => $isDueFrom ? 'Due From Branches' : 'Due To Branches',
+            'level' => 1,
+            'parent_id' => null,
+            'balance' => $isDueFrom ? $balance : -$balance,
+            'comparison_balance' => $isDueFrom ? $comparisonBalance : -$comparisonBalance,
+            'sub_type' => $isDueFrom ? 'current_asset' : 'current_liability',
+        ];
+
+        return [
+            'accounts' => $remaining,
+            'item' => $item,
+            'bucket' => $isDueFrom ? 'assets' : 'liabilities',
         ];
     }
 

--- a/tests/Feature/Reports/PerBranchFinancialReportTest.php
+++ b/tests/Feature/Reports/PerBranchFinancialReportTest.php
@@ -205,6 +205,67 @@ test('reports filter by line-level branch, not header branch', function () {
     expect(round((float) ($cashRowA['debit'] ?? 0), 2))->toBe(0.0);
 });
 
+test('balance sheet reclassifies clearing slice as Due From / Due To per branch', function () {
+    $entry = JournalEntry::create([
+        'fiscal_year_id' => $this->fiscalYear->id,
+        'entry_number' => 'JV-IBC-1',
+        'entry_date' => '2026-02-01',
+        'reference' => 'JV-IBC-1',
+        'description' => 'Inter-branch cash transfer A -> B',
+        'status' => 'posted',
+        'branch_id' => null,
+        'created_by' => $this->user->id,
+        'posted_by' => $this->user->id,
+        'posted_at' => now(),
+    ]);
+
+    // Branch A sends cash (net credit) -> clearing net debit for A (Due From).
+    // Branch B receives cash (net debit) -> clearing net credit for B (Due To).
+    $rows = [
+        ['11110', $this->branchA->id, 0, 500000],
+        ['1999-IBC', $this->branchA->id, 500000, 0],
+        ['11110', $this->branchB->id, 500000, 0],
+        ['1999-IBC', $this->branchB->id, 0, 500000],
+    ];
+    foreach ($rows as [$code, $branchId, $debit, $credit]) {
+        JournalEntryLine::create([
+            'journal_entry_id' => $entry->id,
+            'account_id' => $this->accountMap[$code],
+            'branch_id' => $branchId,
+            'debit' => $debit,
+            'credit' => $credit,
+            'memo' => 'fixture',
+        ]);
+    }
+
+    $reportA = $this->service->getBalanceSheet($this->fiscalYear->id, null, $this->branchA->id);
+    $dueFromA = collect($reportA['assets'])->firstWhere('code', '1999-IBC');
+    expect($dueFromA)->not->toBeNull();
+    expect($dueFromA['name'])->toBe('Due From Branches');
+    expect(round($dueFromA['balance'], 2))->toBe(500000.0);
+    expect(collect($reportA['liabilities'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(round($reportA['totals']['assets'], 2))
+        ->toBe(round($reportA['totals']['liabilities'] + $reportA['totals']['equity'], 2));
+
+    $reportB = $this->service->getBalanceSheet($this->fiscalYear->id, null, $this->branchB->id);
+    $dueToB = collect($reportB['liabilities'])->firstWhere('code', '1999-IBC');
+    expect($dueToB)->not->toBeNull();
+    expect($dueToB['name'])->toBe('Due To Branches');
+    expect(round($dueToB['balance'], 2))->toBe(500000.0);
+    expect(collect($reportB['assets'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(round($reportB['totals']['assets'], 2))
+        ->toBe(round($reportB['totals']['liabilities'] + $reportB['totals']['equity'], 2));
+});
+
+test('company-wide balance sheet does not reclassify clearing (byte-identical)', function () {
+    seedTwoBranchFixtures($this);
+
+    $companyWide = $this->service->getBalanceSheet($this->fiscalYear->id);
+
+    expect(collect($companyWide['liabilities'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(collect($companyWide['assets'])->firstWhere('name', 'Due From Branches'))->toBeNull();
+});
+
 test('balance sheet export validates branch_id', function () {
     $user = createTestUserWithPermissions(['balance_sheet_report']);
 


### PR DESCRIPTION
feat(accounting): per-branch clearing reclassification on balance sheet (full 2b PR5b)

Completes the per-branch balance sheet. The single Inter-Branch Clearing account
(1999-IBC) is now reclassified by SIGN per branch when a branch is selected:
- net-debit slice  -> "Due From Branches" (current asset)
- net-credit slice -> "Due To Branches"  (current liability)

This is the presentation half of the user-confirmed "single account + sign
reclassification" model. The accounting equation already balanced per branch
(clearing is a debit-normal asset and PR3 guarantees each branch self-balances);
this fixes the PRESENTATION so a branch that owes other branches shows a Due-To
liability instead of a negative asset.

Implementation:
- getBalanceSheet: new extractClearingReclassification() pulls 1999-IBC out of
  the asset list (when branchId != null), computes its per-branch balance, and
  injects a root-level Due-From/Due-To item into the correct bucket. Mirrors the
  existing synthetic-CYE injection seam.
- Per-branch CYE was already line-level (calculateNetIncome flows through
  accountsWithPostedSums, switched in PR5a) — no change needed there.

Dormant-safe / byte-identical:
- branchId == null (company-wide): no reclassification (clearing nets to 0
  company-wide anyway). Explicit regression test.
- single-branch / zero clearing slice: skipped. All current data unaffected.

Tests:
- 'balance sheet reclassifies clearing slice as Due From / Due To per branch':
  inter-branch transfer A->B; branch A shows Due From (asset, 500k), branch B
  shows Due To (liability, 500k); each branch's A == L + E holds.
- 'company-wide balance sheet does not reclassify clearing (byte-identical)'.

Verified: reports group 48 green. Duster + PHPStan clean.
