### PR TITLE
feat(accounting): schedule weekly cross-branch journal detection + structured logging

### DIFF
--- a/app/Console/Commands/DetectCrossBranchJournals.php
+++ b/app/Console/Commands/DetectCrossBranchJournals.php
@@ -6,6 +6,7 @@ use App\Services\InterBranchClearingService;
 use Illuminate\Console\Command;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class DetectCrossBranchJournals extends Command
 {
@@ -83,6 +84,14 @@ class DetectCrossBranchJournals extends Command
                 '%d multi-branch journal entries detected. Evaluate whether retro-correction (PR8) is now warranted.',
                 $multiBranchCount,
             ));
+
+            Log::warning('Cross-branch journals detected by scheduled monitor.', [
+                'scope' => $postedOnly ? 'posted' : 'all',
+                'multi_branch_entries' => $multiBranchCount,
+                'clearing_entries' => $clearingEntryCount,
+                'clearing_lines' => $clearingLineCount,
+                'null_branch_lines' => $nullBranchLineCount,
+            ]);
         }
 
         return self::SUCCESS;

--- a/routes/console.php
+++ b/routes/console.php
@@ -48,6 +48,11 @@ Artisan::command('recurring-journals:execute', function () {
 
 Schedule::command('recurring-journals:execute')->daily();
 
+Schedule::command('journals:detect-cross-branch', ['--posted-only'])
+    ->weekly()
+    ->mondays()
+    ->at('06:00');
+
 Artisan::command('approvals:repair-missing-steps {--dry-run : Audit only without writing data}', function () {
     $report = app(RepairMissingApprovalStepsAction::class)->execute(
         (bool) $this->option('dry-run'),

--- a/tests/Feature/Console/DetectCrossBranchJournalsTest.php
+++ b/tests/Feature/Console/DetectCrossBranchJournalsTest.php
@@ -9,6 +9,7 @@ use App\Models\CoaVersion;
 use App\Models\FiscalYear;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 
 use function Pest\Laravel\seed;
 
@@ -77,4 +78,46 @@ test('posted-only scope ignores draft cross-branch journals', function () {
     $this->artisan('journals:detect-cross-branch --posted-only')
         ->expectsOutputToContain('No economically multi-branch journals detected')
         ->assertSuccessful();
+});
+
+test('logs a warning when multi-branch journals are detected', function () {
+    Log::spy();
+
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Inter-branch cash transfer A -> B',
+        'status' => 'posted',
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500],
+            ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchB->id, 'debit' => 500, 'credit' => 0],
+        ],
+    ]);
+
+    $this->artisan('journals:detect-cross-branch')->assertSuccessful();
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(function (string $message, array $context): bool {
+            return str_contains($message, 'Cross-branch journals detected')
+                && $context['multi_branch_entries'] >= 1;
+        });
+});
+
+test('does not log a warning when no multi-branch journals exist', function () {
+    Log::spy();
+
+    $this->action->execute([
+        'entry_date' => '2026-02-01',
+        'description' => 'Single-branch entry',
+        'status' => 'posted',
+        'branch_id' => $this->branchA->id,
+        'lines' => [
+            ['account_id' => $this->accountMap['11110'], 'debit' => 1000, 'credit' => 0],
+            ['account_id' => $this->accountMap['41000'], 'debit' => 0, 'credit' => 1000],
+        ],
+    ]);
+
+    $this->artisan('journals:detect-cross-branch')->assertSuccessful();
+
+    Log::shouldNotHaveReceived('warning');
 });


### PR DESCRIPTION
## Summary

Turns the PR8 gate from a manual check into automated monitoring. The `journals:detect-cross-branch` command (merged in #55) now runs on a schedule and writes a structured log line whenever cross-branch activity appears — so the moment the inter-branch clearing engine stops being dormant, it surfaces in logs/Sentry without anyone remembering to run the command.

### Changes
- **Scheduled run** (`routes/console.php`): `journals:detect-cross-branch --posted-only` weekly on Mondays at 06:00.
- **Self-logging** (`DetectCrossBranchJournals`): when `multi_branch_entries > 0`, emit `Log::warning('Cross-branch journals detected by scheduled monitor.', [...])` with scope + all four counts. Scheduled console output is invisible otherwise; this routes the signal to the log/Sentry pipeline. No log when count is 0 (stays quiet while dormant).

## Why `--posted-only`
The scheduled monitor only cares about committed accounting reality. Draft entries are noise for the retro-correction decision, so the scheduled scope excludes them. Ad-hoc full scans remain available by running the command without the flag.

## Testing
- `sail test --group inter-branch-clearing` → 24 passed, 260 assertions (2 new: log emitted on detection / not emitted when zero, via `Log::spy`)
- `sail bin duster fix` on changed files → clean
- `sail bin phpstan analyze` on command → no errors

## Blocked features
None. PR8 (retro-correction) remains deferred; this PR is purely the monitoring tripwire for it.