### PR TITLE
test: add Budget Playwright E2E suite

### DIFF
--- a/docs/module-registry.md
+++ b/docs/module-registry.md
@@ -493,6 +493,20 @@ Semua modul simple CRUD memiliki konfigurasi E2E yang identik kecuali nama:
   view_type: dialog
   checkbox_header: false
 
+- slug: budgets
+  route: /budgets
+  api: /api/budgets
+  export_api: /api/budgets/export
+  search_placeholder: "Search budgets..."
+  sortable_columns: [Name, Budget Type, Status, Total Amount, Created At]
+  non_sortable_columns: [Fiscal Year]
+  view_type: dialog
+  view_dialog_title: "Budget Details"
+  checkbox_header: false
+  note: "Complex CRUD dengan nested Budget Lines (min 1 line: account_id, period_start/end, allocated_amount). Create via inline Add Line row (bukan nested dialog)."
+  tests:
+    - tests/e2e/budgets/budget.spec.ts
+
 - slug: recurring-journals
   route: /recurring-journals
   api: /api/recurring-journals

--- a/task.md
+++ b/task.md
@@ -1,33 +1,43 @@
 # AI Handoff: ERP Active State
 
-Last updated: 2026-08-05 — Budget E2E implemented on `feat/budgets-e2e`.
+Last updated: 2026-08-05 — Budget E2E PR #72 open.
 
 ## Current milestone
 
 **Branch:** `feat/budgets-e2e` (from `main` @ `f8f4be01`)  
-**Goal:** Close Budget product gap — Playwright E2E + module registry entry.  
-**Status:** E2E + registry written; next = commit / push / PR (do not wait for CI).
+**PR:** https://github.com/gmedia/erp/pull/72  
+**HEAD:** `40ca2fba`  
+**Goal:** Close Budget product gap — Playwright E2E + module registry.  
+**Status:** Done — 3 commits pushed; PR open. Do not wait for CI.
 
 ## What changed this session
 
-- Created `tests/e2e/budgets/helpers.ts` — create (≥1 line), search, edit
-- Created `tests/e2e/budgets/budget.spec.ts` — `generateModuleTests` (9 standard cases + status/type filters)
-- Updated `docs/module-registry.md` — budgets E2E YAML under Complex CRUD
+- `tests/e2e/budgets/helpers.ts` — create (≥1 line), search, edit
+- `tests/e2e/budgets/budget.spec.ts` — `generateModuleTests` + Status/Budget Type filters
+- `docs/module-registry.md` — budgets Complex CRUD YAML
+- Commits: `b8a44ef8` test | `62c29ff8` docs | `40ca2fba` chore handoff
+
+## Validated commands and outcomes
+
+- `git push -u origin feat/budgets-e2e` — OK
+- `gh pr create` → #72 — OK
+- Working tree clean; branch tracking `origin/feat/budgets-e2e`
 
 ## Open risks / blockers
 
-- Create helper depends on seed data: ≥1 fiscal year + ≥1 account for AsyncSelect first-option pick
-- Inline line editor (not nested dialog) — date pickers use placeholder triggers (`Pick start/end date`)
-- Prefer light sequential tool use (heavy parallel agents previously killed OpenCode)
+- Create helper needs seed: ≥1 fiscal year + ≥1 account (first AsyncSelect option)
+- Inline line editor date pickers use `Pick start/end date` placeholders
+- Playwright budgets suite not run locally this session (CI will cover)
 
 ## Recommended next step
 
-Commit, push, `gh pr create`. Optionally run:
-`PLAYWRIGHT_USE_SAIL=1 ./vendor/bin/sail npx playwright test tests/e2e/budgets/`
+- Session start: process open MRs — if #72 green → squash merge; if red → fix
+- Optional local: `PLAYWRIGHT_USE_SAIL=1 ./vendor/bin/sail npx playwright test tests/e2e/budgets/`
 
 ## Continuation Prompt
 
 ```
-On feat/budgets-e2e: commit Budget E2E + registry, push, gh pr create.
-Do not wait for CI. Handoff template in AGENTS.md.
+PR #72 (feat/budgets-e2e) is open. Check gh pr checks 72.
+Green → squash merge + delete branch + pull main.
+Red → checkout feat/budgets-e2e, fix, push. Do not wait on CI otherwise.
 ```

--- a/task.md
+++ b/task.md
@@ -1,59 +1,33 @@
 # AI Handoff: ERP Active State
 
