### PR TITLE
fix: disable API rate limiting for Playwright E2E CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ APP_MAINTENANCE_DRIVER=file
 
 APP_ADMIN=admin@dokfin.id
 
+# Set true for parallel Playwright E2E to avoid API 429 rate limits.
+# Honored by AppServiceProvider (imports/exports/api Limit::none()).
+# DISABLE_RATE_LIMITING=false
+
 PHP_CLI_SERVER_WORKERS=4
 
 BCRYPT_ROUNDS=12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -292,6 +292,10 @@ jobs:
           cp .env.example .env
           sed -i "s/^WWWUSER=.*/WWWUSER=$(id -u)/" .env
           sed -i "s/^WWWGROUP=.*/WWWGROUP=$(id -g)/" .env
+          # Bypass API/import/export rate limits under parallel Playwright load.
+          # AppServiceProvider honors config('app.disable_rate_limiting') via Limit::none().
+          # Must live in .env (Sail app process), not only GHA job env.
+          echo "DISABLE_RATE_LIMITING=true" >> .env
           mkdir -p storage/tmp
           chmod -R u+rwX,g+rwX,o-rwx storage/tmp
 

--- a/app/Http/Resources/Branches/BranchCollection.php
+++ b/app/Http/Resources/Branches/BranchCollection.php
@@ -6,5 +6,8 @@ use App\Http\Resources\SimpleCrudCollection;
 
 class BranchCollection extends SimpleCrudCollection
 {
-    // Intentionally empty. Behavior is inherited from the base class.
+    /**
+     * @var class-string
+     */
+    public $collects = BranchResource::class;
 }

--- a/app/Http/Resources/Branches/BranchResource.php
+++ b/app/Http/Resources/Branches/BranchResource.php
@@ -3,8 +3,20 @@
 namespace App\Http\Resources\Branches;
 
 use App\Http\Resources\SimpleCrudResource;
+use Illuminate\Http\Request;
 
 class BranchResource extends SimpleCrudResource
 {
-    // Intentionally empty. Behavior is inherited from the base class.
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return array_merge(parent::toArray($request), [
+            'company_id' => $this->resource->company_id,
+        ]);
+    }
 }

--- a/database/factories/BranchFactory.php
+++ b/database/factories/BranchFactory.php
@@ -24,7 +24,7 @@ class BranchFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->city().' Branch',
+            'name' => $this->faker->city() . ' Branch',
             'company_id' => Company::factory(),
         ];
     }

--- a/database/factories/BranchFactory.php
+++ b/database/factories/BranchFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Branch;
+use App\Models\Company;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -23,7 +24,8 @@ class BranchFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->city() . ' Branch',
+            'name' => $this->faker->city().' Branch',
+            'company_id' => Company::factory(),
         ];
     }
 }

--- a/database/seeders/BranchSeeder.php
+++ b/database/seeders/BranchSeeder.php
@@ -3,18 +3,26 @@
 namespace Database\Seeders;
 
 use App\Models\Branch;
