### PR TITLE
test(accounting): multi-branch smoke test + cross-branch detection (2b follow-up)

### DIFF
--- a/app/Console/Commands/DetectCrossBranchJournals.php
+++ b/app/Console/Commands/DetectCrossBranchJournals.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\InterBranchClearingService;
+use Illuminate\Console\Command;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class DetectCrossBranchJournals extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'journals:detect-cross-branch {--posted-only : Count only posted journal entries} {--limit=20 : Max number of sample entry numbers to list}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Report how many journal entries are economically multi-branch and how many inter-branch clearing lines exist. Read-only gate for the deferred retro-correction work (full 2b PR8).';
+
+    public function handle(): int
+    {
+        $postedOnly = (bool) $this->option('posted-only');
+        $limit = max(1, (int) $this->option('limit'));
+
+        $entryFilter = function ($query) use ($postedOnly): void {
+            if ($postedOnly) {
+                $query->where('journal_entries.status', 'posted');
+            }
+        };
+
+        $multiBranchEntryIds = DB::table('journal_entry_lines')
+            ->join('journal_entries', 'journal_entries.id', '=', 'journal_entry_lines.journal_entry_id')
+            ->whereNotNull('journal_entry_lines.branch_id')
+            ->where($entryFilter)
+            ->select('journal_entry_lines.journal_entry_id')
+            ->groupBy('journal_entry_lines.journal_entry_id')
+            ->havingRaw('COUNT(DISTINCT journal_entry_lines.branch_id) > 1')
+            ->pluck('journal_entry_lines.journal_entry_id');
+
+        $multiBranchCount = $multiBranchEntryIds->count();
+
+        $clearingLineCount = $this->clearingLineQuery($postedOnly)->count('journal_entry_lines.id');
+
+        $clearingEntryCount = $this->clearingLineQuery($postedOnly)
+            ->distinct()
+            ->count('journal_entry_lines.journal_entry_id');
+
+        $nullBranchLineCount = DB::table('journal_entry_lines')
+            ->join('journal_entries', 'journal_entries.id', '=', 'journal_entry_lines.journal_entry_id')
+            ->whereNull('journal_entry_lines.branch_id')
+            ->where($entryFilter)
+            ->count('journal_entry_lines.id');
+
+        $this->renderSummary(
+            $postedOnly,
+            $multiBranchCount,
+            $clearingEntryCount,
+            $clearingLineCount,
+            $nullBranchLineCount,
+        );
+
+        if ($multiBranchCount > 0) {
+            $sampleNumbers = DB::table('journal_entries')
+                ->whereIn('id', $multiBranchEntryIds)
+                ->orderBy('entry_date')
+                ->limit($limit)
+                ->pluck('entry_number');
+
+            $this->line('');
+            $this->line('Sample multi-branch entries:');
+            foreach ($sampleNumbers as $number) {
+                $this->line("  - {$number}");
+            }
+        }
+
+        $this->line('');
+        if ($multiBranchCount === 0) {
+            $this->info('No economically multi-branch journals detected. Retro-correction (PR8) is NOT warranted.');
+        } else {
+            $this->warn(sprintf(
+                '%d multi-branch journal entries detected. Evaluate whether retro-correction (PR8) is now warranted.',
+                $multiBranchCount,
+            ));
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function clearingLineQuery(bool $postedOnly): Builder
+    {
+        $query = DB::table('journal_entry_lines')
+            ->join('journal_entries', 'journal_entries.id', '=', 'journal_entry_lines.journal_entry_id')
+            ->join('accounts', 'accounts.id', '=', 'journal_entry_lines.account_id')
+            ->where('accounts.code', InterBranchClearingService::CLEARING_CODE);
+
+        if ($postedOnly) {
+            $query->where('journal_entries.status', 'posted');
+        }
+
+        return $query;
+    }
+
+    private function renderSummary(
+        bool $postedOnly,
+        int $multiBranchCount,
+        int $clearingEntryCount,
+        int $clearingLineCount,
+        int $nullBranchLineCount,
+    ): void {
+        $this->info($postedOnly ? 'Scope: posted journal entries only.' : 'Scope: all journal entries (draft + posted).');
+
+        $this->table(
+            ['Metric', 'Count'],
+            [
+                ['Economically multi-branch entries', $multiBranchCount],
+                ['Entries with clearing lines (' . InterBranchClearingService::CLEARING_CODE . ')', $clearingEntryCount],
+                ['Total clearing lines', $clearingLineCount],
+                ['Null-branch lines (company-wide)', $nullBranchLineCount],
+            ],
+        );
+    }
+}

--- a/tests/Feature/Console/DetectCrossBranchJournalsTest.php
+++ b/tests/Feature/Console/DetectCrossBranchJournalsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\Account;
+use App\Models\Branch;
+use App\Models\CoaVersion;
+use App\Models\FiscalYear;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\seed;
+
+uses(RefreshDatabase::class)->group('inter-branch-clearing');
+
+beforeEach(function () {
+    seed();
+
+    $this->fiscalYear = FiscalYear::where('status', 'open')->firstOrFail();
+    /** @var CoaVersion $coaVersion */
+    $coaVersion = $this->fiscalYear->coaVersions()->where('status', 'active')->firstOrFail();
+    $this->accountMap = Account::where('coa_version_id', $coaVersion->id)
+        ->pluck('id', 'code')
+        ->toArray();
+
+    $this->user = User::firstOrFail();
+    $this->branchA = Branch::factory()->create(['name' => 'Branch A']);
+    $this->branchB = Branch::factory()->create(['name' => 'Branch B']);
+    $this->action = app(CreateJournalEntryAction::class);
+});
+
+test('detects zero multi-branch journals on single-branch data', function () {
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Single-branch entry',
+        'status' => 'posted',
+        'branch_id' => $this->branchA->id,
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'debit' => 1000, 'credit' => 0],
+            ['account_id' => $this->accountMap['41000'], 'debit' => 0, 'credit' => 1000],
+        ],
+    ]);
+
+    $this->artisan('journals:detect-cross-branch')
+        ->expectsOutputToContain('No economically multi-branch journals detected')
+        ->assertSuccessful();
+});
+
+test('detects multi-branch journals and clearing lines once a cross-branch entry exists', function () {
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Inter-branch cash transfer A -> B',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500],
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchB->id, 'debit' => 500, 'credit' => 0],
+        ],
+    ]);
+
+    $this->artisan('journals:detect-cross-branch')
+        ->expectsOutputToContain('Evaluate whether retro-correction')
+        ->assertSuccessful();
+});
+
+test('posted-only scope ignores draft cross-branch journals', function () {
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Draft inter-branch entry',
+        'status' => 'draft',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500],
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchB->id, 'debit' => 500, 'credit' => 0],
+        ],
+    ]);
+
+    $this->artisan('journals:detect-cross-branch --posted-only')
+        ->expectsOutputToContain('No economically multi-branch journals detected')
+        ->assertSuccessful();
+});

