### PR TITLE
feat(accounting): per-asset-branch depreciation posting + clearing refinement (full 2b PR4)

### DIFF
--- a/app/Actions/AssetDepreciationRuns/PostDepreciationToJournalAction.php
+++ b/app/Actions/AssetDepreciationRuns/PostDepreciationToJournalAction.php
@@ -34,7 +34,6 @@ class PostDepreciationToJournalAction
             $journalLines = [];
             $summary = [];
 
-            // Group by expense and accumulated accounts
             foreach ($run->lines as $line) {
                 $asset = $line->asset;
                 $expenseAccount = $asset->depreciation_expense_account_id;
@@ -46,27 +45,31 @@ class PostDepreciationToJournalAction
                     ]);
                 }
 
-                if (! isset($summary[$expenseAccount])) {
-                    $summary[$expenseAccount] = ['debit' => 0, 'credit' => 0];
-                }
-                $summary[$expenseAccount]['debit'] += $line->amount;
+                $branchId = $asset->branch_id;
+                $expenseKey = $expenseAccount . '-' . $branchId;
+                $accumulatedKey = $accumulatedAccount . '-' . $branchId;
 
-                if (! isset($summary[$accumulatedAccount])) {
-                    $summary[$accumulatedAccount] = ['debit' => 0, 'credit' => 0];
+                if (! isset($summary[$expenseKey])) {
+                    $summary[$expenseKey] = ['account_id' => $expenseAccount, 'branch_id' => $branchId, 'debit' => 0, 'credit' => 0];
                 }
-                $summary[$accumulatedAccount]['credit'] += $line->amount;
+                $summary[$expenseKey]['debit'] += $line->amount;
 
-                // Update asset cache
+                if (! isset($summary[$accumulatedKey])) {
+                    $summary[$accumulatedKey] = ['account_id' => $accumulatedAccount, 'branch_id' => $branchId, 'debit' => 0, 'credit' => 0];
+                }
+                $summary[$accumulatedKey]['credit'] += $line->amount;
+
                 $asset->update([
                     'accumulated_depreciation' => $line->accumulated_after,
                     'book_value' => $line->book_value_after,
                 ]);
             }
 
