### PR TITLE
test: add Budget Variance report Playwright E2E

### DIFF
--- a/docs/budget-management-design.md
+++ b/docs/budget-management-design.md
@@ -230,11 +230,11 @@ Standard `ReportDataTablePage` with:
 - Report page: `pages/reports/budget-variance/index.tsx`
 - Route registration in `app-routes.tsx`
 
-### Phase 4: Tests + Integration — ✅ Done (CRUD E2E)
+### Phase 4: Tests + Integration — ✅ Done (CRUD + report E2E)
 - ✅ Pest: `BudgetControllerTest`, `BudgetExportTest`, `BudgetVarianceReportTest` + model unit tests
 - ✅ E2E: `tests/e2e/budgets/` (helpers + standard CRUD cases via `generateModuleTests`) — **PR #72**
+- ✅ E2E: `tests/e2e/budget-variance-report/` (required `budget_id` filter, status/account_type, export)
 - Optional: approval flow integration (if `ApprovalFlow` already configured for Budget entity)
-- Optional: Playwright coverage for budget-variance **report** page (`/reports/budget-variance`)
 
 ---
 

--- a/docs/module-registry.md
+++ b/docs/module-registry.md
@@ -503,7 +503,7 @@ Semua modul simple CRUD memiliki konfigurasi E2E yang identik kecuali nama:
   view_type: dialog
   view_dialog_title: "Budget Details"
   checkbox_header: false
-  note: "Complex CRUD dengan nested Budget Lines (min 1 line: account_id, period_start/end, allocated_amount). Create via inline Add Line row (bukan nested dialog)."
+  note: "Complex CRUD dengan nested Budget Lines (min 1 line: account_id, period_start/end, allocated_amount). Create via inline Add Line row (bukan nested dialog). Report page: slug budget-variance-report."
   tests:
     - tests/e2e/budgets/budget.spec.ts
 
@@ -883,6 +883,18 @@ Semua modul simple CRUD memiliki konfigurasi E2E yang identik kecuali nama:
   tests:
     - tests/e2e/posting-journals/post-journal.spec.ts
 
+- slug: budget-variance-report
+  route: /reports/budget-variance
+  api: /api/reports/budget-variance
+  export_api: /api/reports/budget-variance/export
+  search_placeholder: ""
+  sortable_columns: [Account Code, Account Name, Account Type, Period Start, Period End, Allocated, Actual, Available, Variance %, Status]
+  view_type: page
+  checkbox_header: false
+  note: "Non-CRUD laporan variance budget vs actual (posted JE). budget_id WAJIB di index/export. Filter status (within_budget|warning|over_budget) dan account_type. Permission budget_variance_report. Export filename budget_variance_*.xlsx."
+  tests:
+    - tests/e2e/budget-variance-report/budget-variance-report.spec.ts
+
 ## Testing
 
 E2E testing uses Playwright. Tests are organized by module in `tests/e2e/`.
@@ -983,6 +995,7 @@ E2E testing uses Playwright. Tests are organized by module in `tests/e2e/`.
 | 28 | Purchase History Report | `purchase-history-report` | `Feature/Reports/PurchaseHistoryReportTest.php` | Laporan riwayat pembelian per supplier/produk/periode + export |
 | 29 | Goods Receipt Report | `goods-receipt-report` | `Feature/Reports/GoodsReceiptReportTest.php` | Laporan penerimaan barang per periode/supplier/gudang + export |
 | 30 | Aging Dashboard | `aging-dashboard` | `Feature/AgingDashboard/AgingDashboardControllerTest.php` | AR/AP aging dashboard with 5 buckets + top 10 overdue customers/suppliers + branch filter |
+| 31 | Budget Variance Report | `budget-variance-report` | `Feature/Budgets/BudgetVarianceReportControllerTest.php` | Non-CRUD laporan variance budget; E2E di `tests/e2e/budget-variance-report/` (budget_id required) |
 
 ---
 

