### PR TITLE
feat(accounting): per-line branch pickers UI + validation (full 2b PR7b)

### DIFF
--- a/app/Http/Requests/JournalEntries/AbstractJournalEntryRequest.php
+++ b/app/Http/Requests/JournalEntries/AbstractJournalEntryRequest.php
@@ -15,6 +15,7 @@ abstract class AbstractJournalEntryRequest extends AuthorizedFormRequest
             'branch_id' => ['nullable', 'integer', 'exists:branches,id'],
             'lines' => ['required', 'array', 'min:2'],
             'lines.*.account_id' => ['required', 'exists:accounts,id'],
+            'lines.*.branch_id' => ['nullable', 'integer', 'exists:branches,id'],
             'lines.*.debit' => ['required', 'numeric', 'min:0'],
             'lines.*.credit' => ['required', 'numeric', 'min:0'],
             'lines.*.memo' => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/RecurringJournals/StoreRecurringJournalRequest.php
+++ b/app/Http/Requests/RecurringJournals/StoreRecurringJournalRequest.php
@@ -26,6 +26,7 @@ class StoreRecurringJournalRequest extends FormRequest
             'is_active' => ['boolean'],
             'lines' => ['required', 'array', 'min:2'],
             'lines.*.account_id' => ['required', 'integer', 'exists:accounts,id'],
+            'lines.*.branch_id' => ['nullable', 'integer', 'exists:branches,id'],
             'lines.*.debit' => ['required', 'numeric', 'min:0'],
             'lines.*.credit' => ['required', 'numeric', 'min:0'],
             'lines.*.memo' => ['nullable', 'string', 'max:255'],

--- a/resources/js/components/bank-reconciliations/BankReconciliationForm.tsx
+++ b/resources/js/components/bank-reconciliations/BankReconciliationForm.tsx
@@ -21,6 +21,7 @@ const bankReconciliationFormSchema = z
         statement_balance: z.coerce.number({
             message: 'Statement balance is required.',
         }),
+        branch_id: z.string().optional(),
     })
     .refine((data) => data.period_end >= data.period_start, {
         message: 'Period end must be after or equal to period start.',
@@ -47,6 +48,7 @@ const getBankReconciliationFormDefaults = (
             period_start: new Date(),
             period_end: new Date(),
             statement_balance: 0,
+            branch_id: '',
         };
     }
     return {
@@ -55,6 +57,7 @@ const getBankReconciliationFormDefaults = (
         period_start: new Date(entity.period_start),
         period_end: new Date(entity.period_end),
         statement_balance: Number(entity.statement_balance),
+        branch_id: entity.branch_id ? String(entity.branch_id) : '',
     };
 };
 
@@ -78,6 +81,7 @@ export const BankReconciliationForm = memo<BankReconciliationFormProps>(
         const accountCode = entity?.account?.code;
         const accountName = entity?.account?.name;
         const fiscalYearName = entity?.fiscal_year?.name;
+        const branchName = entity?.branch?.name;
 
         return (
             <EntityForm
@@ -126,13 +130,22 @@ export const BankReconciliationForm = memo<BankReconciliationFormProps>(
                     <DatePickerField name="period_end" label="Period End" />
                 </div>
 
-                <InputField
-                    name="statement_balance"
-                    label="Statement Balance"
-                    type="number"
-                    step="0.01"
-                    placeholder="0.00"
-                />
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <InputField
+                        name="statement_balance"
+                        label="Statement Balance"
+                        type="number"
+                        step="0.01"
+                        placeholder="0.00"
+                    />
+                    <AsyncSelectField<{ name: string }>
+                        name="branch_id"
+                        label="Branch"
+                        url="/api/branches"
+                        placeholder="Select branch"
+                        initialLabel={branchName || ''}
+                    />
+                </div>
             </EntityForm>
         );
     },

--- a/resources/js/components/journal-entries/JournalEntryLineFormDialog.tsx
+++ b/resources/js/components/journal-entries/JournalEntryLineFormDialog.tsx
@@ -27,6 +27,8 @@ const journalEntryLineSchema = z
         debit: z.coerce.number().min(0).optional().default(0),
         credit: z.coerce.number().min(0).optional().default(0),
         memo: z.string().optional(),
+        branch_id: z.string().optional(),
+        branch_name: z.string().optional(),
     })
     .refine(
         () => {
@@ -67,6 +69,8 @@ export function JournalEntryLineFormDialog({
                 debit: 0,
                 credit: 0,
                 memo: '',
+                branch_id: '',
+                branch_name: '',
             };
         }
 
@@ -77,6 +81,8 @@ export function JournalEntryLineFormDialog({
             debit: Number(item.debit || 0),
             credit: Number(item.credit || 0),
             memo: item.memo || '',
+            branch_id: item.branch_id || '',
+            branch_name: item.branch_name || '',
         };
     }, [item]);
 
@@ -147,6 +153,21 @@ export function JournalEntryLineFormDialog({
                                     form.setValue(
                                         'account_code',
                                         account?.code || '',
+                                        { shouldDirty: true },
+                                    );
+                                }}
+                            />
+                            <AsyncSelectField<{ name: string }>
+                                key={`branch-${defaultValues.branch_id || 'new'}-${open ? 'open' : 'closed'}`}
+                                name="branch_id"
+                                label="Branch"
+                                url="/api/branches"
+                                placeholder="Select branch"
+                                initialLabel={defaultValues.branch_name || ''}
+                                onItemSelect={(branch) => {
+                                    form.setValue(
+                                        'branch_name',
+                                        branch?.name || '',
                                         { shouldDirty: true },
                                     );
                                 }}

--- a/resources/js/components/recurring-journals/RecurringJournalLineFormDialog.tsx
+++ b/resources/js/components/recurring-journals/RecurringJournalLineFormDialog.tsx
@@ -16,6 +16,8 @@ const recurringJournalLineSchema = z.object({
     debit: z.coerce.number().min(0).optional().default(0),
     credit: z.coerce.number().min(0).optional().default(0),
     memo: z.string().optional(),
+    branch_id: z.string().optional(),
+    branch_name: z.string().optional(),
 });
 
 type RecurringJournalLineFormData = z.infer<typeof recurringJournalLineSchema>;
@@ -42,6 +44,8 @@ export function RecurringJournalLineFormDialog({
                 debit: 0,
                 credit: 0,
                 memo: '',
+                branch_id: '',
+                branch_name: '',
             };
         }
 
@@ -52,6 +56,8 @@ export function RecurringJournalLineFormDialog({
             debit: Number(item.debit || 0),
             credit: Number(item.credit || 0),
             memo: item.memo || '',
+            branch_id: item.branch_id || '',
+            branch_name: item.branch_name || '',
         };
     }, [item]);
 