-Last updated: 2026-08-04 — docs cleanup on `docs/cleanup-user-guides-and-stale-docs`.
+Last updated: 2026-08-05 — Budget E2E implemented on `feat/budgets-e2e`.
 
 ## Current milestone
 
-**Branch:** `docs/cleanup-user-guides-and-stale-docs`  
-**Base:** `main` @ `bd573fb3` (post PR #70)  
-**Goal:** Restore corrupted user guides + fix stale design/status/registry/dashboard docs.
+**Branch:** `feat/budgets-e2e` (from `main` @ `f8f4be01`)  
+**Goal:** Close Budget product gap — Playwright E2E + module registry entry.  
+**Status:** E2E + registry written; next = commit / push / PR (do not wait for CI).
 
-## What changed in this session
+## What changed this session
 
-### P0 — User guides (7 files rewritten)
-Corrupted guides deleted and rewritten (Indonesian, menus/routes, workflows, FAQ):
-- `docs/user-guide-purchase-requests.md`
-- `docs/user-guide-purchase-orders.md`
-- `docs/user-guide-goods-receipts.md`
-- `docs/user-guide-supplier-returns.md`
-- `docs/user-guide-stock-transfers.md`
-- `docs/user-guide-asset-maintenances.md`
-- `docs/user-guide-asset-stocktakes.md`
-
-### P1 — Status / design truth
-- `docs/budget-management-design.md` — removed GREENFIELD; marked Implemented + E2E gap
-- `docs/database/IMPLEMENTATION_STATUS.md` — date 2026-08-04; rows 19–23 (Budget + dashboards); test baseline note
-- `docs/refactor-sonar-progress.md` — **FROZEN**; superseded OPEN-83 section; closed Next Steps
-
-### P2 — Registry / index / dashboards
-- `docs/module-registry.md` — Last updated + correct count notes (Pest 74); dashboards note fixed
-- `docs/README.md` — **new** docs index + dashboard matrix
-- `docs/user-guide-dashboard.md` — rewrite for real home dashboard (4 entity totals)
-- `docs/user-guide-financial-dashboard.md` — disambiguation callout vs `/dashboard`
-
-## Validated
-
-- Docs-only branch; no app code changes
-- Guides served by `UserGuideController` glob `docs/user-guide-*.md`
-- Main dashboard ground truth: `resources/js/pages/dashboard.tsx` → `GET /api/dashboard` totals
+- Created `tests/e2e/budgets/helpers.ts` — create (≥1 line), search, edit
+- Created `tests/e2e/budgets/budget.spec.ts` — `generateModuleTests` (9 standard cases + status/type filters)
+- Updated `docs/module-registry.md` — budgets E2E YAML under Complex CRUD
 
 ## Open risks / blockers
 
-- Budget E2E still missing (`tests/e2e/budgets/`) — product gap, out of scope for this docs PR
-- Lean rewrites of 7 guides are shorter than peer guides; expand later if product needs more depth
-- Prefer light sequential tool use (heavy parallel agents killed OpenCode session)
+- Create helper depends on seed data: ≥1 fiscal year + ≥1 account for AsyncSelect first-option pick
+- Inline line editor (not nested dialog) — date pickers use placeholder triggers (`Pick start/end date`)
+- Prefer light sequential tool use (heavy parallel agents previously killed OpenCode)
 
 ## Recommended next step
 
-1. Commit all docs changes on this branch
-2. Push + open PR with handoff template
-3. Do **not** wait for CI; move on
+Commit, push, `gh pr create`. Optionally run:
+`PLAYWRIGHT_USE_SAIL=1 ./vendor/bin/sail npx playwright test tests/e2e/budgets/`
 
 ## Continuation Prompt
 
 ```
-Continue docs cleanup on docs/cleanup-user-guides-and-stale-docs.
-If uncommitted: commit, push, gh pr create.
-If PR open: process open MRs per AGENTS.md (merge if green).
-Do not re-do P0–P2 unless verification fails.
+On feat/budgets-e2e: commit Budget E2E + registry, push, gh pr create.
+Do not wait for CI. Handoff template in AGENTS.md.
 ```

--- a/tests/e2e/budgets/budget.spec.ts
+++ b/tests/e2e/budgets/budget.spec.ts
@@ -1,0 +1,46 @@
+import { generateModuleTests } from '../shared-test-factories';
+import { createBudget, searchBudget, editBudget } from './helpers';
+
+generateModuleTests({
+  entityName: 'Budget',
+  entityNamePlural: 'Budgets',
+  route: '/budgets',
+  apiPath: '/api/budgets',
+
+  createEntity: (page) => createBudget(page),
+  searchEntity: (page, identifier) => searchBudget(page, identifier),
+  editEntity: (page, identifier, updates) => editBudget(page, identifier, updates),
+  editUpdates: { name: `Budget-Updated-${Date.now()}` },
+
+  sortableColumns: ['Name', 'Budget Type', 'Status', 'Total Amount', 'Created At'],
+
+  viewType: 'dialog',
+  viewDialogTitle: 'Budget Details',
+
+  exportApiPath: '/api/budgets/export',
+  expectedExportColumns: [
+    'ID',
+    'Name',
+    'Fiscal Year',
+    'Budget Type',
+    'Status',
+    'Total Amount',
+    'Created By',
+    'Created At',
+  ],
+
+  filterTests: [
+    {
+      filterName: 'Status',
+      filterType: 'select',
+      filterValue: 'Draft',
+      expectedText: 'Draft',
+    },
+    {
+      filterName: 'Budget Type',
+      filterType: 'select',
+      filterValue: 'Operational',
+      expectedText: 'Operational',
+    },
+  ],
+});

--- a/tests/e2e/budgets/helpers.ts
+++ b/tests/e2e/budgets/helpers.ts
@@ -1,0 +1,180 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Pick a day from an open DatePicker calendar (line-row placeholders).
+ */
+async function pickCalendarDay(page: Page, triggerText: RegExp, day: string): Promise<void> {
+  const dialog = page.getByRole('dialog').last();
+  const trigger = dialog.getByRole('button', { name: triggerText }).first();
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+
+  const calendar = page.locator('[data-slot="calendar"]').last();
+  await calendar.waitFor({ state: 'visible', timeout: 15000 });
+
+  const dayButton = calendar
+    .locator('button')
+    .filter({ hasText: new RegExp(`^${day}$`) })
+    .first();
+  await dayButton.waitFor({ state: 'visible' });
+  await dayButton.click({ force: true });
+
+  await page.keyboard.press('Escape');
+  await expect(calendar).not.toBeVisible().catch(() => null);
+}
+
+/**
+ * Select the first visible option from an AsyncSelect / combobox.
+ */
+async function selectFirstComboboxOption(
+  page: Page,
+  trigger: ReturnType<Page['locator']>,
+): Promise<void> {
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+
+  const option = page
+    .locator('[role="option"]:visible, ul[aria-busy]:visible button:visible')
+    .first();
+  await expect(option).toBeVisible({ timeout: 15000 });
+  await option.click({ force: true });
+  await expect(
+    page.locator('[role="option"]:visible, ul[aria-busy]:visible button:visible'),
+  )
+    .toHaveCount(0, { timeout: 10000 })
+    .catch(() => null);
+}
+
+/**
+ * Create a new budget via the UI (requires ≥1 budget line).
+ */
+export async function createBudget(
+  page: Page,
+  overrides: Partial<{ name: string; budget_type: string }> = {},
+): Promise<string> {
+  const timestamp = Date.now();
+  const name = overrides.name ?? `Budget ${timestamp}`;
+
+  const addButton = page.getByRole('button', { name: /Add/i });
+  await expect(addButton).toBeVisible();
+  await addButton.click();
+
+  const dialog = page.getByRole('dialog', { name: /Add New Budget/i });
+  await expect(dialog).toBeVisible();
+
+  await dialog.locator('input[name="name"]').fill(name);
+
+  // Budget type (defaults to Operational; override when provided)
+  if (overrides.budget_type) {
+    const typeTrigger = dialog.getByRole('combobox', { name: /Budget Type/i });
+    await typeTrigger.click();
+    await page
+      .getByRole('option', { name: overrides.budget_type, exact: true })
+      .click();
+  }
+
+  // Fiscal year — preferred meta may auto-select; otherwise pick first option
+  const fyTrigger = dialog.locator('button').filter({ hasText: /Select fiscal year/i });
+  if (await fyTrigger.isVisible().catch(() => false)) {
+    await selectFirstComboboxOption(page, fyTrigger);
+  } else {
+    // Already auto-selected — wait briefly for preferred resolution
+    await page.waitForTimeout(500);
+  }
+
+  // Add one budget line (inline editing row)
+  const addLineBtn = dialog.getByRole('button', { name: /Add Line/i });
+  await expect(addLineBtn).toBeVisible();
+  await addLineBtn.click();
+
+  // Account (AsyncSelect)
+  const accountTrigger = dialog
+    .locator('button')
+    .filter({ hasText: /Select account/i })
+    .first();
+  await selectFirstComboboxOption(page, accountTrigger);
+
+  // Period dates
+  await pickCalendarDay(page, /Pick start date/i, '1');
+  await pickCalendarDay(page, /Pick end date/i, '28');
+
+  // Allocated amount
+  await dialog.locator('input[name="lines.0.allocated_amount"]').fill('1000000');
+
+  // Commit line edit mode (green pencil) so row is not stuck open — optional
+  const commitLineBtn = dialog.locator('button:has(svg.lucide-pencil)').first();
+  if (await commitLineBtn.isVisible().catch(() => false)) {
+    await commitLineBtn.click();
+  }
+
+  const responsePromise = page.waitForResponse(
+    (r) =>
+      r.url().includes('/api/budgets') &&
+      r.request().method() === 'POST' &&
+      r.status() < 400,
+    { timeout: 20000 },
+  );
+
+  const submitButton = dialog.getByRole('button', { name: /Add/i }).last();
+  await expect(submitButton).toBeVisible();
+  await submitButton.click();
+  await responsePromise;
+  await expect(dialog).not.toBeVisible({ timeout: 15000 });
+
+  return name;
+}
+
+/**
+ * Search budgets by name.
+ */
+export async function searchBudget(page: Page, name: string): Promise<void> {
+  const searchInput = page.getByPlaceholder('Search budgets...');
+  await searchInput.waitFor({ state: 'visible' });
+  const normalized = name.trim();
+  if ((await searchInput.inputValue()).trim() === normalized) {
+    return;
+  }
+
+  const responsePromise = page.waitForResponse(
+    (r) => r.url().includes('/api/budgets') && r.status() < 400,
+  );
+  await searchInput.clear();
+  await searchInput.fill(normalized);
+  await searchInput.press('Enter');
+  await responsePromise;
+}
+
+/**
+ * Edit an existing budget (name only — keeps lines intact).
+ */
+export async function editBudget(
+  page: Page,
+  identifier: string,
+  updates: Record<string, string>,
+): Promise<void> {
+  const row = page.locator('tbody tr').filter({ hasText: identifier }).first();
+  await expect(row).toBeVisible();
+  await row.getByRole('button').last().click();
+  await page.getByRole('menuitem', { name: 'Edit' }).click();
+
+  const dialog = page.getByRole('dialog', { name: /Edit Budget/i });
+  await expect(dialog).toBeVisible();
+
+  if (updates.name) {
+    await dialog.locator('input[name="name"]').fill(updates.name);
+  }
+
+  const responsePromise = page.waitForResponse(
+    (r) =>
+      r.url().includes('/api/budgets') &&
+      ['PUT', 'PATCH', 'POST'].includes(r.request().method()) &&
+      r.status() < 400,
+    { timeout: 20000 },
+  );
+
+  const updateBtn = dialog.getByRole('button', { name: /Update/i });
+  await expect(updateBtn).toBeVisible();
+  await updateBtn.click();
+  await responsePromise;
+  await expect(dialog).not.toBeVisible({ timeout: 15000 });
+}


### PR DESCRIPTION
## What was done
- Added Playwright E2E for Budgets complex CRUD via `generateModuleTests`
- Helpers cover create/search/edit with nested Budget Lines (inline Add Line row)
- Registered budgets entry in `docs/module-registry.md` Complex CRUD YAML
- Updated `task.md` session handoff

## Files changed
- `tests/e2e/budgets/helpers.ts` — createBudget / searchBudget / editBudget (account AsyncSelect, period date pickers, allocated_amount)
- `tests/e2e/budgets/budget.spec.ts` — generateModuleTests + Status/Budget Type filter cases
- `docs/module-registry.md` — budgets slug, sortable columns, view dialog, test path
- `task.md` — handoff for post-E2E / pre-merge state

## Verification
- [ ] sail test --group budgets (Pest — existing backend suite)
- [ ] PLAYWRIGHT_USE_SAIL=1 ./vendor/bin/sail npx playwright test tests/e2e/budgets/
- [ ] CI passing (gh pr checks)

## Next steps
- Optional: run Playwright budgets suite locally if CI flaky
- Merge when green; no further product code expected for this gap