### PR TITLE
fix: resolve Sonar S2187 empty columns.test.ts

### DIFF
--- a/resources/js/utils/columns.type-assertions.ts
+++ b/resources/js/utils/columns.type-assertions.ts
@@ -15,7 +15,7 @@ import {
     createPhoneColumn,
     createSelectColumn,
     createTextColumn,
-} from '../columns';
+} from './columns';
 
 interface PayrollFixture {
     salary: string | null;

--- a/resources/js/utils/columns.type-assertions.ts
+++ b/resources/js/utils/columns.type-assertions.ts
@@ -1,6 +1,7 @@
-// Type checking test for column utilities
-// This file performs compile-time type assertions — no runtime test framework needed.
-// Run: tsc --noEmit (ensures types compile cleanly)
+// Compile-time type assertions for column utilities (not a runtime test suite).
+// Intentionally NOT named *.test.ts — Sonar S2187 flags empty test files, and this
+// project has no Vitest/Jest unit runner for frontend (Playwright E2E + `tsc --noEmit` only).
+// Run: npm run types  (tsc --noEmit)
 
 import { Department } from '@/types/department';
 import { Employee } from '@/types/employee';


### PR DESCRIPTION
## What was done
- Renamed `resources/js/utils/__tests__/columns.test.ts` → `resources/js/utils/columns.type-assertions.ts`
- Clarified header: compile-time assertions only; no Vitest/Jest in this repo

## Why
- Sonar **BLOCKER** `typescript:S2187` (`AZ744113f85aalgS9l5T`): “Add some tests to this file or delete it.”
- File never had runtime tests — only `satisfies` / type-level checks for `create*Column` helpers
- Adding a unit runner just for this file is out of scope; renaming off `*.test.ts` is the correct fix

## Files changed
- `resources/js/utils/columns.type-assertions.ts` — moved + header
- removed empty `__tests__/` dir under utils

## Verification
- [ ] `npm run types` (or CI typecheck) still picks up the file via `resources/js/**/*.ts`
- [ ] Next Sonar scan should drop issue `AZ744113f85aalgS9l5T`

## Next steps
- After merge + Sonar reanalyze, confirm zero OPEN HIGH/BLOCKER issues