### PR TITLE
feat(accounting): per-branch period closing (full 2b PR6)

### DIFF
--- a/app/Actions/PeriodClosings/ClosePeriodAction.php
+++ b/app/Actions/PeriodClosings/ClosePeriodAction.php
@@ -3,8 +3,6 @@
 namespace App\Actions\PeriodClosings;
 
 use App\Actions\AccountBalances\RecalculateAccountBalancesAction;
-use App\Models\Account;
-use App\Models\AccountBalance;
 use App\Models\JournalEntry;
 use App\Models\PeriodClosing;
 use App\Services\InterBranchClearingService;
@@ -25,6 +23,11 @@ class ClosePeriodAction
                 throw ValidationException::withMessages([
                     'status' => 'Period is already closed.',
                 ]);
+            }
+
+            if ($periodClosing->closing_journal_entry_id) {
+                JournalEntry::where('id', $periodClosing->closing_journal_entry_id)->delete();
+                $periodClosing->update(['closing_journal_entry_id' => null]);
             }
 
             $month = $periodClosing->period_month ?? 12;
@@ -57,12 +60,9 @@ class ClosePeriodAction
 
     private function createAnnualClosingEntry(PeriodClosing $periodClosing): JournalEntry
     {
-        $accounts = Account::query()
-            ->whereIn('type', ['revenue', 'expense'])
-            ->get();
         $entry = JournalEntry::create([
             'fiscal_year_id' => $periodClosing->fiscal_year_id,
-            'entry_number' => 'CL-' . now()->format('YmdHis'),
+            'entry_number' => 'CL-' . now()->format('YmdHis') . '-' . $periodClosing->id,
             'entry_date' => now()->toDateString(),
             'reference' => 'Period Closing #' . $periodClosing->id,
             'description' => 'Annual closing entry',
@@ -74,36 +74,54 @@ class ClosePeriodAction
             'posted_by' => auth()->id(),
             'posted_at' => now(),
         ]);
-        $netIncome = 0.0;
-        $lines = [];
 
-        foreach ($accounts as $account) {
-            $balance = (float) AccountBalance::query()
-                ->where('account_id', $account->id)
-                ->where('fiscal_year_id', $periodClosing->fiscal_year_id)
-                ->where('period_year', $periodClosing->period_year)
-                ->orderByDesc('period_month')
-                ->value('closing_balance');
-            if ($balance == 0.0) {
+        $rows = DB::table('journal_entry_lines')
+            ->join('journal_entries', 'journal_entry_lines.journal_entry_id', '=', 'journal_entries.id')
+            ->join('accounts', 'accounts.id', '=', 'journal_entry_lines.account_id')
+            ->where('journal_entries.fiscal_year_id', $periodClosing->fiscal_year_id)
+            ->where('journal_entries.status', 'posted')
+            ->where('journal_entries.journal_type', '<>', 'closing')
+            ->whereIn('accounts.type', ['revenue', 'expense'])
+            ->groupBy('journal_entry_lines.account_id', 'journal_entry_lines.branch_id', 'accounts.name')
+            ->select('journal_entry_lines.account_id', 'journal_entry_lines.branch_id', 'accounts.name')
+            ->selectRaw('COALESCE(SUM(journal_entry_lines.debit), 0) as debit_total')
+            ->selectRaw('COALESCE(SUM(journal_entry_lines.credit), 0) as credit_total')
+            ->get();
+
+        $lines = [];
+        $netByBranch = [];
+
+        foreach ($rows as $row) {
+            $netCents = $this->toCents($row->debit_total) - $this->toCents($row->credit_total);
+            if ($netCents === 0) {
                 continue;
             }
-            $netIncome += $account->type === 'revenue' ? $balance : -$balance;
+
+            $branchKey = $row->branch_id === null ? 'null' : (string) $row->branch_id;
+            $netByBranch[$branchKey] = ($netByBranch[$branchKey] ?? 0) + $netCents;
+
             $lines[] = [
-                'account_id' => $account->id,
-                'branch_id' => null,
-                'debit' => $account->type === 'revenue' ? abs($balance) : 0,
-                'credit' => $account->type === 'expense' ? abs($balance) : 0,
-                'memo' => 'Close ' . $account->name,
+                'account_id' => $row->account_id,
+                'branch_id' => $row->branch_id,
+                'debit' => $netCents < 0 ? $this->fromCents(-$netCents) : '0.00',
+                'credit' => $netCents > 0 ? $this->fromCents($netCents) : '0.00',
+                'memo' => 'Close ' . $row->name,
             ];
         }
 
-        $lines[] = [
-            'account_id' => $periodClosing->retained_earnings_account_id,
-            'branch_id' => null,
-            'debit' => $netIncome < 0 ? abs($netIncome) : 0,
-            'credit' => $netIncome > 0 ? $netIncome : 0,
-            'memo' => 'Close net income to retained earnings',
-        ];
+        $netIncomeCents = 0;
+        foreach ($netByBranch as $branchKey => $branchNet) {
+            $netIncomeCents -= $branchNet;
+            $branchId = $branchKey === 'null' ? null : (int) $branchKey;
+
+            $lines[] = [
+                'account_id' => $periodClosing->retained_earnings_account_id,
+                'branch_id' => $branchId,
+                'debit' => $branchNet > 0 ? $this->fromCents($branchNet) : '0.00',
+                'credit' => $branchNet < 0 ? $this->fromCents(-$branchNet) : '0.00',
+                'memo' => 'Close net income to retained earnings',
+            ];
+        }
 
         $clearingAccountId = $this->clearing->resolveAccountIdForFiscalYear($periodClosing->fiscal_year_id);
         $lines = $this->clearing->inject($lines, $clearingAccountId);
@@ -119,8 +137,18 @@ class ClosePeriodAction
             ]);
         }
 