--- a/tests/Feature/JournalEntries/MultiBranchJournalSmokeTest.php
+++ b/tests/Feature/JournalEntries/MultiBranchJournalSmokeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\JournalEntries;
+
+use App\Actions\JournalEntries\CreateJournalEntryAction;
+use App\Models\Account;
+use App\Models\Branch;
+use App\Models\CoaVersion;
+use App\Models\FiscalYear;
+use App\Models\User;
+use App\Services\FinancialReportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\seed;
+
+uses(RefreshDatabase::class)->group('inter-branch-clearing');
+
+beforeEach(function () {
+    seed();
+
+    $this->fiscalYear = FiscalYear::where('status', 'open')->firstOrFail();
+    /** @var CoaVersion $coaVersion */
+    $coaVersion = $this->fiscalYear->coaVersions()->where('status', 'active')->firstOrFail();
+    $this->accountMap = Account::where('coa_version_id', $coaVersion->id)
+        ->pluck('id', 'code')
+        ->toArray();
+    $this->clearingId = (int) $this->accountMap['1999-IBC'];
+
+    $this->user = User::firstOrFail();
+    $this->branchA = Branch::factory()->create(['name' => 'Branch A']);
+    $this->branchB = Branch::factory()->create(['name' => 'Branch B']);
+
+    $this->action = app(CreateJournalEntryAction::class);
+    $this->reports = app(FinancialReportService::class);
+});
+
+test('multi-branch journal created via write-path flows through to per-branch reports', function () {
+    $entry = $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Branch A pays Branch B expense',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500000],
+            ['account_id' => $this->accountMap['52000'], 'branch_id' => $this->branchB->id, 'debit' => 500000, 'credit' => 0],
+        ],
+    ]);
+
+    $persistedLines = $entry->lines()->get();
+    expect($persistedLines->where('account_id', $this->clearingId))->toHaveCount(2);
+
+    foreach ([$this->branchA->id, $this->branchB->id] as $branchId) {
+        $rows = $this->reports->getTrialBalance($this->fiscalYear->id, $branchId);
+        expect(round((float) collect($rows)->sum('debit'), 2))
+            ->toBe(round((float) collect($rows)->sum('credit'), 2));
+    }
+
+    $reportA = $this->reports->getBalanceSheet($this->fiscalYear->id, null, $this->branchA->id);
+    $dueFromA = collect($reportA['assets'])->firstWhere('code', '1999-IBC');
+    expect($dueFromA)->not->toBeNull();
+    expect($dueFromA['name'])->toBe('Due From Branches');
+    expect(round($dueFromA['balance'], 2))->toBe(500000.0);
+    expect(collect($reportA['liabilities'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(round($reportA['totals']['assets'], 2))
+        ->toBe(round($reportA['totals']['liabilities'] + $reportA['totals']['equity'], 2));
+
+    $reportB = $this->reports->getBalanceSheet($this->fiscalYear->id, null, $this->branchB->id);
+    $dueToB = collect($reportB['liabilities'])->firstWhere('code', '1999-IBC');
+    expect($dueToB)->not->toBeNull();
+    expect($dueToB['name'])->toBe('Due To Branches');
+    expect(round($dueToB['balance'], 2))->toBe(500000.0);
+    expect(collect($reportB['assets'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(round($reportB['totals']['assets'], 2))
+        ->toBe(round($reportB['totals']['liabilities'] + $reportB['totals']['equity'], 2));
+});
+
+test('per-branch income statement reflects expense booked on the receiving branch', function () {
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Branch A pays Branch B expense',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500000],
+            ['account_id' => $this->accountMap['52000'], 'branch_id' => $this->branchB->id, 'debit' => 500000, 'credit' => 0],
+        ],
+    ]);
+
+    $incomeB = $this->reports->getIncomeStatement($this->fiscalYear->id, null, $this->branchB->id);
+    expect(round($incomeB['totals']['expense'], 2))->toBe(500000.0);
+
+    $incomeA = $this->reports->getIncomeStatement($this->fiscalYear->id, null, $this->branchA->id);
+    expect(round($incomeA['totals']['expense'], 2))->toBe(0.0);
+});
+
+test('clearing nets to zero company-wide after multi-branch posting', function () {
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Branch A pays Branch B expense',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500000],
+            ['account_id' => $this->accountMap['52000'], 'branch_id' => $this->branchB->id, 'debit' => 500000, 'credit' => 0],
+        ],
+    ]);
+
+    $companyWide = $this->reports->getBalanceSheet($this->fiscalYear->id);
+    expect(collect($companyWide['assets'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(collect($companyWide['liabilities'])->firstWhere('code', '1999-IBC'))->toBeNull();
+    expect(round($companyWide['totals']['assets'], 2))
+        ->toBe(round($companyWide['totals']['liabilities'] + $companyWide['totals']['equity'], 2));
+});


### PR DESCRIPTION
## Summary

Two operational-validation follow-ups for the now-complete full 2b inter-branch initiative. No production code paths change — this adds an end-to-end proof and a read-only monitoring tool.

### #1 — End-to-end smoke test (`MultiBranchJournalSmokeTest`)
Existing tests cover the write-path and the report layer *separately*. This new test proves the **full chain**: a multi-branch journal created via the real `CreateJournalEntryAction` write-path → clearing lines auto-injected → persisted rows fed into `FinancialReportService` per branch:
- per-branch trial balance self-balances (dr == cr)
- Branch A balance sheet shows **Due From Branches** asset (1999-IBC), Branch B shows **Due To Branches** liability
- each branch BS balances (A == L + E)
- receiving branch's income statement reflects the expense; sending branch shows 0
- clearing nets to 0 company-wide (no reclassification on the consolidated view)

### #2 — Cross-branch detection command (`journals:detect-cross-branch`)
Read-only artisan command + 3 tests. Counts economically multi-branch entries, clearing lines (1999-IBC), and null-branch lines. Serves as the **data gate for the deferred PR8** (retro-correction): only worth building if this count becomes material.

```
--posted-only   Count only posted entries
--limit=N       Max sample entry numbers to list (default 20)
```

Current dev data: **0 economically multi-branch journals** — confirms the engine is dormant-but-correct.

## Testing
- `sail test --group inter-branch-clearing` → 22 passed, 232 assertions (6 new)
- `sail bin duster fix` on new files → clean (Pint converted one FQCN return type to a proper import)
- `sail bin phpstan analyze` on new command → no errors

## Blocked features
None.