@@ -107,6 +113,19 @@ export function RecurringJournalLineFormDialog({
                             shouldDirty: true,
                         });
                         form.setValue('account_code', account?.code || '', {
+                            shouldDirty: true,
+                        });
+                    }}
+                />
+                <AsyncSelectField<{ name: string }>
+                    key={`branch-${defaultValues.branch_id || 'new'}-${open ? 'open' : 'closed'}`}
+                    name="branch_id"
+                    label="Branch"
+                    url="/api/branches"
+                    placeholder="Select branch"
+                    initialLabel={defaultValues.branch_name || ''}
+                    onItemSelect={(branch) => {
+                        form.setValue('branch_name', branch?.name || '', {
                             shouldDirty: true,
                         });
                     }}

--- a/resources/js/types/bank-reconciliation.ts
+++ b/resources/js/types/bank-reconciliation.ts
@@ -45,6 +45,11 @@ export interface BankReconciliation {
         id: number;
         name: string;
     };
+    branch_id?: number | null;
+    branch?: {
+        id: number;
+        name: string;
+    } | null;
     period_start: string;
     period_end: string;
     statement_balance: number;

--- a/resources/js/types/journal-entry.ts
+++ b/resources/js/types/journal-entry.ts
@@ -6,6 +6,8 @@ export interface JournalEntryLine {
     debit: number;
     credit: number;
     memo?: string;
+    branch_id?: string;
+    branch_name?: string;
 }
 
 export interface JournalEntry {

--- a/resources/js/types/recurring-journal.ts
+++ b/resources/js/types/recurring-journal.ts
@@ -6,6 +6,8 @@ export interface RecurringJournalLine {
     debit: number;
     credit: number;
     memo?: string;
+    branch_id?: string;
+    branch_name?: string;
 }
 
 export interface RecurringJournal {

--- a/resources/js/utils/schemas.ts
+++ b/resources/js/utils/schemas.ts
@@ -245,6 +245,8 @@ export const journalEntryFormSchema = z.object({
                 memo: z.string().optional(),
                 account_name: z.string().optional(),
                 account_code: z.string().optional(),
+                branch_id: z.string().optional(),
+                branch_name: z.string().optional(),
             }),
         )
         .min(2, { message: 'At least 2 lines are required.' })

--- a/tests/Feature/JournalEntries/JournalEntryBranchScopeTest.php
+++ b/tests/Feature/JournalEntries/JournalEntryBranchScopeTest.php
@@ -158,4 +158,46 @@ describe('Manual journal entry branch attribution gate', function () {
             ->assertJsonPath('data.branch.id', $branch->id)
             ->assertJsonPath('data.branch.name', $branch->name);
     });
+
+    test('accepts per-line branch_id and persists it on the journal lines', function () {
+        $accounts = makeBalancedJournalLines();
+        $branchA = Branch::factory()->create();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create', 'view_all_branches']);
+        actingAs($user);
+
+        $payload = [
+            'entry_date' => '2026-03-15',
+            'description' => 'Per-line branch entry',
+            'lines' => [
+                ['account_id' => $accounts[0]->id, 'branch_id' => $branchA->id, 'debit' => 1000, 'credit' => 0],
+                ['account_id' => $accounts[1]->id, 'branch_id' => $branchA->id, 'debit' => 0, 'credit' => 1000],
+            ],
+        ];
+
+        postJson('/api/journal-entries', $payload)->assertCreated();
+
+        $entry = JournalEntry::latest('id')->first();
+        $lines = $entry->lines()->get();
+        expect($lines->firstWhere('account_id', $accounts[0]->id)->branch_id)->toBe($branchA->id);
+        expect($lines->firstWhere('account_id', $accounts[1]->id)->branch_id)->toBe($branchA->id);
+    });
+
+    test('rejects a per-line branch_id that does not exist', function () {
+        $accounts = makeBalancedJournalLines();
+        $user = makeJournalUserInBranch(null, ['journal_entry', 'journal_entry.create', 'view_all_branches']);
+        actingAs($user);
+
+        $payload = [
+            'entry_date' => '2026-03-15',
+            'description' => 'Bad per-line branch',
+            'lines' => [
+                ['account_id' => $accounts[0]->id, 'branch_id' => 999999, 'debit' => 1000, 'credit' => 0],
+                ['account_id' => $accounts[1]->id, 'debit' => 0, 'credit' => 1000],
+            ],
+        ];
+
+        postJson('/api/journal-entries', $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['lines.0.branch_id']);
+    });
 });