-        $periodClosing->update(['net_income' => $netIncome]);
+        $periodClosing->update(['net_income' => $netIncomeCents / 100]);
 
         return $entry;
+    }
+
+    private function toCents(mixed $value): int
+    {
+        return (int) round(((float) $value) * 100);
+    }
+
+    private function fromCents(int $cents): string
+    {
+        return number_format($cents / 100, 2, '.', '');
     }
 }

--- a/app/Actions/PeriodClosings/ReopenPeriodAction.php
+++ b/app/Actions/PeriodClosings/ReopenPeriodAction.php
@@ -2,7 +2,9 @@
 
 namespace App\Actions\PeriodClosings;
 
+use App\Models\JournalEntry;
 use App\Models\PeriodClosing;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class ReopenPeriodAction
@@ -15,19 +17,26 @@ class ReopenPeriodAction
             ]);
         }
 
-        $periodClosing->update([
-            'status' => 'reopened',
-            'reopened_by' => auth()->id(),
-            'reopened_at' => now(),
-        ]);
+        return DB::transaction(function () use ($periodClosing): PeriodClosing {
+            if ($periodClosing->closing_journal_entry_id) {
+                JournalEntry::where('id', $periodClosing->closing_journal_entry_id)->delete();
+            }
 
-        return $periodClosing->refresh()->load([
-            'fiscalYear',
-            'closingJournalEntry',
-            'retainedEarningsAccount',
-            'closedBy',
-            'reopenedBy',
-            'creator',
-        ]);
+            $periodClosing->update([
+                'status' => 'reopened',
+                'reopened_by' => auth()->id(),
+                'reopened_at' => now(),
+                'closing_journal_entry_id' => null,
+            ]);
+
+            return $periodClosing->refresh()->load([
+                'fiscalYear',
+                'closingJournalEntry',
+                'retainedEarningsAccount',
+                'closedBy',
+                'reopenedBy',
+                'creator',
+            ]);
+        });
     }
 }

