### PR TITLE
docs: mark Budget E2E as landed (PR #72)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Index for agents and developers. Prefer these paths over inventing new status do
 
 | Doc | Status |
 |-----|--------|
-| [budget-management-design.md](./budget-management-design.md) | **Implemented** (2026-06-22); Pest OK; E2E pending |
+| [budget-management-design.md](./budget-management-design.md) | **Implemented** (2026-06-22); Pest OK; E2E PR #72 |
 | [profit-loss-by-department-design.md](./profit-loss-by-department-design.md) | Research only |
 | [database/\*_design.md](./database/) | Module design specs (see IMPLEMENTATION_STATUS) |
 

--- a/docs/budget-management-design.md
+++ b/docs/budget-management-design.md
@@ -1,15 +1,15 @@
 # Budget Management Module — Design
 
 **Generated:** 2026-06-05
-**Status:** Implemented (2026-06-22). Pest tests present. **E2E tests pending** (`tests/e2e/budgets/` does not exist yet).
-**Last updated:** 2026-08-04
+**Status:** Implemented (2026-06-22). Pest OK. Playwright E2E suite on **PR #72** (`tests/e2e/budgets/`, registry entry).
+**Last updated:** 2026-08-05
 
 ## Executive Summary
 
 Budget Management is **implemented**. Finance teams set per-account spending targets per fiscal year period and track actual-vs-budget variance in real time. The module reuses `FinancialReportService`, `Account`, `FiscalYear`, and `JournalEntry` infrastructure.
 
-**What shipped:** Models (`Budget`, `BudgetLine`), `BudgetController`, `BudgetVarianceReportController`, `BudgetVarianceService`, export, SPA pages under `/budgets` and budget-variance report, Pest feature/unit tests.
-**Remaining gap:** Playwright E2E suite for budgets (not started).
+**What shipped:** Models (`Budget`, `BudgetLine`), `BudgetController`, `BudgetVarianceReportController`, `BudgetVarianceService`, export, SPA pages under `/budgets` and budget-variance report, Pest feature/unit tests, Playwright E2E (`tests/e2e/budgets/` via PR #72).
+**Remaining gaps (product, not E2E):** optional ApprovalFlow integration; commitment tracking (PO-level); multi-currency (tracked separately). Budget-variance **report** E2E is still optional follow-up.
 **Original estimate (historical):** 3–4 days (schema + backend + frontend + tests).
 **Value:** High — enables proactive financial control instead of reactive GL review.
 
@@ -230,10 +230,11 @@ Standard `ReportDataTablePage` with:
 - Report page: `pages/reports/budget-variance/index.tsx`
 - Route registration in `app-routes.tsx`
 
-### Phase 4: Tests + Integration — 🔨 Partial
+### Phase 4: Tests + Integration — ✅ Done (CRUD E2E)
 - ✅ Pest: `BudgetControllerTest`, `BudgetExportTest`, `BudgetVarianceReportTest` + model unit tests
-- ❌ E2E: `tests/e2e/budgets/` (9 standard cases) — **still pending**
+- ✅ E2E: `tests/e2e/budgets/` (helpers + standard CRUD cases via `generateModuleTests`) — **PR #72**
 - Optional: approval flow integration (if `ApprovalFlow` already configured for Budget entity)
+- Optional: Playwright coverage for budget-variance **report** page (`/reports/budget-variance`)
 
 ---
 
@@ -277,4 +278,4 @@ Decisions made for the shipped MVP (kept for context):
 4. **Budget types** — All four types supported in schema (operational, capital, project, revenue).
 5. **Report scope** — Variance by account; department/branch dimension deferred.
 
-**Open follow-ups:** E2E suite; optional ApprovalFlow integration; commitment tracking; multi-currency (tracked separately).
+**Open follow-ups:** optional ApprovalFlow integration; commitment tracking; multi-currency (tracked separately); optional budget-variance report E2E.

--- a/docs/database/IMPLEMENTATION_STATUS.md
+++ b/docs/database/IMPLEMENTATION_STATUS.md
@@ -32,7 +32,7 @@
 | 16 | Accounts Receivable | `16_accounts_receivable_design.md` | ✅ Implemented | PR #11 |
 | 17 | General Ledger (Extended) | `17_general_ledger_design.md` | ✅ Implemented | PR #12 |
 | 18 | Financial Reports | `18_financial_reports_design.md` | ✅ Implemented | PR #13 |
-| 19 | Budget Management | `docs/budget-management-design.md` | ✅ Implemented | Pest OK; E2E pending |
+| 19 | Budget Management | `docs/budget-management-design.md` | ✅ Implemented | Pest OK; E2E PR #72 (`tests/e2e/budgets/`) |
 | 20 | Financial Dashboard | — | ✅ Implemented | KPI / YoY; permission `financial_dashboard` |
 | 21 | Aging Dashboard | — | ✅ Implemented | AR/AP aging; permission `aging_dashboard` |
 | 22 | Asset Dashboard | — | ✅ Implemented | Asset distribution / alerts |
@@ -380,9 +380,10 @@ Task-task ini bisa dikerjakan kapan saja, tidak harus menunggu Fase 1-3.
 
 | Date | Milestone |
 |------|-----------|
+| 2026-08-05 | Budget design + status: E2E suite on PR #72 (`tests/e2e/budgets/`) |
 | 2026-08-04 | Docs cleanup: budget design truth, status table +19–23, Sonar progress frozen |
 | 2026-06-25 | Sonar batch E regression closed; gate OK, coverage 95.5% |
-| 2026-06-22 | Budget Management module implemented (Pest; E2E pending) |
+| 2026-06-22 | Budget Management module implemented (Pest; E2E later on PR #72) |
 | 2026-05-15 | Financial Reports module complete (PR #13) |
 | 2026-05-13 | General Ledger Extended module complete (PR #12) |
 | 2026-05-11 | Accounts Receivable module complete (PR #11) |


### PR DESCRIPTION
## What was done
- Updated `docs/budget-management-design.md` so status no longer claims E2E is missing
- Synced `docs/README.md` design-doc index and `docs/database/IMPLEMENTATION_STATUS.md` module row + milestones to PR #72

## Files changed
- `docs/budget-management-design.md` — Phase 4 + executive summary + open follow-ups
- `docs/README.md` — design table status
- `docs/database/IMPLEMENTATION_STATUS.md` — row 19 + milestone log

## Verification
- [x] Docs-only; no code/runtime change
- [ ] CI N/A for pure docs (or green if docs workflow runs)

## Next steps
- When #72 merges, optionally reword “on PR #72” → “merged” in a tiny follow-up
- Optional next: Sonar S2187 on `columns.test.ts`, or budget-variance report E2E

## Related
- Depends on / pairs with https://github.com/gmedia/erp/pull/72