--- a/tests/e2e/journal-entries/helpers.ts
+++ b/tests/e2e/journal-entries/helpers.ts
@@ -57,7 +57,7 @@ export async function createJournalEntry(
     const lineDialog = page.getByRole('dialog', { name: /Add Line/i }).first();
     await expect(lineDialog).toBeVisible();
 
-    const accountTrigger = lineDialog.locator('button[role="combobox"]');
+    const accountTrigger = lineDialog.locator('button[role="combobox"]').first();
     await accountTrigger.click();
 
     const searchInput = page.getByPlaceholder('Search...');


### PR DESCRIPTION
feat(accounting): per-line branch pickers UI + validation (full 2b PR7b)

Final PR of full 2b. Lets users assign branch on the journal/recurring LINE
level and on the bank reconciliation header, completing the user-facing surface
of per-branch accounting.

Backend (validation):
- AbstractJournalEntryRequest (manual journal store+update): add
  lines.*.branch_id => nullable|integer|exists:branches,id. CreateJournalEntry
  Action already threads per-line branch + runs the clearing engine.
- StoreRecurringJournalRequest (recurring store+update): same lines.*.branch_id
  rule. RecurringJournalController::syncLines passes the validated line array to
  lines()->create(), so branch_id persists (fillable added in PR7a).

Frontend (delegated to visual-engineering, reuses the established
AsyncSelectField url="/api/branches" pattern):
- JournalEntryLineFormDialog: optional per-line Branch select after Account,
  edit-mode preload via initialLabel, branch_name tracked for display.
- RecurringJournalLineFormDialog: same per-line Branch select.
- BankReconciliationForm: optional header Branch select paired with Statement
  Balance.
- Zod schemas + TS types updated (branch_id optional everywhere; nullable
  backend columns => never required in UI).

Dormant-correct: branch is optional; leaving it unset preserves byte-identical
single-null-branch behavior (clearing no-ops). Behavior changes only when a user
assigns branches that don't self-balance, where the PR3 engine injects clearing.

Tests:
- journal-entries 50 green (+2: per-line branch_id persists; bad per-line
  branch_id => 422 lines.0.branch_id).
- recurring-journals 17 green, bank-reconciliations 52 green.
- types/lint/format clean; duster + phpstan clean on changed PHP.
