### PR TITLE
feat(accounting): bank-rec + recurring per-line branch schema & wiring (full 2b PR7a)

### DIFF
--- a/app/Actions/AccountingPosting/PostBankReconciliationJournalAction.php
+++ b/app/Actions/AccountingPosting/PostBankReconciliationJournalAction.php
@@ -71,6 +71,7 @@ class PostBankReconciliationJournalAction
                 'description' => "Bank Reconciliation - {$bankReconciliation->account->code}",
                 'status' => 'posted',
                 'journal_type' => 'system',
+                'branch_id' => $bankReconciliation->branch_id,
                 'source_type' => BankReconciliation::class,
                 'source_id' => $bankReconciliation->id,
                 'lines' => $lines,

--- a/app/Models/BankReconciliation.php
+++ b/app/Models/BankReconciliation.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Carbon;
 /**
  * @property int $id
  * @property int $account_id
+ * @property int|null $branch_id
  * @property int $fiscal_year_id
  * @property Carbon $reconciliation_date
  * @property Carbon $period_start
@@ -30,6 +31,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Account $account
+ * @property-read Branch|null $branch
  * @property-read User|null $completedBy
  * @property-read User|null $creator
  * @property-read FiscalYear $fiscalYear
@@ -74,6 +76,7 @@ class BankReconciliation extends Model
      */
     protected $fillable = [
         'account_id',
+        'branch_id',
         'fiscal_year_id',
         'reconciliation_date',
         'period_start',
@@ -107,6 +110,11 @@ class BankReconciliation extends Model
     public function account(): BelongsTo
     {
         return $this->belongsTo(Account::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 
     public function fiscalYear(): BelongsTo

--- a/app/Models/RecurringJournalLine.php
+++ b/app/Models/RecurringJournalLine.php
@@ -12,12 +12,14 @@ use Illuminate\Support\Carbon;
  * @property int $id
  * @property int $recurring_journal_id
  * @property int $account_id
+ * @property int|null $branch_id
  * @property numeric $debit
  * @property numeric $credit
  * @property string|null $memo
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Account $account
+ * @property-read Branch|null $branch
  * @property-read RecurringJournal $recurringJournal
  *
  * @method static \Database\Factories\RecurringJournalLineFactory factory($count = null, $state = [])
@@ -48,6 +50,7 @@ class RecurringJournalLine extends Model
     protected $fillable = [
         'recurring_journal_id',
         'account_id',
+        'branch_id',
         'debit',
         'credit',
         'memo',
@@ -64,6 +67,11 @@ class RecurringJournalLine extends Model
     public function recurringJournal(): BelongsTo
     {
         return $this->belongsTo(RecurringJournal::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 
     public function account(): BelongsTo

--- a/database/migrations/2026_06_21_000002_add_branch_id_to_bank_reconciliations_table.php
+++ b/database/migrations/2026_06_21_000002_add_branch_id_to_bank_reconciliations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bank_reconciliations', function (Blueprint $table) {
+            $table
+                ->foreignId('branch_id')
+                ->nullable()
+                ->after('account_id')
+                ->constrained('branches')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bank_reconciliations', function (Blueprint $table) {
+            $table->dropForeign(['branch_id']);
+            $table->dropColumn('branch_id');
+        });
+    }
+};

--- a/database/migrations/2026_06_21_000003_add_branch_id_to_recurring_journal_lines_table.php
+++ b/database/migrations/2026_06_21_000003_add_branch_id_to_recurring_journal_lines_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('recurring_journal_lines', function (Blueprint $table) {
+            $table
+                ->foreignId('branch_id')
+                ->nullable()
+                ->after('account_id')
+                ->constrained('branches')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('recurring_journal_lines', function (Blueprint $table) {
+            $table->dropForeign(['branch_id']);
+            $table->dropColumn('branch_id');
+        });
+    }
+};

--- a/tests/Unit/Models/BankReconciliationTest.php
+++ b/tests/Unit/Models/BankReconciliationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class)->group('bank-reconciliations');
 
 test('it has correct fillable attributes', function () {
-    expect((new BankReconciliation)->getFillable())->toBe(['account_id', 'fiscal_year_id', 'reconciliation_date', 'period_start', 'period_end', 'statement_balance', 'book_balance', 'reconciled_balance', 'difference', 'status', 'notes', 'completed_by', 'completed_at', 'created_by', 'journal_entry_id']);
+    expect((new BankReconciliation)->getFillable())->toBe(['account_id', 'branch_id', 'fiscal_year_id', 'reconciliation_date', 'period_start', 'period_end', 'statement_balance', 'book_balance', 'reconciled_balance', 'difference', 'status', 'notes', 'completed_by', 'completed_at', 'created_by', 'journal_entry_id']);
 });
 
 test('it belongs to account', function () {


### PR DESCRIPTION
feat(accounting): bank-rec + recurring per-line branch schema & wiring (full 2b PR7a)

Backend half of PR7. Adds the branch dimension to the two remaining journal
source domains so their posted lines carry branch_id and the clearing engine
attributes them correctly. (Frontend pickers + clearing preview land in PR7b.)

Schema (both nullable FK -> branches, nullOnDelete):
- bank_reconciliations.branch_id
- recurring_journal_lines.branch_id

Wiring:
- BankReconciliation model: branch_id fillable + branch() relation + PHPDoc.
  PostBankReconciliationJournalAction now passes header branch_id =
  $bankReconciliation->branch_id (single-branch source: one bank account -> one
  branch; CreateJournalEntryAction threads header -> line).
- RecurringJournalLine model: branch_id fillable + branch() relation + PHPDoc.
  ExecuteRecurringJournalAction already reads $line->branch_id (added defensively
  in PR3); now the column exists so per-template-line branch flows through and
  the clearing engine fires for a multi-branch recurring template.

Dormant-correct: branch_id is nullable and unset by default, so existing
bank-rec/recurring posting is byte-identical (single null-branch group ->
clearing no-ops). Behavior only changes once a branch is assigned (PR7b UI).

Tests: bank-reconciliations 52 green (updated the fillable-shape unit assertion
to include branch_id), recurring-journals 17 green. Duster + PHPStan clean.