+use App\Models\Company;
 use Illuminate\Database\Seeder;
 
 class BranchSeeder extends Seeder
 {
     public function run(): void
     {
+        $company = Company::query()->firstOrCreate(
+            ['name' => 'PT. Default Company'],
+        );
+
         $branches = [
             'Head Office', 'Branch 1', 'Branch 2', 'Branch 3',
         ];
 
         foreach ($branches as $name) {
-            Branch::updateOrCreate(['name' => $name]);
+            Branch::updateOrCreate(
+                ['name' => $name],
+                ['company_id' => $company->id],
+            );
         }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Branch;
+use App\Models\Company;
 use App\Models\Department;
 use App\Models\Employee;
 use App\Models\Employment;
@@ -86,6 +87,8 @@ class DatabaseSeeder extends Seeder
         $departmentId = Department::query()->value('id');
         $positionId = Position::query()->value('id');
         $branchId = Branch::query()->value('id');
+        $companyId = Company::query()->value('id')
+            ?? Company::query()->firstOrCreate(['name' => 'PT. Default Company'])->id;
 
         // Test User Employee (for test@example.com — ensures CheckPermission middleware finds employee)
         $testEmployee = Employee::updateOrCreate([
@@ -98,7 +101,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         Employment::factory()->withDepartment($departmentId)->withPosition($positionId)->withBranch($branchId)->for($testEmployee)->create([
-            'company_id' => 1,
+            'company_id' => $companyId,
             'salary' => 50000,
             'hire_date' => now(),
             'employment_status' => 'regular',
@@ -115,7 +118,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         Employment::factory()->withDepartment($departmentId)->withPosition($positionId)->withBranch($branchId)->for($adminEmployee)->create([
-            'company_id' => 1,
+            'company_id' => $companyId,
             'salary' => 100000,
             'hire_date' => now(),
             'employment_status' => 'regular',
@@ -133,7 +136,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         Employment::factory()->withDepartment(Department::where('name', 'HR')->value('id'))->withPosition(Position::where('name', 'Manager')->value('id'))->withBranch($branchId)->for($hrManagerEmployee)->create([
-            'company_id' => 1,
+            'company_id' => $companyId,
             'salary' => 15000000,
             'hire_date' => now()->subYears(2),
             'employment_status' => 'regular',
@@ -150,7 +153,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         Employment::factory()->withDepartment(Department::where('name', 'Finance')->value('id'))->withPosition(Position::where('name', 'Director')->value('id'))->withBranch($branchId)->for($financeDirectorEmployee)->create([
-            'company_id' => 1,
+            'company_id' => $companyId,
             'salary' => 25000000,
             'hire_date' => now()->subYears(5),
             'employment_status' => 'regular',
@@ -167,7 +170,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         Employment::factory()->withDepartment(Department::where('name', 'Engineering')->value('id'))->withPosition(Position::where('name', 'Senior')->value('id'))->withBranch($branchId)->for($itStaffEmployee)->create([
-            'company_id' => 1,
+            'company_id' => $companyId,
             'salary' => 12000000,
             'hire_date' => now()->subYears(1),
             'employment_status' => 'regular',

--- a/resources/js/components/employees/EmployeeColumns.tsx
+++ b/resources/js/components/employees/EmployeeColumns.tsx
@@ -54,7 +54,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
     },
     createTextColumn<Employee>({ accessorKey: 'name', label: 'Name' }),
     {
-        id: 'employment_status',
+        id: 'employments.employment_status',
         accessorFn: (row) => row.current_employment?.employment_status,
         ...createSortingHeader('Status'),
         cell: ({ row }) => {
@@ -73,7 +73,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
     createEmailColumn<Employee>({ accessorKey: 'email', label: 'Email' }),
     createPhoneColumn<Employee>({ accessorKey: 'phone', label: 'Phone' }),
     {
-        id: 'department_id',
+        id: 'employments.department_id',
         accessorFn: (row) => row.current_employment?.department?.name,
         ...createSortingHeader('Department'),
         cell: ({ row }) => (
@@ -83,7 +83,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
         ),
     },
     {
-        id: 'position_id',
+        id: 'employments.position_id',
         accessorFn: (row) => row.current_employment?.position?.name,
         ...createSortingHeader('Position'),
         cell: ({ row }) => (
@@ -91,7 +91,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
         ),
     },
     {
-        id: 'branch_id',
+        id: 'employments.branch_id',
         accessorFn: (row) => row.current_employment?.branch?.name,
         ...createSortingHeader('Branch'),
         cell: ({ row }) => (
@@ -99,7 +99,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
         ),
     },
     {
-        id: 'salary',
+        id: 'employments.salary',
         accessorFn: (row) => row.current_employment?.salary,
         ...createSortingHeader('Salary'),
         cell: ({ row }) => (
@@ -107,7 +107,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
         ),
     },
     {
-        id: 'hire_date',
+        id: 'employments.hire_date',
         accessorFn: (row) => row.current_employment?.hire_date,
         ...createSortingHeader('Hire Date'),
         cell: ({ row }) => (

--- a/resources/js/components/employees/EmployeeColumns.tsx
+++ b/resources/js/components/employees/EmployeeColumns.tsx
@@ -5,8 +5,6 @@ import { ColumnDef } from '@tanstack/react-table';
 
 import {
     createActionsColumn,
-    createCurrencyColumn,
-    createDateColumn,
     createEmailColumn,
     createPhoneColumn,
     createSelectColumn,
@@ -16,28 +14,34 @@ import {
 
 import { Employee } from '@/types/entity';
 
-/**
- * Cell renderer for department column - handles both object and string values
- */
-const renderDepartmentCell = ({ row }: { row: { original: Employee } }) => {
-    const val = row.original.department;
-    return <div>{typeof val === 'object' ? val.name : val}</div>;
+const formatCurrency = (value: string | null | undefined): string => {
+    if (!value) {
+        return '-';
+    }
+
+    const amount = Number(value);
+    if (Number.isNaN(amount)) {
+        return value;
+    }
+
+    return new Intl.NumberFormat('id-ID', {
+        style: 'currency',
+        currency: 'IDR',
+        maximumFractionDigits: 0,
+    }).format(amount);
 };
 
-/**
- * Cell renderer for position column - handles both object and string values
- */
-const renderPositionCell = ({ row }: { row: { original: Employee } }) => {
-    const val = row.original.position;
-    return <div>{typeof val === 'object' ? val.name : val}</div>;
-};
+const formatDate = (value: string | null | undefined): string => {
+    if (!value) {
+        return '-';
+    }
 
-/**
- * Cell renderer for branch column - handles both object and string values
- */
-const renderBranchCell = ({ row }: { row: { original: Employee } }) => {
-    const val = row.original.branch;
-    return <div>{typeof val === 'object' ? val.name : val}</div>;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleDateString('id-ID');
 };
 
 export const employeeColumns: ColumnDef<Employee>[] = [
@@ -51,10 +55,14 @@ export const employeeColumns: ColumnDef<Employee>[] = [
     createTextColumn<Employee>({ accessorKey: 'name', label: 'Name' }),
     {
         id: 'employment_status',
-        accessorKey: 'employment_status',
+        accessorFn: (row) => row.current_employment?.employment_status,
         ...createSortingHeader('Status'),
         cell: ({ row }) => {
-            const status = row.original.employment_status;
+            const status = row.original.current_employment?.employment_status;
+            if (!status) {
+                return <div>-</div>;
+            }
+
             return (
                 <Badge variant={status === 'intern' ? 'secondary' : 'default'}>
                     {status === 'intern' ? 'Intern' : 'Regular'}
@@ -66,31 +74,43 @@ export const employeeColumns: ColumnDef<Employee>[] = [
     createPhoneColumn<Employee>({ accessorKey: 'phone', label: 'Phone' }),
     {
         id: 'department_id',
-        accessorKey: 'department',
+        accessorFn: (row) => row.current_employment?.department?.name,
         ...createSortingHeader('Department'),
-        cell: renderDepartmentCell,
+        cell: ({ row }) => (
+            <div>{row.original.current_employment?.department?.name ?? '-'}</div>
+        ),
     },
     {
         id: 'position_id',
-        accessorKey: 'position',
+        accessorFn: (row) => row.current_employment?.position?.name,
         ...createSortingHeader('Position'),
-        cell: renderPositionCell,
+        cell: ({ row }) => (
+            <div>{row.original.current_employment?.position?.name ?? '-'}</div>
+        ),
     },
     {
         id: 'branch_id',
-        accessorKey: 'branch',
+        accessorFn: (row) => row.current_employment?.branch?.name,
         ...createSortingHeader('Branch'),
-        cell: renderBranchCell,
+        cell: ({ row }) => (
+            <div>{row.original.current_employment?.branch?.name ?? '-'}</div>
+        ),
     },
-    createCurrencyColumn<Employee>({
-        accessorKey: 'salary',
-        label: 'Salary',
-        currency: 'IDR',
-        locale: 'id-ID',
-    }),
-    createDateColumn<Employee>({
-        accessorKey: 'hire_date',
-        label: 'Hire Date',
-    }),
+    {
+        id: 'salary',
+        accessorFn: (row) => row.current_employment?.salary,
+        ...createSortingHeader('Salary'),
+        cell: ({ row }) => (
+            <div>{formatCurrency(row.original.current_employment?.salary)}</div>
+        ),
+    },
+    {
+        id: 'hire_date',
+        accessorFn: (row) => row.current_employment?.hire_date,
+        ...createSortingHeader('Hire Date'),
+        cell: ({ row }) => (
+            <div>{formatDate(row.original.current_employment?.hire_date)}</div>
+        ),
+    },
     createActionsColumn<Employee>(),
 ];

--- a/resources/js/components/employees/EmployeeColumns.tsx
+++ b/resources/js/components/employees/EmployeeColumns.tsx
@@ -77,7 +77,9 @@ export const employeeColumns: ColumnDef<Employee>[] = [
         accessorFn: (row) => row.current_employment?.department?.name,
         ...createSortingHeader('Department'),
         cell: ({ row }) => (
-            <div>{row.original.current_employment?.department?.name ?? '-'}</div>
+            <div>
+                {row.original.current_employment?.department?.name ?? '-'}
+            </div>
         ),
     },
     {

--- a/resources/js/components/employees/EmployeeForm.tsx
+++ b/resources/js/components/employees/EmployeeForm.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { memo, useEffect, useMemo } from 'react';
+import { format } from 'date-fns';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
-
-import { format } from 'date-fns';
 
 import AsyncSelectField from '@/components/common/AsyncSelectField';
 import { DatePickerField } from '@/components/common/DatePickerField';
@@ -21,13 +20,98 @@ interface EmployeeFormProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     entity?: Employee | null;
-    onSubmit: (data: EmployeeFormData) => void;
+    onSubmit: (data: EmployeeFormData | Record<string, unknown>) => void;
     isLoading?: boolean;
 }
 
-/**
- * Employee form sections for better organization and maintainability
- */
+interface BranchOption {
+    id: number;
+    name: string;
+    company_id?: number | null;
+}
+
+type EmployeeFormValues = z.input<typeof employeeFormSchema>;
+
+const emptyDefaults = (): EmployeeFormValues => ({
+    employee_id: '',
+    name: '',
+    email: '',
+    phone: '',
+    company_id: '',
+    department_id: '',
+    position_id: '',
+    branch_id: '',
+    salary: '',
+    hire_date: new Date(),
+    employment_status: 'regular',
+    termination_date: null,
+});
+
+const getEmployeeFormDefaults = (
+    employee?: Employee | null,
+): EmployeeFormValues => {
+    if (!employee) {
+        return emptyDefaults();
+    }
+
+    const employment = employee.current_employment;
+
+    return {
+        employee_id: employee.employee_id || '',
+        name: employee.name,
+        email: employee.email,
+        phone: employee.phone || '',
+        company_id: employment?.company_id
+            ? String(employment.company_id)
+            : '',
+        department_id: employment?.department_id
+            ? String(employment.department_id)
+            : '',
+        position_id: employment?.position_id
+            ? String(employment.position_id)
+            : '',
+        branch_id: employment?.branch_id ? String(employment.branch_id) : '',
+        salary: employment?.salary || '',
+        hire_date: employment?.hire_date
+            ? new Date(employment.hire_date)
+            : new Date(),
+        employment_status: employment?.employment_status || 'regular',
+        termination_date: employment?.termination_date
+            ? new Date(employment.termination_date)
+            : null,
+    };
+};
+
+const toApiPayload = (data: EmployeeFormValues): Record<string, unknown> => {
+    const hireDate =
+        data.hire_date instanceof Date
+            ? format(data.hire_date, 'yyyy-MM-dd')
+            : String(data.hire_date);
+
+    const terminationDate = data.termination_date
+        ? data.termination_date instanceof Date
+            ? format(data.termination_date, 'yyyy-MM-dd')
+            : String(data.termination_date)
+        : null;
+
+    return {
+        employee_id: data.employee_id,
+        name: data.name,
+        email: data.email,
+        phone: data.phone || null,
+        current_employment: {
+            company_id: Number(data.company_id),
+            department_id: Number(data.department_id),
+            position_id: Number(data.position_id),
+            branch_id: Number(data.branch_id),
+            salary: data.salary ? data.salary : null,
+            hire_date: hireDate,
+            employment_status: data.employment_status,
+            termination_date: terminationDate,
+        },
+    };
+};
+
 const renderEmployeeBasicInfoSection = () => (
     <>
         <InputField
@@ -46,44 +130,6 @@ const renderEmployeeBasicInfoSection = () => (
             name="phone"
             label="Phone"
             placeholder="+1 (555) 123-4567"
-        />
-    </>
-);
-
-const renderEmployeeWorkInfoSection = () => (
-    <>
-        <SelectField
-            name="employment_status"
-            label="Employment Status"
-            options={[
-                { value: 'regular', label: 'Regular' },
-                { value: 'intern', label: 'Intern' },
-            ]}
-        />
-        <AsyncSelectField
-            name="department_id"
-            label="Department"
-            url="/api/departments"
-            placeholder="Select a department"
-        />
-        <AsyncSelectField
-            name="position_id"
-            label="Position"
-            url="/api/positions"
-            placeholder="Select a position"
-        />
-        <AsyncSelectField
-            name="branch_id"
-            label="Branch"
-            url="/api/branches"
-            placeholder="Select a branch"
-        />
-        <InputField
-            name="salary"
-            label="Salary (Optional)"
-            type="number"
-            placeholder="50000"
-            prefix="Rp"
         />
     </>
 );
@@ -111,54 +157,6 @@ const renderEmployeeHireDateSection = () => (
     </div>
 );
 
-/**
- * Helper function to get default values for employee form
- */
-const getEmployeeFormDefaults = (
-    employee?: Employee | null,
-): EmployeeFormData => {
-    if (!employee) {
-        return {
-            employee_id: '',
-            name: '',
-            email: '',
-            phone: '',
-            department_id: '',
-            position_id: '',
-            branch_id: '',
-            salary: '',
-            hire_date: new Date(),
-            employment_status: 'regular',
-            termination_date: null,
-        };
-    }
-
-    return {
-        employee_id: employee.employee_id || '',
-        name: employee.name,
-        email: employee.email,
-        phone: employee.phone,
-        department_id:
-            typeof employee.department === 'object'
-                ? String(employee.department.id)
-                : String(employee.department),
-        position_id:
-            typeof employee.position === 'object'
-                ? String(employee.position.id)
-                : String(employee.position),
-        branch_id:
-            typeof employee.branch === 'object'
-                ? String(employee.branch.id)
-                : String(employee.branch),
-        salary: employee.salary || '',
-        hire_date: new Date(employee.hire_date),
-        employment_status: employee.employment_status || 'regular',
-        termination_date: employee.termination_date
-            ? new Date(employee.termination_date)
-            : null,
-    };
-};
-
 export const EmployeeForm = memo<EmployeeFormProps>(function EmployeeForm({
     open,
     onOpenChange,
@@ -171,28 +169,29 @@ export const EmployeeForm = memo<EmployeeFormProps>(function EmployeeForm({
         [entity],
     );
 
-    const form = useForm<z.input<typeof employeeFormSchema>>({
+    const form = useForm<EmployeeFormValues>({
         resolver: zodResolver(employeeFormSchema),
         defaultValues,
     });
 
-    // Reset form when entity changes (for edit mode)
     useEffect(() => {
         form.reset(defaultValues);
     }, [form, defaultValues]);
 
-    const handleFormSubmit = (data: z.input<typeof employeeFormSchema>) => {
-        const payload = {
-            ...data,
-            hire_date: format(data.hire_date, 'yyyy-MM-dd') as unknown as Date,
-            termination_date: data.termination_date
-                ? (format(
-                      data.termination_date,
-                      'yyyy-MM-dd',
-                  ) as unknown as Date)
-                : null,
-        } as EmployeeFormData;
-        onSubmit(payload);
+    const handleBranchSelect = useCallback(
+        (item: BranchOption) => {
+            if (item.company_id != null) {
+                form.setValue('company_id', String(item.company_id), {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                });
+            }
+        },
+        [form],
+    );
+
+    const handleFormSubmit = (data: EmployeeFormValues) => {
+        onSubmit(toApiPayload(data));
     };
 
     return (
@@ -205,7 +204,41 @@ export const EmployeeForm = memo<EmployeeFormProps>(function EmployeeForm({
             isLoading={isLoading}
         >
             {renderEmployeeBasicInfoSection()}
-            {renderEmployeeWorkInfoSection()}
+            <SelectField
+                name="employment_status"
+                label="Employment Status"
+                options={[
+                    { value: 'regular', label: 'Regular' },
+                    { value: 'intern', label: 'Intern' },
+                ]}
+            />
+            <AsyncSelectField
+                name="department_id"
+                label="Department"
+                url="/api/departments"
+                placeholder="Select a department"
+            />
+            <AsyncSelectField
+                name="position_id"
+                label="Position"
+                url="/api/positions"
+                placeholder="Select a position"
+            />
+            <AsyncSelectField<BranchOption>
+                name="branch_id"
+                label="Branch"
+                url="/api/branches"
+                placeholder="Select a branch"
+                onItemSelect={handleBranchSelect}
+            />
+            <input type="hidden" {...form.register('company_id')} />
+            <InputField
+                name="salary"
+                label="Salary (Optional)"
+                type="number"
+                placeholder="50000"
+                prefix="Rp"
+            />
             {renderEmployeeHireDateSection()}
         </EntityForm>
     );

--- a/resources/js/components/employees/EmployeeForm.tsx
+++ b/resources/js/components/employees/EmployeeForm.tsx
@@ -14,10 +14,7 @@ import NameField from '@/components/common/NameField';
 import SelectField from '@/components/common/SelectField';
 
 import { Employee } from '@/types/entity';
-import {
-    employeeFormSchema,
-    type EmployeeFormData,
-} from '@/utils/schemas';
+import { employeeFormSchema, type EmployeeFormData } from '@/utils/schemas';
 
 interface EmployeeFormProps {
     open: boolean;

--- a/resources/js/components/employees/EmployeeForm.tsx
+++ b/resources/js/components/employees/EmployeeForm.tsx
@@ -61,9 +61,7 @@ const getEmployeeFormDefaults = (
         name: employee.name,
         email: employee.email,
         phone: employee.phone || '',
-        company_id: employment?.company_id
-            ? String(employment.company_id)
-            : '',
+        company_id: employment?.company_id ? String(employment.company_id) : '',
         department_id: employment?.department_id
             ? String(employment.department_id)
             : '',

--- a/resources/js/components/employees/EmployeeForm.tsx
+++ b/resources/js/components/employees/EmployeeForm.tsx
@@ -13,14 +13,17 @@ import { InputField } from '@/components/common/InputField';
 import NameField from '@/components/common/NameField';
 import SelectField from '@/components/common/SelectField';
 
-import { Employee, EmployeeFormData } from '@/types/entity';
-import { employeeFormSchema } from '@/utils/schemas';
+import { Employee } from '@/types/entity';
+import {
+    employeeFormSchema,
+    type EmployeeFormData,
+} from '@/utils/schemas';
 
 interface EmployeeFormProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     entity?: Employee | null;
-    onSubmit: (data: EmployeeFormData | Record<string, unknown>) => void;
+    onSubmit: (data: Record<string, unknown>) => void;
     isLoading?: boolean;
 }
 
@@ -30,9 +33,9 @@ interface BranchOption {
     company_id?: number | null;
 }
 
-type EmployeeFormValues = z.input<typeof employeeFormSchema>;
+type EmployeeFormInput = z.input<typeof employeeFormSchema>;
 
-const emptyDefaults = (): EmployeeFormValues => ({
+const emptyDefaults = (): EmployeeFormInput => ({
     employee_id: '',
     name: '',
     email: '',
@@ -49,7 +52,7 @@ const emptyDefaults = (): EmployeeFormValues => ({
 
 const getEmployeeFormDefaults = (
     employee?: Employee | null,
-): EmployeeFormValues => {
+): EmployeeFormInput => {
     if (!employee) {
         return emptyDefaults();
     }
@@ -80,16 +83,11 @@ const getEmployeeFormDefaults = (
     };
 };
 
-const toApiPayload = (data: EmployeeFormValues): Record<string, unknown> => {
-    const hireDate =
-        data.hire_date instanceof Date
-            ? format(data.hire_date, 'yyyy-MM-dd')
-            : String(data.hire_date);
+const toApiPayload = (data: EmployeeFormData): Record<string, unknown> => {
+    const hireDate = format(data.hire_date, 'yyyy-MM-dd');
 
     const terminationDate = data.termination_date
-        ? data.termination_date instanceof Date
-            ? format(data.termination_date, 'yyyy-MM-dd')
-            : String(data.termination_date)
+        ? format(data.termination_date, 'yyyy-MM-dd')
         : null;
 
     return {
@@ -167,7 +165,7 @@ export const EmployeeForm = memo<EmployeeFormProps>(function EmployeeForm({
         [entity],
     );
 
-    const form = useForm<EmployeeFormValues>({
+    const form = useForm<EmployeeFormInput, unknown, EmployeeFormData>({
         resolver: zodResolver(employeeFormSchema),
         defaultValues,
     });
@@ -188,12 +186,12 @@ export const EmployeeForm = memo<EmployeeFormProps>(function EmployeeForm({
         [form],
     );
 
-    const handleFormSubmit = (data: EmployeeFormValues) => {
+    const handleFormSubmit = (data: EmployeeFormData) => {
         onSubmit(toApiPayload(data));
     };
 
     return (
-        <EntityForm<EmployeeFormData>
+        <EntityForm<EmployeeFormInput, EmployeeFormData>
             form={form}
             open={open}
             onOpenChange={onOpenChange}

--- a/resources/js/components/employees/EmployeeViewModal.tsx
+++ b/resources/js/components/employees/EmployeeViewModal.tsx
@@ -16,27 +16,19 @@ interface EmployeeViewModalProps {
     item: Employee | null;
 }
 
-/**
- * EmployeeViewModal - A read-only modal to display employee details.
- * Similar layout to Edit modal but with static text instead of form inputs.
- */
 export const EmployeeViewModal = memo<EmployeeViewModalProps>(
     function EmployeeViewModal({ open, onClose, item }) {
         const { t } = useTranslation();
         if (!item) return null;
 
-        const departmentName =
-            typeof item.department === 'object'
-                ? item.department.name
-                : item.department;
-
-        const positionName =
-            typeof item.position === 'object'
-                ? item.position.name
-                : item.position;
-
-        const branchName =
-            typeof item.branch === 'object' ? item.branch.name : item.branch;
+        const employment = item.current_employment;
+        const status = employment?.employment_status;
+        const statusLabel =
+            status === 'intern'
+                ? 'Intern'
+                : status === 'regular'
+                  ? 'Regular'
+                  : '-';
 
         return (
             <ViewModalShell
@@ -50,29 +42,35 @@ export const EmployeeViewModal = memo<EmployeeViewModalProps>(
                     <ViewField label="Name" value={item.name} />
                     <ViewField label="Email" value={item.email} />
                     <ViewField label="Phone" value={item.phone} />
+                    <ViewField label="Status" value={statusLabel} />
                     <ViewField
-                        label="Status"
-                        value={
-                            item.employment_status === 'intern'
-                                ? 'Intern'
-                                : 'Regular'
-                        }
+                        label="Department"
+                        value={employment?.department?.name ?? '-'}
                     />
-                    <ViewField label="Department" value={departmentName} />
-                    <ViewField label="Position" value={positionName} />
-                    <ViewField label="Branch" value={branchName} />
+                    <ViewField
+                        label="Position"
+                        value={employment?.position?.name ?? '-'}
+                    />
+                    <ViewField
+                        label="Branch"
+                        value={employment?.branch?.name ?? '-'}
+                    />
                     <ViewField
                         label="Salary"
-                        value={formatRupiah(item.salary || 0)}
+                        value={formatRupiah(employment?.salary || 0)}
                     />
                     <ViewField
                         label="Hire Date"
-                        value={formatDate(item.hire_date)}
+                        value={
+                            employment?.hire_date
+                                ? formatDate(employment.hire_date)
+                                : '-'
+                        }
                     />
-                    {item.termination_date && (
+                    {employment?.termination_date && (
                         <ViewField
                             label="Termination Date"
-                            value={formatDate(item.termination_date)}
+                            value={formatDate(employment.termination_date)}
                         />
                     )}
                 </div>

--- a/resources/js/types/employee.ts
+++ b/resources/js/types/employee.ts
@@ -1,17 +1,32 @@
 import { BaseEntity } from './entity';
 
+export interface EmploymentRelation {
+    id: number;
+    name: string;
+}
+
+export interface Employment {
+    id: number;
+    company_id: number;
+    department_id: number;
+    position_id: number;
+    branch_id: number;
+    salary: string | null;
+    hire_date: string;
+    employment_status: 'regular' | 'intern';
+    termination_date: string | null;
+    company?: EmploymentRelation | null;
+    department?: EmploymentRelation | null;
+    position?: EmploymentRelation | null;
+    branch?: EmploymentRelation | null;
+}
+
 export interface Employee extends BaseEntity {
     employee_id: string;
     name: string;
     email: string;
     phone: string;
-    department: { id: number; name: string } | string;
-    position: { id: number; name: string } | string;
-    branch: { id: number; name: string } | string;
-    salary: string | null;
-    hire_date: string;
-    employment_status: 'regular' | 'intern';
-    termination_date: string | null;
+    current_employment?: Employment | null;
 }
 
 export interface EmployeeFormData {
@@ -22,8 +37,9 @@ export interface EmployeeFormData {
     department_id: string;
     position_id: string;
     branch_id: string;
+    company_id: string;
     salary?: string;
-    hire_date: Date;
+    hire_date: Date | string;
     employment_status: 'regular' | 'intern';
-    termination_date?: Date | null;
+    termination_date?: Date | string | null;
 }

--- a/resources/js/utils/__tests__/columns.test.ts
+++ b/resources/js/utils/__tests__/columns.test.ts
@@ -16,6 +16,11 @@ import {
     createTextColumn,
 } from '../columns';
 
+interface PayrollFixture {
+    salary: string | null;
+    hire_date: string;
+}
+
 // ── Helper ──
 
 type AccessorKeyCol = ColumnDef<unknown> & { accessorKey: string };
@@ -92,10 +97,10 @@ const _phoneAk: _PhoneAccessorKey = 'phone';
 
 // ── createCurrencyColumn ──
 
-const _currencyCol = createCurrencyColumn<Employee>({
+const _currencyCol = createCurrencyColumn<PayrollFixture>({
     accessorKey: 'salary',
     label: 'Salary',
-}) as WithAccessorKey<Employee>;
+}) as WithAccessorKey<PayrollFixture>;
 type _CurrencyAccessorKey = (typeof _currencyCol)['accessorKey'];
 const _currencyAk: _CurrencyAccessorKey = 'salary';
 
@@ -130,8 +135,11 @@ const _empColumns = [
     createTextColumn<Employee>({ accessorKey: 'name', label: 'Name' }),
     createEmailColumn<Employee>({ accessorKey: 'email', label: 'Email' }),
     createPhoneColumn<Employee>({ accessorKey: 'phone', label: 'Phone' }),
-    createCurrencyColumn<Employee>({ accessorKey: 'salary', label: 'Salary' }),
-    createDateColumn<Employee>({
+    createCurrencyColumn<PayrollFixture>({
+        accessorKey: 'salary',
+        label: 'Salary',
+    }),
+    createDateColumn<PayrollFixture>({
         accessorKey: 'hire_date',
         label: 'Hire Date',
     }),

--- a/resources/js/utils/schemas.ts
+++ b/resources/js/utils/schemas.ts
@@ -101,6 +101,7 @@ export const employeeFormSchema = z.object({
         })
         .or(z.literal(''))
         .optional(),
+    company_id: z.string().min(1, { message: 'Company is required.' }),
     department_id: z.string().min(1, { message: 'Department is required.' }),
     position_id: z.string().min(1, { message: 'Position is required.' }),
     branch_id: z.string().min(1, { message: 'Branch is required.' }),

--- a/task.md
+++ b/task.md
@@ -1,12 +1,12 @@
 # AI Handoff: ERP Active State
 
-Last updated: 2026-07-24 — branch `fix/e2e-disable-rate-limiting` (E2E 429 fix).
+Last updated: 2026-07-24 — PR #70 open (`764fd737`) for E2E 429 fix.
 
 ## SESSION 2026-07-24 — Playwright E2E 429 rate-limit fix
 
 **Goal**: Stop residual Playwright CI failures caused by HTTP 429 under parallel suite load (post PR #69 merge).
 
-**Current milestone**: Fix implemented on branch; PR open/pending.
+**Current milestone**: PR #70 open — https://github.com/gmedia/erp/pull/70
 
 ### Root cause
 

--- a/task.md
+++ b/task.md
@@ -1,81 +1,69 @@
 # AI Handoff: ERP Active State
 
-Last updated: 2026-07-23 — APP_ENV fix applied. PR #69 OPEN on fix/e2e-login-debug.
+Last updated: 2026-07-24 — branch `fix/e2e-disable-rate-limiting` (E2E 429 fix).
 
-## SESSION 2026-07-23 — Fix E2E login DB mismatch (PR #69)
+## SESSION 2026-07-24 — Playwright E2E 429 rate-limit fix
 
-**Goal**: Get PR #69 fully green (Quality + Test suite; Playwright past global-setup login).
+**Goal**: Stop residual Playwright CI failures caused by HTTP 429 under parallel suite load (post PR #69 merge).
 
-**Current milestone**: Pushed `APP_ENV=local` fix; one-shot CI check pending.
+**Current milestone**: Fix implemented on branch; PR open/pending.
 
-### Root causes (confirmed)
+### Root cause
 
-1. **E2E migrate (fixed)**: `--database=testing` invalid. Now `migrate:fresh --seed --force` on default `mariadb`/`laravel`.
-2. **Quality Sonar (fixed)**: removed `sonar.scanner.skipJreProvisioning=true` so scanner provisions Java 21+.
-3. **E2E login 500 (fix applied)**: CI `cp .env.example .env` with `APP_ENV=testing` → Laravel `LoadEnvironmentVariables` loads tracked `.env.testing` → `DB_DATABASE=testing`. Migrate/seed fill `laravel`; HTTP app queries `testing.users` → 500.
+1. API middleware always applies `ThrottleRequests:api` (`bootstrap/app.php`).
+2. `AppServiceProvider` registers `api` limiter at **60/min per user id or IP**, unless:
+   - `app()->environment('testing')`, or
+   - `config('app.disable_rate_limiting')` is truthy (`DISABLE_RATE_LIMITING` env).
+3. After PR #69, E2E uses `APP_ENV=local` (correct for DB), so `testing` env bypass no longer applies.
+4. Playwright suite shares one admin user + parallel workers → exceeds 60 API req/min → widespread 429 → timeouts.
+5. Infrastructure already existed (`config/app.php` + `Limit::none()`), but **CI E2E never set** `DISABLE_RATE_LIMITING=true`.
 
-| Context | Connection | Database |
-|---------|------------|----------|
-| Pest (`phpunit.xml`) | `mariadb` | `testing` |
-| Sail app / E2E (intended) | `mariadb` | `laravel` |
-| Broken HTTP path (before fix) | `mariadb` | `testing` via `.env.testing` |
+Evidence: job `89345123775` on run `30047647276` — many `429 (Too Many Requests)` console errors after successful global-setup login.
 
-### What changed this session
+### Fix (minimal)
 
-| Commit | Message |
-|--------|---------|
-| (pending) | fix: use APP_ENV=local in .env.example so E2E uses laravel DB |
-| (pending) | docs: update task.md for env/DB mismatch fix |
+| File | Change |
+|------|--------|
+| `.github/workflows/tests.yml` | E2E **Prepare environment** appends `DISABLE_RATE_LIMITING=true` to `.env` (Sail app process must read it; GHA job env alone is not enough) |
+| `.env.example` | Document optional `DISABLE_RATE_LIMITING` for local E2E |
 
-Prior commits on branch:
+Quality/Test suite jobs are **unchanged** (rate limits stay on).
 
-| Commit | Message |
-|--------|---------|
-| `6a71c163` | docs: note CI run after Sonar JRE fix push |
-| `03468670` | fix: keep Sonar scanner JRE provisioning for Java 21+ |
-| `3285c2cd` | fix: use default DB for E2E migrate:fresh --seed |
-| `44ba57c2` | fix: remove temporary AuthController login debug logging |
+### Constraints that remain valid
 
-### Validated
-
-- CI run 29902892175 (`headSha` `6a71c163`): Quality green (incl. Sonar); E2E migrate/seed green; Playwright failed at `createAdminAuthState` with login **500**
-- Exact error: `Table 'testing.users' doesn't exist ... Database: testing ... email = admin@dokfin.id`
-- Framework: `Env::get('APP_ENV')` → load `.env.{APP_ENV}` when file exists
-- `artisan serve` passthrough includes `APP_ENV` to child PHP server process
-- Pest isolation unchanged: `phpunit.xml` still sets `APP_ENV=testing` + `DB_DATABASE=testing`
-
-### Next steps
-
-1. One-shot check next CI run after push (no polling).
-2. Confirm Quality still green.
-3. Confirm Playwright global-setup login past 500 (no `testing.users` error).
-4. If Quality + Test suite green and E2E verified: squash-merge PR #69. E2E has `continue-on-error: true`.
-
-### Critical context
-
-- Branch: `fix/e2e-login-debug`
-- PR: https://github.com/gmedia/erp/pull/69
-- Prior CI: https://github.com/gmedia/erp/actions/runs/29902892175
 - Do **not** invent a `testing` connection for E2E
 - Do **not** re-add `skipJreProvisioning=true`
 - Do **not** poll CI
-- Keep `.env.testing` for Pest-only overrides; do not point Sail/E2E at it
+- Keep `.env.testing` for Pest-only; Sail/E2E use `.env` from `.env.example` with `APP_ENV=local`
+- Production must never set `DISABLE_RATE_LIMITING=true`
 
-### Key files
+### Prior session (PR #69) — closed
 
-- `.env.example` — `APP_ENV=local` (was `testing`)
-- `.env.testing` — Pest DB `testing` (unchanged)
-- `phpunit.xml` — Pest env overrides (unchanged)
-- `.github/workflows/tests.yml` — `cp .env.example .env`; E2E migrate/seed
-- `tests/e2e/global-setup.ts` — login bootstrap
-- `app/Http/Controllers/Api/AuthController.php`
+- Merge commit: `304f0a78` on `main`
+- Fixed: invalid E2E migrate DB, Sonar JRE, login 500 (`APP_ENV=testing` → wrong DB)
+- Residual after merge: this 429 issue
+
+### Validated / expected
+
+- Local change is workflow + docs only (no PHP behavior change unless env set)
+- Next: push branch, open PR, one-shot CI check (do not poll)
+
+### Open risks
+
+- Residual non-429 failures may remain (e.g. CSP blocking MinIO logo `img-src`)
+- Fortify login limiter (5/min) is separate; E2E uses preloaded auth state so usually not hit
+
+### Recommended next step
+
+```
+Push fix/e2e-disable-rate-limiting, open PR, one-shot gh pr checks.
+If E2E still red without 429, investigate CSP/MinIO branding next.
+```
 
 ## Continuation Prompt
 
 ```
-Continue PR #69 on fix/e2e-login-debug. Read task.md.
-One-shot check gh pr checks 69 / latest CI run after APP_ENV=local fix.
-Expect: Quality green; Playwright login no longer hits testing.users.
-If still 500, re-read E2E logs for active DB name.
-Do not invent testing connection. Do not poll CI. Do not re-add skipJreProvisioning.
+Branch fix/e2e-disable-rate-limiting: DISABLE_RATE_LIMITING=true for E2E CI only.
+Read task.md. Push if not pushed, open PR if missing, one-shot CI check.
+Do not poll CI. Do not re-add skipJreProvisioning.
 ```

--- a/task.md
+++ b/task.md
@@ -1,69 +1,86 @@
 # AI Handoff: ERP Active State
 
-Last updated: 2026-07-24 — PR #70 open (`764fd737`) for E2E 429 fix.
+Last updated: 2026-07-30 — PR #70 residual nested-employment fix pushed (`48940ce6`).
 
-## SESSION 2026-07-24 — Playwright E2E 429 rate-limit fix
+## SESSION 2026-07-30 — Residual Employee E2E after 429 fix
 
-**Goal**: Stop residual Playwright CI failures caused by HTTP 429 under parallel suite load (post PR #69 merge).
+**Goal**: Clear residual Playwright Employee/User E2E failures on PR #70 after rate-limit 429 was fixed.
 
-**Current milestone**: PR #70 open — https://github.com/gmedia/erp/pull/70
+**Current milestone**: PR #70 open — https://github.com/gmedia/erp/pull/70  
+**Branch**: `fix/e2e-disable-rate-limiting`  
+**HEAD**: `48940ce6`
 
-### Root cause
+### Prior: 429 rate-limit (done)
 
-1. API middleware always applies `ThrottleRequests:api` (`bootstrap/app.php`).
-2. `AppServiceProvider` registers `api` limiter at **60/min per user id or IP**, unless:
-   - `app()->environment('testing')`, or
-   - `config('app.disable_rate_limiting')` is truthy (`DISABLE_RATE_LIMITING` env).
-3. After PR #69, E2E uses `APP_ENV=local` (correct for DB), so `testing` env bypass no longer applies.
-4. Playwright suite shares one admin user + parallel workers → exceeds 60 API req/min → widespread 429 → timeouts.
-5. Infrastructure already existed (`config/app.php` + `Limit::none()`), but **CI E2E never set** `DISABLE_RATE_LIMITING=true`.
+- Root cause: 60/min API throttle + shared admin + parallel Playwright + `APP_ENV=local`
+- Fix: E2E Prepare environment appends `DISABLE_RATE_LIMITING=true` to `.env`
+- Verified on run `30056540816`: **0× 429**, Quality + Test suite green
+- Residual: **13 failed / 499 passed** — Employee/User dialog-not-close
 
-Evidence: job `89345123775` on run `30047647276` — many `429 (Too Many Requests)` console errors after successful global-setup login.
+### Residual root cause (done product fix)
 
-### Fix (minimal)
+Frontend + E2E still used flat Employee fields after Employment refactor (#68). Backend requires nested:
 
-| File | Change |
-|------|--------|
-| `.github/workflows/tests.yml` | E2E **Prepare environment** appends `DISABLE_RATE_LIMITING=true` to `.env` (Sail app process must read it; GHA job env alone is not enough) |
-| `.env.example` | Document optional `DISABLE_RATE_LIMITING` for local E2E |
+```json
+{
+  "employee_id", "name", "email", "phone",
+  "current_employment": {
+    "company_id", "department_id", "position_id", "branch_id",
+    "salary", "hire_date", "employment_status"
+  }
+}
+```
 
-Quality/Test suite jobs are **unchanged** (rate limits stay on).
+No companies API — company is derived from selected Branch (`company_id`).
+
+### What landed this session (5 commits)
+
+| Commit | Change |
+|--------|--------|
+| `35f8b60c` | BranchResource exposes `company_id` + unit test |
+| `2b8693e0` | BranchFactory / BranchSeeder / DatabaseSeeder assign company |
+| `623b76dd` | Nested Employee/Employment types + `company_id` in form schema |
+| `9933861e` | EmployeeForm submits nested `current_employment`; branch `onItemSelect` sets company |
+| `48940ce6` | EmployeeColumns + EmployeeViewModal read `current_employment.*` |
+
+E2E helpers left UI-flat intentionally: form combobox labels still match Engineering / Senior Developer / Head Office / Regular; form nests payload + derives company on submit.
 
 ### Constraints that remain valid
 
 - Do **not** invent a `testing` connection for E2E
 - Do **not** re-add `skipJreProvisioning=true`
-- Do **not** poll CI
-- Keep `.env.testing` for Pest-only; Sail/E2E use `.env` from `.env.example` with `APP_ENV=local`
+- Do **not** poll CI (one-shot only)
+- Keep `.env.testing` for Pest-only; Sail/E2E use `APP_ENV=local`
 - Production must never set `DISABLE_RATE_LIMITING=true`
+- Prefer light sequential work (OpenCode killed by heavy parallel agents)
 
-### Prior session (PR #69) — closed
+### Validated
 
-- Merge commit: `304f0a78` on `main`
-- Fixed: invalid E2E migrate DB, Sonar JRE, login 500 (`APP_ENV=testing` → wrong DB)
-- Residual after merge: this 429 issue
+- Working tree clean; branch in sync with origin
+- 429 fix still present (`764fd737`)
+- Product residual fix pushed to PR #70
 
-### Validated / expected
+### Open risks / next
 
-- Local change is workflow + docs only (no PHP behavior change unless env set)
-- Next: push branch, open PR, one-shot CI check (do not poll)
-
-### Open risks
-
-- Residual non-429 failures may remain (e.g. CSP blocking MinIO logo `img-src`)
-- Fortify login limiter (5/min) is separate; E2E uses preloaded auth state so usually not hit
+1. One-shot CI recheck after push — confirm Employee/User E2E no longer fail on dialog-not-close
+2. If still red: minimal E2E helper polish (hire_date defaults, salary edit, export expectations)
+3. Optional later: CSP MinIO logo `img-src` if still noisy after suite green
 
 ### Recommended next step
 
 ```
-Push fix/e2e-disable-rate-limiting, open PR, one-shot gh pr checks.
-If E2E still red without 429, investigate CSP/MinIO branding next.
+One-shot: gh pr checks 70  (or latest run on PR #70 after headSha 48940ce6)
+If Employee/User E2E green → squash-merge PR #70
+If still red → inspect residual assertion (not 429) and patch helpers minimally
+Do not poll CI. Do not re-add skipJreProvisioning.
 ```
 
 ## Continuation Prompt
 
 ```
-Branch fix/e2e-disable-rate-limiting: DISABLE_RATE_LIMITING=true for E2E CI only.
-Read task.md. Push if not pushed, open PR if missing, one-shot CI check.
-Do not poll CI. Do not re-add skipJreProvisioning.
+Branch fix/e2e-disable-rate-limiting HEAD 48940ce6 on PR #70.
+429 fixed; nested-employment product fix pushed (Branch company_id + EmployeeForm nested payload + columns/view).
+Read task.md. One-shot CI check for PR #70. Do not poll.
+If Employee/User E2E still fail, minimal helper polish only.
+Do not re-add skipJreProvisioning. Prefer sequential work over heavy parallel agents.
 ```

--- a/tests/Feature/Branches/BranchControllerTest.php
+++ b/tests/Feature/Branches/BranchControllerTest.php
@@ -34,7 +34,7 @@ describe('Branch API Endpoints', function () {
         $response->assertOk()
             ->assertJsonStructure([
                 'data' => [
-                    '*' => ['id', 'name', 'created_at', 'updated_at'],
+                    '*' => ['id', 'name', 'company_id', 'created_at', 'updated_at'],
                 ],
                 'meta' => ['total', 'per_page', 'current_page'],
             ]);

--- a/tests/Feature/Employees/EmployeeControllerTest.php
+++ b/tests/Feature/Employees/EmployeeControllerTest.php
@@ -181,6 +181,37 @@ describe('Employee API Endpoints', function () {
         expect($aIndex)->toBeLessThan($zIndex);
     });
 
+    test('index accepts nested employment sort_by values and rejects bare employment fields', function () {
+        $accepted = [
+            'employments.department_id',
+            'employments.position_id',
+            'employments.branch_id',
+            'employments.salary',
+            'employments.employment_status',
+            'employments.hire_date',
+        ];
+
+        foreach ($accepted as $sortBy) {
+            getJson('/api/employees?sort_by=' . $sortBy . '&sort_direction=asc')
+                ->assertOk();
+        }
+
+        $rejected = [
+            'department_id',
+            'position_id',
+            'branch_id',
+            'salary',
+            'employment_status',
+            'hire_date',
+        ];
+
+        foreach ($rejected as $sortBy) {
+            getJson('/api/employees?sort_by=' . $sortBy . '&sort_direction=asc')
+                ->assertUnprocessable()
+                ->assertJsonValidationErrors(['sort_by']);
+        }
+    });
+
     test('store creates employee with valid data and returns 201 status', function () {
         $company = Company::factory()->create();
         $department = Department::factory()->create();

--- a/tests/Unit/Resources/Branches/BranchCollectionTest.php
+++ b/tests/Unit/Resources/Branches/BranchCollectionTest.php
@@ -17,4 +17,6 @@ test('to array transforms collection', function () {
 
     expect($result)->toHaveCount(3);
     expect($result[0]['name'])->toBe($branches[0]->name);
+    expect($result[0])->toHaveKey('company_id')
+        ->and($result[0]['company_id'])->toBe($branches[0]->company_id);
 });

--- a/tests/Unit/Resources/Branches/BranchResourceTest.php
+++ b/tests/Unit/Resources/Branches/BranchResourceTest.php
@@ -2,13 +2,18 @@
 
 use App\Http\Resources\Branches\BranchResource;
 use App\Models\Branch;
+use App\Models\Company;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 
 uses(RefreshDatabase::class)->group('branches');
 
 test('to array returns correct structure', function () {
-    $branch = Branch::factory()->create(['name' => 'Main Branch']);
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->create([
+        'name' => 'Main Branch',
+        'company_id' => $company->id,
+    ]);
 
     $resource = new BranchResource($branch);
     $request = Request::create('/');
@@ -18,6 +23,7 @@ test('to array returns correct structure', function () {
     expect($result)->toMatchArray([
         'id' => $branch->id,
         'name' => 'Main Branch',
+        'company_id' => $company->id,
     ]);
 
     expect($result['created_at'])->toBeString()


### PR DESCRIPTION
## What was done
- Diagnosed residual Playwright E2E failures after PR #69 merge: widespread **HTTP 429** under parallel suite load (not login/DB).
- Root cause: `ThrottleRequests:api` at 60/min per user; E2E runs as one admin under parallel workers; with `APP_ENV=local` the `testing` env bypass no longer applies.
- Wired existing `DISABLE_RATE_LIMITING` / `config('app.disable_rate_limiting')` into the **E2E job only** by appending `DISABLE_RATE_LIMITING=true` to `.env` during Prepare environment (Sail app process must read it).
- Documented the optional env flag in `.env.example`.

## Files changed
- `.github/workflows/tests.yml` — E2E prepare sets `DISABLE_RATE_LIMITING=true` in `.env`
- `.env.example` — comment documenting the flag
- `task.md` — handoff for this residual fix

## Verification
- [ ] Quality checks via Sail
- [ ] Test suite via Sail
- [ ] Playwright E2E via Sail — expect no systematic 429 console errors
- [ ] CI one-shot after push (do not poll)

## Next steps
- If E2E still red without 429, investigate CSP blocking MinIO branding logo (`img-src 'self' data:`) as separate follow-up.

## Related
- Post-merge failed job: https://github.com/gmedia/erp/actions/runs/30047647276/job/89345123775
- Prior merge: #69 (`304f0a78`)