### PR TITLE
fix: replace void exhaustiveness guards (Sonar S3735)

### DIFF
--- a/resources/js/utils/columns.type-assertions.ts
+++ b/resources/js/utils/columns.type-assertions.ts
@@ -167,30 +167,32 @@ type _PosColsLen = (typeof _posColumns)['length'] extends 4 ? true : false;
 const _posLenCheck: _PosColsLen = true;
 
 // ── Exhaustiveness guard ──
-void _selectIdCheck;
-void _selectMetaCheck;
-void _textAk;
-void _textHeader;
-void _dateAk;
-void _dateNoSortCheck;
-void _emailAk;
-void _phoneAk;
-void _currencyAk;
-void _actionsIdCheck;
-void _actionsColWithCbIdCheck;
-void _deptLenCheck;
-void _empLenCheck;
-void _posLenCheck;
-void accessorKeyOf;
-void _selectCol;
-void _textCol;
-void _dateCol;
-void _dateColNoSort;
-void _emailCol;
-void _phoneCol;
-void _currencyCol;
-void _actionsCol;
-void _actionsColWithCb;
-void _deptColumns;
-void _empColumns;
-void _posColumns;
+export const __columnsTypeAssertionGuards = {
+    accessorKeyOf,
+    selectCol: _selectCol,
+    selectId: _selectIdCheck,
+    selectMeta: _selectMetaCheck,
+    textCol: _textCol,
+    textAk: _textAk,
+    textHeader: _textHeader,
+    dateCol: _dateCol,
+    dateAk: _dateAk,
+    dateColNoSort: _dateColNoSort,
+    dateNoSort: _dateNoSortCheck,
+    emailCol: _emailCol,
+    emailAk: _emailAk,
+    phoneCol: _phoneCol,
+    phoneAk: _phoneAk,
+    currencyCol: _currencyCol,
+    currencyAk: _currencyAk,
+    actionsCol: _actionsCol,
+    actionsId: _actionsIdCheck,
+    actionsColWithCb: _actionsColWithCb,
+    actionsColWithCbId: _actionsColWithCbIdCheck,
+    deptColumns: _deptColumns,
+    deptLen: _deptLenCheck,
+    empColumns: _empColumns,
+    empLen: _empLenCheck,
+    posColumns: _posColumns,
+    posLen: _posLenCheck,
+} as const;


### PR DESCRIPTION
## What was done
- Replaced 27× `void x` exhaustiveness guards in `columns.type-assertions.ts` with a single exported `__columnsTypeAssertionGuards` object (Sonar **typescript:S3735**)
- Verified `npm run types` (`tsc --noEmit`) clean

## Files changed
- `resources/js/utils/columns.type-assertions.ts` — export guards object instead of void statements

## Context
- **#74** already deleted empty `columns.test.ts` (S2187). On `main` the file is **gone**; Sonar issue `AZ744113f85aalgS9l5T` is **analysis lag** (Quality Gate **OK**). No further S2187 code change needed.
- Remaining HIGH/CRITICAL noise on this file was S3735 on `void` — this PR addresses that.

## Verification
- [x] `npm run types`
- [ ] CI passing (`gh pr checks`) — do not poll

## Next steps
- When green: squash-merge
- After Sonar re-scan: confirm S3735 + stale S2187 clear