### PR TITLE
fix: resolve Sonar MAJOR issues (S3358, S103, S9011, S4782)

### DIFF
--- a/app/Actions/Employees/IndexEmployeesAction.php
+++ b/app/Actions/Employees/IndexEmployeesAction.php
@@ -21,7 +21,11 @@ class IndexEmployeesAction
      */
     public function execute(IndexEmployeeRequest $request): LengthAwarePaginator
     {
-        $query = Employee::query()->with(['currentEmployment.department', 'currentEmployment.position', 'currentEmployment.branch']);
+        $query = Employee::query()->with([
+            'currentEmployment.department',
+            'currentEmployment.position',
+            'currentEmployment.branch',
+        ]);
 
         return $this->handleSearchOrPrimaryIndexRequest(
             $request,

--- a/app/Exports/EmployeeExport.php
+++ b/app/Exports/EmployeeExport.php
@@ -18,7 +18,12 @@ class EmployeeExport extends BaseExport
             ->with(['currentEmployment.department', 'currentEmployment.position', 'currentEmployment.branch'])
             ->select('employees.*');
 
-        $this->applySearchFilter($query, $this->filters, ['employees.employee_id', 'employees.name', 'employees.email', 'employees.phone']);
+        $this->applySearchFilter($query, $this->filters, [
+            'employees.employee_id',
+            'employees.name',
+            'employees.email',
+            'employees.phone',
+        ]);
         $this->applyExactFilters($query, $this->filters, [
             'department_id' => 'employments.department_id',
             'position_id' => 'employments.position_id',
@@ -65,12 +70,27 @@ class EmployeeExport extends BaseExport
             'Name' => fn (Employee $e): mixed => $e->name,
             'Email' => fn (Employee $e): mixed => $e->email,
             'Phone' => fn (Employee $e): mixed => $e->phone,
-            'Department' => fn (Employee $e): mixed => $this->relatedAttribute($e->currentEmployment, 'department', 'name'),
-            'Position' => fn (Employee $e): mixed => $this->relatedAttribute($e->currentEmployment, 'position', 'name'),
-            'Branch' => fn (Employee $e): mixed => $this->relatedAttribute($e->currentEmployment, 'branch', 'name'),
+            'Department' => fn (Employee $e): mixed => $this->relatedAttribute(
+                $e->currentEmployment,
+                'department',
+                'name',
+            ),
+            'Position' => fn (Employee $e): mixed => $this->relatedAttribute(
+                $e->currentEmployment,
+                'position',
+                'name',
+            ),
+            'Branch' => fn (Employee $e): mixed => $this->relatedAttribute(
+                $e->currentEmployment,
+                'branch',
+                'name',
+            ),
             'Salary' => fn (Employee $e): mixed => $e->currentEmployment?->salary,
             'Status' => fn (Employee $e): mixed => $e->currentEmployment?->employment_status,
-            'Hire Date' => fn (Employee $e): mixed => $this->formatDateValue($e->currentEmployment?->hire_date, 'Y-m-d'),
+            'Hire Date' => fn (Employee $e): mixed => $this->formatDateValue(
+                $e->currentEmployment?->hire_date,
+                'Y-m-d',
+            ),
             'Created At' => fn (Employee $e): mixed => $this->formatIso8601($e->created_at),
         ];
     }

--- a/app/Http/Requests/Employees/IndexEmployeeRequest.php
+++ b/app/Http/Requests/Employees/IndexEmployeeRequest.php
@@ -11,8 +11,21 @@ class IndexEmployeeRequest extends AbstractEmployeeListingRequest
     {
         return array_merge(
             $this->employeeListingRules(
-                'id,employee_id,name,email,phone,employments.department_id,employments.position_id,' .
-                    'employments.branch_id,employments.salary,employments.employment_status,employments.hire_date,created_at,updated_at',
+                implode(',', [
+                    'id',
+                    'employee_id',
+                    'name',
+                    'email',
+                    'phone',
+                    'employments.department_id',
+                    'employments.position_id',
+                    'employments.branch_id',
+                    'employments.salary',
+                    'employments.employment_status',
+                    'employments.hire_date',
+                    'created_at',
+                    'updated_at',
+                ]),
                 [
                     'salary_min' => ['nullable', 'numeric', 'min:0'],
                     'salary_max' => ['nullable', 'numeric', 'min:0'],

--- a/resources/js/components/bank-reconciliations/BankReconciliationWorkspace.tsx
+++ b/resources/js/components/bank-reconciliations/BankReconciliationWorkspace.tsx
@@ -669,6 +669,7 @@ export const BankReconciliationWorkspace =
                                                                                     asChild
                                                                                 >
                                                                                     <button
+                                                                                        type="button"
                                                                                         className="max-w-[130px] truncate text-left text-xs font-medium text-blue-700 hover:underline"
                                                                                         onClick={() =>
                                                                                             openAssignDialog(
@@ -718,38 +719,50 @@ export const BankReconciliationWorkspace =
                                                             })()}
                                                         </TableCell>
                                                         <TableCell className="text-right">
-                                                            {loadingItemId ===
-                                                            item.id ? (
-                                                                <Loader2 className="ml-auto size-4 animate-spin text-muted-foreground" />
-                                                            ) : item.is_reconciled ? (
-                                                                <Button
-                                                                    variant="ghost"
-                                                                    size="sm"
-                                                                    className="h-7 px-2 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
-                                                                    onClick={() =>
-                                                                        handleUnmatch(
-                                                                            item.id!,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    <Link2Off className="mr-1 size-3" />
-                                                                    Unmatch
-                                                                </Button>
-                                                            ) : (
-                                                                <Button
-                                                                    variant="outline"
-                                                                    size="sm"
-                                                                    className="h-7 px-2 text-xs"
-                                                                    onClick={() =>
-                                                                        openMatchDialog(
-                                                                            item.id!,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    <Link2 className="mr-1 size-3" />
-                                                                    Match
-                                                                </Button>
-                                                            )}
+                                                            {(() => {
+                                                                if (
+                                                                    loadingItemId ===
+                                                                    item.id
+                                                                ) {
+                                                                    return (
+                                                                        <Loader2 className="ml-auto size-4 animate-spin text-muted-foreground" />
+                                                                    );
+                                                                }
+                                                                if (
+                                                                    item.is_reconciled
+                                                                ) {
+                                                                    return (
+                                                                        <Button
+                                                                            variant="ghost"
+                                                                            size="sm"
+                                                                            className="h-7 px-2 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
+                                                                            onClick={() =>
+                                                                                handleUnmatch(
+                                                                                    item.id!,
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <Link2Off className="mr-1 size-3" />
+                                                                            Unmatch
+                                                                        </Button>
+                                                                    );
+                                                                }
+                                                                return (
+                                                                    <Button
+                                                                        variant="outline"
+                                                                        size="sm"
+                                                                        className="h-7 px-2 text-xs"
+                                                                        onClick={() =>
+                                                                            openMatchDialog(
+                                                                                item.id!,
+                                                                            )
+                                                                        }
+                                                                    >
+                                                                        <Link2 className="mr-1 size-3" />
+                                                                        Match
+                                                                    </Button>
+                                                                );
+                                                            })()}
                                                         </TableCell>
                                                     </TableRow>
                                                 ))

--- a/resources/js/components/employees/EmployeeViewModal.tsx
+++ b/resources/js/components/employees/EmployeeViewModal.tsx
@@ -27,8 +27,7 @@ export const EmployeeViewModal = memo<EmployeeViewModalProps>(
             intern: 'Intern',
             regular: 'Regular',
         };
-        const statusLabel =
-            (status ? statusLabels[status] : undefined) ?? '-';
+        const statusLabel = (status ? statusLabels[status] : undefined) ?? '-';
 
         return (
             <ViewModalShell

--- a/resources/js/components/employees/EmployeeViewModal.tsx
+++ b/resources/js/components/employees/EmployeeViewModal.tsx
@@ -23,12 +23,12 @@ export const EmployeeViewModal = memo<EmployeeViewModalProps>(
 
         const employment = item.current_employment;
         const status = employment?.employment_status;
+        const statusLabels: Record<string, string> = {
+            intern: 'Intern',
+            regular: 'Regular',
+        };
         const statusLabel =
-            status === 'intern'
-                ? 'Intern'
-                : status === 'regular'
-                  ? 'Regular'
-                  : '-';
+            (status ? statusLabels[status] : undefined) ?? '-';
 
         return (
             <ViewModalShell

--- a/resources/js/utils/number-format.ts
+++ b/resources/js/utils/number-format.ts
@@ -222,7 +222,9 @@ export interface RegionalNumberFormatOptions {
 
 export interface RegionalCurrencyFormatOptions extends RegionalNumberFormatOptions {
     currency?: string;
-    currencyDisplay?: Intl.NumberFormatOptions['currencyDisplay'];
+    currencyDisplay?: NonNullable<
+        Intl.NumberFormatOptions['currencyDisplay']
+    >;
 }
 
 function resolveCurrencyCode(

--- a/resources/js/utils/number-format.ts
+++ b/resources/js/utils/number-format.ts
@@ -222,9 +222,7 @@ export interface RegionalNumberFormatOptions {
 
 export interface RegionalCurrencyFormatOptions extends RegionalNumberFormatOptions {
     currency?: string;
-    currencyDisplay?: NonNullable<
-        Intl.NumberFormatOptions['currencyDisplay']
-    >;
+    currencyDisplay?: NonNullable<Intl.NumberFormatOptions['currencyDisplay']>;
 }
 
 function resolveCurrencyCode(


### PR DESCRIPTION
## What was done
- **S3358** `EmployeeViewModal` — status label map instead of nested ternary
- **php:S103** Employee export / index action / index request — wrap long lines
- **S9011 + S3358** `BankReconciliationWorkspace` — `type="button"` + if/return for match actions
- **S4782** `number-format` — `NonNullable` for `currencyDisplay`

## Files changed
- `resources/js/components/employees/EmployeeViewModal.tsx`
- `app/Actions/Employees/IndexEmployeesAction.php`
- `app/Exports/EmployeeExport.php`
- `app/Http/Requests/Employees/IndexEmployeeRequest.php`
- `resources/js/components/bank-reconciliations/BankReconciliationWorkspace.tsx`
- `resources/js/utils/number-format.ts`

## Verification
- [x] `npm run types`
- [ ] CI (`gh pr checks`) — do not poll

## Context
- Parallel to post-#75/#76 work; does **not** touch `columns.type-assertions.ts`
- Quality Gate already OK; this clears remaining MAJOR noise outside S3735 (landed in #76)