### PR TITLE
feat(monitoring): send cross-branch detection alert to Sentry

### DIFF
--- a/app/Console/Commands/DetectCrossBranchJournals.php
+++ b/app/Console/Commands/DetectCrossBranchJournals.php
@@ -7,6 +7,11 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Sentry\Severity;
+use Sentry\State\Scope;
+
+use function Sentry\captureMessage;
+use function Sentry\withScope;
 
 class DetectCrossBranchJournals extends Command
 {
@@ -92,6 +97,21 @@ class DetectCrossBranchJournals extends Command
                 'clearing_lines' => $clearingLineCount,
                 'null_branch_lines' => $nullBranchLineCount,
             ]);
+
+            withScope(function (Scope $scope) use ($postedOnly, $multiBranchCount, $clearingEntryCount, $clearingLineCount, $nullBranchLineCount): void {
+                $scope->setContext('cross_branch_monitor', [
+                    'scope' => $postedOnly ? 'posted' : 'all',
+                    'multi_branch_entries' => $multiBranchCount,
+                    'clearing_entries' => $clearingEntryCount,
+                    'clearing_lines' => $clearingLineCount,
+                    'null_branch_lines' => $nullBranchLineCount,
+                ]);
+
+                captureMessage(
+                    sprintf('Cross-branch journals detected by scheduled monitor: %d multi-branch entries.', $multiBranchCount),
+                    Severity::warning(),
+                );
+            });
         }
 
         return self::SUCCESS;

--- a/tests/Feature/Console/DetectCrossBranchJournalsTest.php
+++ b/tests/Feature/Console/DetectCrossBranchJournalsTest.php
@@ -10,6 +10,8 @@ use App\Models\FiscalYear;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Sentry\ClientInterface;
+use Sentry\SentrySdk;
 
 use function Pest\Laravel\seed;
 
@@ -120,4 +122,39 @@ test('does not log a warning when no multi-branch journals exist', function () {
     $this->artisan('journals:detect-cross-branch')->assertSuccessful();
 
     Log::shouldNotHaveReceived('warning');
+});
+
+test('captures a Sentry message when multi-branch journals are detected', function () {
+    $hub = SentrySdk::getCurrentHub();
+    $originalClient = $hub->getClient();
+
+    $captured = [];
+    $mockClient = mock(ClientInterface::class)->makePartial();
+    $mockClient->shouldReceive('captureMessage')
+        ->andReturnUsing(function (string $message) use (&$captured) {
+            $captured[] = $message;
+
+            return null;
+        });
+
+    $hub->bindClient($mockClient);
+
+    try {
+        $this->action->execute([
+            'entry_date' => '2026-02-01',
+            'description' => 'Inter-branch cash transfer A -> B',
+            'status' => 'posted',
+            'lines' => [
+                ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchA->id, 'debit' => 0, 'credit' => 500],
+                ['account_id' => $this->accountMap['11110'], 'branch_id' => $this->branchB->id, 'debit' => 500, 'credit' => 0],
+            ],
+        ]);
+
+        $this->artisan('journals:detect-cross-branch')->assertSuccessful();
+    } finally {
+        $hub->bindClient($originalClient);
+    }
+
+    expect($captured)->toHaveCount(1)
+        ->and($captured[0])->toContain('Cross-branch journals detected by scheduled monitor');
 });


### PR DESCRIPTION
## Summary

Makes the weekly cross-branch monitoring tripwire (PR #56) actually reach a human. An audit of the production deployment surface found the existing `Log::warning` alert was effectively cosmetic:

- **Scheduler not running in prod**: `docker-compose.dist.yml` defines a single `octane:swoole` service — no `schedule:work`/cron service, and the alpine base image (`docker/dist/base/Dockerfile`) has no cron/supervisor. So the Monday 06:00 schedule never fires in prod.
- **`Log::warning` not surfaced**: `config/logging.php` defaults to the `single` file channel (ephemeral container file, no `sentry` channel in the stack), and `config/sentry.php` has `enable_logs=false` — standalone warnings without an exception are not sent to Sentry.

This PR fixes the **notification half** (per the chosen remediation): when the detector finds economically multi-branch journals, it now calls `\Sentry\captureMessage(..., Severity::warning())` wrapped in `withScope` so the structured metrics (scope, multi_branch_entries, clearing_entries/lines, null_branch_lines) attach as Sentry context. The existing `Log::warning` is kept for file-trail parity.

Because this captures directly to the Sentry hub (not via the log channel), it surfaces the moment the detector runs — whether invoked **manually** or by a future scheduler — independent of `enable_logs` or log-channel wiring.

> Note: the **scheduler-execution half** (no `schedule:work` service in prod) is a separate infra concern, intentionally out of scope for this app-code PR. Manual invocation (`sail artisan journals:detect-cross-branch --posted-only`) now alerts correctly; wiring a prod scheduler service can follow separately if desired.

## Behavior
- Sentry helper no-ops safely when no DSN is configured (dev/CI/test unaffected).
- Only fires on positive detection (multi_branch_entries > 0); current data = 0, so silent today.

## Testing
- `sail test tests/Feature/Console/DetectCrossBranchJournalsTest.php` → 6 passed, 13 assertions.
  - New test `captures a Sentry message when multi-branch journals are detected` binds a mock `ClientInterface` to the Sentry hub and asserts `captureMessage` fires with the expected text, restoring the original client in a `finally`.
  - Existing 5 (log + scope + zero-detection) tests unchanged and green.
- `duster fix` + `phpstan analyze` (app/) clean.

## Blocked features
None. Single command + its test touched; no API contract or schema change.