### PR TITLE
feat(infra): add scheduler service to prod stack

### DIFF
--- a/docker-compose.dist.yml
+++ b/docker-compose.dist.yml
@@ -28,6 +28,20 @@ services:
     networks:
       - erp-network
 
+  scheduler:
+    image: ${APP_IMAGE:-ghcr.io/gmedia/erp/app:latest}
+    env_file:
+      - .env.production
+    environment:
+      RUN_MIGRATIONS: "false"
+    command: php artisan schedule:work
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+    networks:
+      - erp-network
+
   # mariadb:
   #   image: mariadb:10.11
   #   environment:


### PR DESCRIPTION
## Summary

Completes the cross-branch monitoring chain by making Laravel's scheduler actually run in production. Closes the infra gap documented in the PR #58 audit: the prod stack previously ran only `octane:swoole` (2 replicas), with no `schedule:work`/cron anywhere — so the weekly `journals:detect-cross-branch` run (and any other scheduled task) never fired in prod.

## Change
Adds a single `scheduler` service to `docker-compose.dist.yml`:
- Same image + `.env.production` as `app`.
- `command: php artisan schedule:work` (long-running; dispatches due scheduled commands every minute).
- `replicas: 1` — **singleton by design**. A second replica would double-execute every scheduled task; the scheduler must run exactly once.
- `RUN_MIGRATIONS: "false"` — only the deploy step / `app` handles migrations; the scheduler must never migrate.
- No published ports (internal worker), attached to the same `erp-network` overlay.

## Effect
- The weekly Monday 06:00 `journals:detect-cross-branch --posted-only` now executes in prod, and on positive detection fires the Sentry alert added in PR #58 — fully automated end to end.
- Any future `routes/console.php` schedule entry is now honored in prod without further infra work.

## Notes / risk
- Infra-only change (single compose service). No app code, no API contract, no schema touched.
- Swarm stack: `schedule:work` is a foreground process, so `restart_policy: condition: any` keeps it alive across crashes/deploys.
- YAML validated locally (`yaml.safe_load`): services = [app, scheduler], scheduler.replicas = 1.

## Blocked features
None.