--- a/tests/e2e/budget-variance-report/budget-variance-report.spec.ts
+++ b/tests/e2e/budget-variance-report/budget-variance-report.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import { login } from '../helpers';
+import {
+    applyStatusFilter,
+    ensureBudgetExists,
+    openBudgetVarianceReport,
+    waitForBudgetVarianceReportResponse,
+} from './helpers';
+
+test.describe('Budget Variance Report', () => {
+    test.setTimeout(120000);
+
+    test.beforeEach(async ({ page }) => {
+        await login(page, undefined, undefined, { requireDashboard: false });
+        await ensureBudgetExists(page);
+    });
+
+    test('can navigate to report page and see filters', async ({ page }) => {
+        await page.goto('/reports/budget-variance');
+        await page.waitForURL('**/reports/budget-variance', { timeout: 15000 });
+
+        const filterButton = page.getByRole('button', { name: /filters/i });
+        await expect(filterButton).toBeVisible({ timeout: 15000 });
+        await filterButton.click();
+
+        const filtersDialog = page.getByRole('dialog');
+        await expect(filtersDialog).toBeVisible();
+
+        await expect(
+            filtersDialog
+                .locator('button')
+                .filter({ hasText: /Select budget|Budget/i })
+                .first(),
+        ).toBeVisible();
+
+        await expect(
+            filtersDialog.getByRole('button', { name: /Apply Filters/i }),
+        ).toBeVisible();
+    });
+
+    test('can view report after selecting budget', async ({ page }) => {
+        await openBudgetVarianceReport(page);
+
+        await expect(page.locator('table').first()).toBeVisible();
+        const rows = page.locator('table tbody tr');
+        const rowCount = await rows.count();
+        if (rowCount > 0) {
+            await expect(rows.first()).toBeVisible();
+        }
+    });
+
+    test('can filter by status', async ({ page }) => {
+        await openBudgetVarianceReport(page);
+        await applyStatusFilter(page, /Over Budget/i);
+        await expect(page.locator('table').first()).toBeVisible();
+    });
+
+    test('can filter by account type', async ({ page }) => {
+        await openBudgetVarianceReport(page);
+
+        await page.getByRole('button', { name: /filters/i }).click();
+        const filtersDialog = page.getByRole('dialog');
+        await expect(filtersDialog).toBeVisible();
+
+        const typeTrigger = filtersDialog
+            .locator('button')
+            .filter({ hasText: /All types|Asset|Liability|Equity|Revenue|Expense/i })
+            .first();
+        await typeTrigger.click({ force: true });
+
+        const option = page
+            .locator('[role="option"]:visible')
+            .filter({ hasText: /Expense/i })
+            .first();
+        await expect(option).toBeVisible({ timeout: 10000 });
+        await option.click({ force: true });
+
+        await Promise.all([
+            page.waitForResponse(
+                (r) =>
+                    r.url().includes('/api/reports/budget-variance') &&
+                    !r.url().includes('/export') &&
+                    r.url().includes('account_type=') &&
+                    r.status() < 400,
+                { timeout: 30000 },
+            ),
+            filtersDialog.getByRole('button', { name: 'Apply Filters' }).click(),
+        ]);
+
+        await expect(page.locator('table').first()).toBeVisible();
+    });
+
+    test('can export budget variance report', async ({ page }) => {
+        await openBudgetVarianceReport(page);
+
+        const exportButton = page.getByRole('button', { name: /^Export$/i });
+        await expect(exportButton).toBeEnabled({ timeout: 10000 });
+
+        const [response] = await Promise.all([
+            page.waitForResponse(
+                (r) =>
+                    r.url().includes('/api/reports/budget-variance/export') &&
+                    r.status() < 400,
+                { timeout: 30000 },
+            ),
+            exportButton.click(),
+        ]);
+
+        const body = await response.json();
+        expect(body).toHaveProperty('url');
+        expect(body).toHaveProperty('filename');
+        expect(body.filename).toMatch(/^budget_variance_.*\.xlsx$/);
+    });
+
+    test('can sort by Account Code column', async ({ page }) => {
+        await openBudgetVarianceReport(page);
+
+        const sortButton = page.getByRole('button', {
+            name: 'Account Code',
+            exact: true,
+        });
+        if (await sortButton.isVisible().catch(() => false)) {
+            await sortButton.click({ force: true });
+            await waitForBudgetVarianceReportResponse(page).catch(() => null);
+            await expect(page.locator('table').first()).toBeVisible();
+        }
+    });
+});