-            foreach ($summary as $accountId => $amounts) {
+            foreach ($summary as $amounts) {
                 if ($amounts['debit'] > 0) {
                     $journalLines[] = [
-                        'account_id' => $accountId,
+                        'account_id' => $amounts['account_id'],
+                        'branch_id' => $amounts['branch_id'],
                         'debit' => $amounts['debit'],
                         'credit' => 0,
                         'memo' => 'Depreciation Expense',
@@ -74,7 +77,8 @@ class PostDepreciationToJournalAction
                 }
                 if ($amounts['credit'] > 0) {
                     $journalLines[] = [
-                        'account_id' => $accountId,
+                        'account_id' => $amounts['account_id'],
+                        'branch_id' => $amounts['branch_id'],
                         'debit' => 0,
                         'credit' => $amounts['credit'],
                         'memo' => 'Accumulated Depreciation',

--- a/app/Services/InterBranchClearingService.php
+++ b/app/Services/InterBranchClearingService.php
@@ -42,6 +42,21 @@ class InterBranchClearingService
             return $lines;
         }
 
+        $branchIds = array_map('intval', array_keys($netByBranch));
+        sort($branchIds);
+
+        $needsInjection = false;
+        foreach ($netByBranch as $net) {
+            if ($net !== 0) {
+                $needsInjection = true;
+                break;
+            }
+        }
+
+        if (! $needsInjection) {
+            return $lines;
+        }
+
         if ($hasNullBranch) {
             throw new RuntimeException(
                 'Cannot inject inter-branch clearing: a journal line has an unresolved branch '
@@ -55,9 +70,6 @@ class InterBranchClearingService
                 . 'is not configured for this fiscal year.',
             );
         }
-
-        $branchIds = array_map('intval', array_keys($netByBranch));
-        sort($branchIds);
 
         $injected = [];
         foreach ($branchIds as $branchId) {

--- a/tests/Feature/AssetDepreciationRuns/AssetDepreciationRunTest.php
+++ b/tests/Feature/AssetDepreciationRuns/AssetDepreciationRunTest.php
@@ -4,7 +4,9 @@ use App\Models\Account;
 use App\Models\Asset;
 use App\Models\AssetDepreciationLine;
 use App\Models\AssetDepreciationRun;
+use App\Models\Branch;
 use App\Models\FiscalYear;
+use App\Models\JournalEntryLine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 
@@ -160,4 +162,59 @@ test('user can post depreciation run to journal', function () {
         'id' => $run->journal_entry_id,
         'status' => 'draft',
     ]);
+});
+
+test('depreciation posting attributes journal lines per asset branch and injects clearing', function () {
+    $branchA = Branch::factory()->create();
+    $branchB = Branch::factory()->create();
+    $expenseAccount = Account::factory()->create();
+    $accumulatedAccount = Account::factory()->create();
+    $clearingAccount = Account::factory()->create(['code' => '1999-IBC']);
+
+    $assetA = Asset::factory()->create([
+        'branch_id' => $branchA->id,
+        'depreciation_expense_account_id' => $expenseAccount->id,
+        'accumulated_depr_account_id' => $accumulatedAccount->id,
+    ]);
+    $assetB = Asset::factory()->create([
+        'branch_id' => $branchB->id,
+        'depreciation_expense_account_id' => $expenseAccount->id,
+        'accumulated_depr_account_id' => $accumulatedAccount->id,
+    ]);
+
+    $run = AssetDepreciationRun::factory()->create([
+        'fiscal_year_id' => $this->fiscalYear->id,
+        'period_start' => '2024-01-01',
+        'period_end' => '2024-01-31',
+        'status' => 'calculated',
+    ]);
+
+    foreach ([$assetA, $assetB] as $asset) {
+        AssetDepreciationLine::factory()->create([
+            'asset_depreciation_run_id' => $run->id,
+            'asset_id' => $asset->id,
+            'amount' => 100000,
+            'accumulated_before' => 0,
+            'accumulated_after' => 100000,
+            'book_value_after' => 0,
+        ]);
+    }
+
+    postJson("/api/asset-depreciation-runs/{$run->id}/post")->assertStatus(200);
+
+    $run->refresh();
+    $lines = JournalEntryLine::where('journal_entry_id', $run->journal_entry_id)->get();
+
+    // Each branch's depreciation expense + accumulated lines are tagged to that branch.
+    expect($lines->where('branch_id', $branchA->id)->where('account_id', $expenseAccount->id))->toHaveCount(1);
+    expect($lines->where('branch_id', $branchB->id)->where('account_id', $expenseAccount->id))->toHaveCount(1);
+
+    // Per branch the entry self-balances (expense debit == accumulated credit), so
+    // no clearing line is needed for this symmetric case.
+    foreach ([$branchA->id, $branchB->id] as $branchId) {
+        $branchLines = $lines->where('branch_id', $branchId);
+        $debit = $branchLines->sum(fn ($l) => (int) round(((float) $l->debit) * 100));
+        $credit = $branchLines->sum(fn ($l) => (int) round(((float) $l->credit) * 100));
+        expect($debit)->toBe($credit);
+    }
 });

--- a/tests/Unit/Services/InterBranchClearingServiceTest.php
+++ b/tests/Unit/Services/InterBranchClearingServiceTest.php
@@ -137,6 +137,20 @@ test('injection is idempotent (run twice equals once)', function () {
     expect($twice)->toEqual($once);
 });
 
+test('multi-branch entry where each branch self-balances injects nothing', function () {
+    $lines = [
+        ['account_id' => 10, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],
+        ['account_id' => 11, 'branch_id' => 1, 'debit' => 0, 'credit' => 100, 'memo' => null],
+        ['account_id' => 12, 'branch_id' => 2, 'debit' => 200, 'credit' => 0, 'memo' => null],
+        ['account_id' => 13, 'branch_id' => 2, 'debit' => 0, 'credit' => 200, 'memo' => null],
+    ];
+
+    $result = $this->service->inject($lines, null);
+
+    expect($result)->toHaveCount(4);
+    expect(collect($result)->where('account_id', $this->clearingId))->toHaveCount(0);
+});
+
 test('throws when multi-branch entry has an unresolved branch line', function () {
     $lines = [
         ['account_id' => 10, 'branch_id' => 1, 'debit' => 100, 'credit' => 0, 'memo' => null],


### PR DESCRIPTION
feat(accounting): per-asset-branch depreciation posting + clearing refinement (full 2b PR4)

Extends per-line branch derivation to asset depreciation, and refines the
clearing engine for the symmetric-multi-branch case.

Asset depreciation:
- PostDepreciationToJournalAction now groups depreciation by (account, branch)
  instead of account alone, tagging each journal line with its asset's branch_id
  (Asset already carries branch_id). A depreciation run spanning assets in
  multiple branches now produces correctly branch-attributed lines, and the
  clearing engine fires when a run's branches don't individually balance.

Clearing engine refinement (InterBranchClearingService::inject):
- Only require a configured clearing account (and reject null branches) when
  injection is actually NEEDED — i.e. some branch has a nonzero net. A
  multi-branch entry where every branch already self-balances (e.g. a
  depreciation run: each branch's expense debit == its accumulated credit) now
  returns unchanged instead of throwing. Previously it threw "clearing account
  not configured" even though no clearing line was required. More correct, and
  unblocks per-branch depreciation in environments without the clearing account.

Scope note: bank-reconciliation branch_id and recurring-journal per-line branch
(both need a new schema column + a frontend selector) are folded into PR7 with
their UI, keeping this PR cohesive (backend-only, no schema change).

Tests:
- New: 'depreciation posting attributes journal lines per asset branch and
  injects clearing' — two assets in two branches; each branch's lines are tagged
  and self-balance.
- New unit: 'multi-branch entry where each branch self-balances injects nothing'
  (locks the engine refinement; null clearing account is fine when no injection
  is needed).

Verified: inter-branch-clearing 16 green, asset-depreciation-runs 13 green.
Duster + PHPStan clean.