--- a/tests/Feature/PeriodClosings/PerBranchPeriodClosingTest.php
+++ b/tests/Feature/PeriodClosings/PerBranchPeriodClosingTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\PeriodClosings;
+
+use App\Models\Account;
+use App\Models\Branch;
+use App\Models\FiscalYear;
+use App\Models\JournalEntry;
+use App\Models\JournalEntryLine;
+use App\Models\PeriodClosing;
+use App\Services\InterBranchClearingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class)->group('period-closings');
+
+beforeEach(function () {
+    $this->user = createTestUserWithPermissions(['period_closing', 'period_closing.create', 'period_closing.edit']);
+    Sanctum::actingAs($this->user, ['*']);
+
+    $this->fiscalYear = FiscalYear::factory()->create([
+        'status' => 'open',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+    ]);
+    $this->revenue = Account::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+    $this->expense = Account::factory()->create(['type' => 'expense', 'normal_balance' => 'debit']);
+    $this->retained = Account::factory()->create(['type' => 'equity', 'normal_balance' => 'credit']);
+});
+
+function seedPostedPnlLine(object $ctx, int $accountId, ?int $branchId, float $debit, float $credit): void
+{
+    $entry = JournalEntry::create([
+        'fiscal_year_id' => $ctx->fiscalYear->id,
+        'entry_number' => 'JV-' . uniqid(),
+        'entry_date' => '2026-06-01',
+        'description' => 'P&L activity',
+        'status' => 'posted',
+        'journal_type' => 'general',
+        'branch_id' => $branchId,
+        'created_by' => $ctx->user->id,
+        'posted_by' => $ctx->user->id,
+        'posted_at' => now(),
+    ]);
+    JournalEntryLine::create([
+        'journal_entry_id' => $entry->id,
+        'account_id' => $accountId,
+        'branch_id' => $branchId,
+        'debit' => $debit,
+        'credit' => $credit,
+        'memo' => 'fixture',
+    ]);
+}
+
+function makeAnnualClosing(object $ctx): PeriodClosing
+{
+    return PeriodClosing::factory()->annual()->create([
+        'fiscal_year_id' => $ctx->fiscalYear->id,
+        'period_year' => 2026,
+        'status' => 'draft',
+        'retained_earnings_account_id' => $ctx->retained->id,
+    ]);
+}
+
+test('multi-branch annual close balances each branch with per-branch retained earnings', function () {
+    $branchA = Branch::factory()->create();
+    $branchB = Branch::factory()->create();
+
+    seedPostedPnlLine($this, $this->revenue->id, $branchA->id, 0, 5000);
+    seedPostedPnlLine($this, $this->revenue->id, $branchB->id, 0, 3000);
+    seedPostedPnlLine($this, $this->expense->id, $branchB->id, 1000, 0);
+
+    $closing = makeAnnualClosing($this);
+    postJson("/api/period-closings/{$closing->id}/close")->assertOk();
+
+    $closing->refresh();
+    $lines = JournalEntryLine::where('journal_entry_id', $closing->closing_journal_entry_id)->get();
+
+    foreach ([$branchA->id, $branchB->id] as $branchId) {
+        $branchLines = $lines->where('branch_id', $branchId);
+        $debit = $branchLines->sum(fn ($l) => (int) round(((float) $l->debit) * 100));
+        $credit = $branchLines->sum(fn ($l) => (int) round(((float) $l->credit) * 100));
+        expect($debit)->toBe($credit);
+    }
+
+    $reA = $lines->where('branch_id', $branchA->id)->firstWhere('account_id', $this->retained->id);
+    $reB = $lines->where('branch_id', $branchB->id)->firstWhere('account_id', $this->retained->id);
+    expect(round((float) $reA->credit, 2))->toBe(5000.0);
+    expect(round((float) $reB->credit, 2))->toBe(2000.0);
+
+    expect(round((float) $closing->net_income, 2))->toBe(7000.0);
+
+    $clearing = collect($lines)->filter(fn ($l) => $l->memo === InterBranchClearingService::CLEARING_MEMO);
+    expect($clearing)->toHaveCount(0);
+});
+
+test('all-null single-branch close produces one null-branch retained earnings line', function () {
+    seedPostedPnlLine($this, $this->revenue->id, null, 0, 5000);
+    seedPostedPnlLine($this, $this->expense->id, null, 2000, 0);
+
+    $closing = makeAnnualClosing($this);
+    postJson("/api/period-closings/{$closing->id}/close")->assertOk();
+
+    $closing->refresh();
+    $lines = JournalEntryLine::where('journal_entry_id', $closing->closing_journal_entry_id)->get();
+
+    expect($lines->whereNotNull('branch_id'))->toHaveCount(0);
+    $re = $lines->firstWhere('account_id', $this->retained->id);
+    expect(round((float) $re->credit, 2))->toBe(3000.0);
+    expect(round((float) $closing->net_income, 2))->toBe(3000.0);
+});
+
+test('reopen then reclose does not double-count and leaves one closing entry', function () {
+    seedPostedPnlLine($this, $this->revenue->id, null, 0, 4000);
+
+    $closing = makeAnnualClosing($this);
+    postJson("/api/period-closings/{$closing->id}/close")->assertOk();
+    $closing->refresh();
+    $firstEntryId = $closing->closing_journal_entry_id;
+
+    postJson("/api/period-closings/{$closing->id}/reopen")->assertOk();
+    expect(JournalEntry::find($firstEntryId))->toBeNull();
+
+    postJson("/api/period-closings/{$closing->id}/close")->assertOk();
+    $closing->refresh();
+
+    expect(round((float) $closing->net_income, 2))->toBe(4000.0);
+    expect(JournalEntry::where('source_type', PeriodClosing::class)->where('source_id', $closing->id)->count())->toBe(1);
+});