--- a/tests/e2e/budget-variance-report/helpers.ts
+++ b/tests/e2e/budget-variance-report/helpers.ts
@@ -1,0 +1,136 @@
+import { expect, type Page } from '@playwright/test';
+import { createBudget } from '../budgets/helpers';
+
+export async function waitForBudgetVarianceReportResponse(
+    page: Page,
+): Promise<void> {
+    await page.waitForResponse(
+        (response) =>
+            response.url().includes('/api/reports/budget-variance') &&
+            !response.url().includes('/export') &&
+            response.status() < 400,
+        { timeout: 30000 },
+    );
+}
+
+async function selectFirstComboboxOption(
+    page: Page,
+    trigger: ReturnType<Page['locator']>,
+): Promise<void> {
+    await expect(trigger).toBeVisible();
+    await trigger.click({ force: true });
+
+    const option = page
+        .locator(
+            '[role="option"]:visible, ul[aria-busy]:visible button:visible, ul.p-1 li button:visible',
+        )
+        .first();
+    await expect(option).toBeVisible({ timeout: 15000 });
+    await option.click({ force: true });
+    await expect(
+        page.locator(
+            '[role="option"]:visible, ul[aria-busy]:visible button:visible',
+        ),
+    )
+        .toHaveCount(0, { timeout: 10000 })
+        .catch(() => null);
+}
+
+export async function ensureBudgetExists(page: Page): Promise<string> {
+    await page.goto('/budgets');
+    await page.waitForURL('**/budgets', { timeout: 15000 });
+
+    await page
+        .waitForResponse(
+            (r) => r.url().includes('/api/budgets') && r.status() < 400,
+            { timeout: 30000 },
+        )
+        .catch(() => null);
+
+    const emptyState = page.getByText(/no results|no data|no budgets/i);
+    const hasRows = await page
+        .locator('tbody tr')
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+    if (!hasRows || (await emptyState.isVisible().catch(() => false))) {
+        return createBudget(page);
+    }
+
+    const firstCell = page.locator('tbody tr').first().locator('td').nth(1);
+    const name = (await firstCell.textContent())?.trim();
+    return name && name.length > 0 ? name : createBudget(page);
+}
+
+/** budget_id is required by the API — bare navigation alone returns 422. */
+export async function openBudgetVarianceReport(page: Page): Promise<void> {
+    await page.goto('/reports/budget-variance');
+    await page.waitForURL('**/reports/budget-variance', { timeout: 15000 });
+
+    await expect(
+        page.getByRole('button', { name: /filters/i }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('button', { name: /filters/i }).click();
+    const filtersDialog = page.getByRole('dialog');
+    await expect(filtersDialog).toBeVisible();
+
+    const budgetTrigger = filtersDialog
+        .locator('button')
+        .filter({ hasText: /Select budget/i })
+        .first();
+
+    if (await budgetTrigger.isVisible().catch(() => false)) {
+        await selectFirstComboboxOption(page, budgetTrigger);
+    } else {
+        const combobox = filtersDialog.locator('button[role="combobox"]').first();
+        if (await combobox.isVisible().catch(() => false)) {
+            const text = (await combobox.textContent()) ?? '';
+            if (/Select budget/i.test(text) || text.trim() === '') {
+                await selectFirstComboboxOption(page, combobox);
+            }
+        }
+    }
+
+    await Promise.all([
+        waitForBudgetVarianceReportResponse(page),
+        filtersDialog.getByRole('button', { name: 'Apply Filters' }).click(),
+    ]);
+
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 });
+}
+
+export async function applyStatusFilter(
+    page: Page,
+    statusLabel: RegExp | string = /Over Budget/i,
+): Promise<void> {
+    await page.getByRole('button', { name: /filters/i }).click();
+    const filtersDialog = page.getByRole('dialog');
+    await expect(filtersDialog).toBeVisible();
+
+    const statusTrigger = filtersDialog
+        .locator('button')
+        .filter({ hasText: /All statuses|Within Budget|Warning|Over Budget/i })
+        .first();
+    await statusTrigger.click({ force: true });
+
+    const option = page
+        .locator('[role="option"]:visible')
+        .filter({ hasText: statusLabel })
+        .first();
+    await expect(option).toBeVisible({ timeout: 10000 });
+    await option.click({ force: true });
+
+    await Promise.all([
+        page.waitForResponse(
+            (r) =>
+                r.url().includes('/api/reports/budget-variance') &&
+                !r.url().includes('/export') &&
+                r.url().includes('status=') &&
+                r.status() < 400,
+            { timeout: 30000 },
+        ),
+        filtersDialog.getByRole('button', { name: 'Apply Filters' }).click(),
+    ]);
+}


### PR DESCRIPTION
## What was done
- Added Playwright E2E for `/reports/budget-variance` covering required `budget_id` filter, status/account_type filters, export, and sort smoke checks
- Registered module in `docs/module-registry.md` (E2E slug + Pest Non-CRUD row)
- Marked design Phase 4 report E2E as done in `docs/budget-management-design.md`

## Files changed
- `tests/e2e/budget-variance-report/helpers.ts` — seed budget, open report, wait for non-export API, apply status filter
- `tests/e2e/budget-variance-report/budget-variance-report.spec.ts` — 6 cases (nav/filters, view, status, account_type, export, sort)
- `docs/module-registry.md` — `slug: budget-variance-report` + Pest table row #31
- `docs/budget-management-design.md` — Phase 4 report E2E marked complete

## Verification
- [ ] `PLAYWRIGHT_USE_SAIL=1 ./vendor/bin/sail npx playwright test tests/e2e/budget-variance-report/`
- [ ] CI passing (`gh pr checks`)

## Notes
- API requires `budget_id` (bare page load without budget selection returns 422) — helpers seed via `createBudget` then select Budget + Apply before asserting table/export
- Export asserts JSON body `url` + `filename` matching `/^budget_variance_.*\.xlsx$/`
- Parallel to open PR #74 (Sonar columns); no overlap with `resources/js/utils/columns*`

## Next steps
- When green: squash-merge
- After #74 merges: recheck Sonar issue `AZ744113f85aalgS9l5T`