### PR DESCRIPTION
feat(accounting): per-branch period closing (full 2b PR6)

Final accounting PR of full 2b. Annual period closing now emits per-branch
retained-earnings close lines so each branch's balance sheet balances with
correct RE attribution. Oracle-reviewed before implementation
(ses_1161bc0caffekvgUBdqraSXqqF) — chose Option A.

Option A (compute per-branch P&L directly from posted journal lines):
- createAnnualClosingEntry no longer reads the company-wide account_balances
  table (which has no branch dimension). It aggregates SUM(debit/credit) grouped
  by (account_id, branch_id) over POSTED, NON-CLOSING journal_entry_lines for the
  fiscal year — the same line-level source the reports now use, guaranteeing
  close/report consistency.
- Integer-cent signed placement: each (account, branch) net is zeroed by the
  opposite side; one retained-earnings plug per branch sized to that branch's net
  income. Each branch's closing entry self-balances by construction, so the
  clearing engine no-ops. ONE closing JournalEntry with branch-tagged lines
  (preserves the single closing_journal_entry_id pointer).
- net_income preserved as the company-wide total (Σ per-branch net).

Reclose double-close fix (Oracle finding 2 — pre-existing latent bug):
- ReopenPeriodAction now DELETES the prior posted closing entry (in a
  transaction) and clears closing_journal_entry_id, instead of only flipping
  status. Otherwise the orphaned closing entry stayed in the ledger and a
  re-close would double-count.
- ClosePeriodAction also defensively deletes any stale closing entry before
  re-closing, AND excludes journal_type='closing' from the P&L aggregation —
  either guard alone is insufficient (exclusion protects the computation,
  deletion protects the ledger).
- entry_number now suffixed with the period-closing id to avoid same-second
  collisions on fast reopen→reclose.

Dormant-correct: all-null single-branch data produces one null-branch RE line
identical in shape to before (clearing no-ops via count<=1).

Tests (PerBranchPeriodClosingTest):
- multi-branch close: each branch self-balances, per-branch RE = that branch's
  net income (5000 / 2000), company net_income 7000, zero clearing lines.
- all-null close: single null-branch RE line (3000), net_income 3000.
- reopen+reclose idempotency: prior entry deleted on reopen, exactly one closing
  entry after reclose, net income not double-counted.

Verified: period-closings 16, reports 48, inter-branch-clearing 16 green.
Duster + PHPStan clean.

Defer (Oracle): Option B (per-branch account_balances) — unnecessary; reopen-as-
reversing-entry — deletion-in-transaction is correct while closing is the only
writer of journal_type='closing'.
