### PR TITLE
docs: mark budget-variance report E2E as landed (#75)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Index for agents and developers. Prefer these paths over inventing new status do
 
 | Doc | Status |
 |-----|--------|
-| [budget-management-design.md](./budget-management-design.md) | **Implemented** (2026-06-22); Pest OK; E2E PR #72 |
+| [budget-management-design.md](./budget-management-design.md) | **Implemented** (2026-06-22); Pest OK; E2E #72 (CRUD) + #75 (variance report) |
 | [profit-loss-by-department-design.md](./profit-loss-by-department-design.md) | Research only |
 | [database/\*_design.md](./database/) | Module design specs (see IMPLEMENTATION_STATUS) |
 

--- a/docs/budget-management-design.md
+++ b/docs/budget-management-design.md
@@ -1,15 +1,15 @@
 # Budget Management Module — Design
 
 **Generated:** 2026-06-05
-**Status:** Implemented (2026-06-22). Pest OK. Playwright E2E suite on **PR #72** (`tests/e2e/budgets/`, registry entry).
+**Status:** Implemented (2026-06-22). Pest OK. Playwright E2E: budgets CRUD **#72** (`tests/e2e/budgets/`); budget-variance report **#75** (`tests/e2e/budget-variance-report/`).
 **Last updated:** 2026-08-05
 
 ## Executive Summary
 
 Budget Management is **implemented**. Finance teams set per-account spending targets per fiscal year period and track actual-vs-budget variance in real time. The module reuses `FinancialReportService`, `Account`, `FiscalYear`, and `JournalEntry` infrastructure.
 
-**What shipped:** Models (`Budget`, `BudgetLine`), `BudgetController`, `BudgetVarianceReportController`, `BudgetVarianceService`, export, SPA pages under `/budgets` and budget-variance report, Pest feature/unit tests, Playwright E2E (`tests/e2e/budgets/` via PR #72).
-**Remaining gaps (product, not E2E):** optional ApprovalFlow integration; commitment tracking (PO-level); multi-currency (tracked separately). Budget-variance **report** E2E is still optional follow-up.
+**What shipped:** Models (`Budget`, `BudgetLine`), `BudgetController`, `BudgetVarianceReportController`, `BudgetVarianceService`, export, SPA pages under `/budgets` and budget-variance report, Pest feature/unit tests, Playwright E2E (`tests/e2e/budgets/` via **#72**; `tests/e2e/budget-variance-report/` via **#75**).
+**Remaining gaps (product, not E2E):** optional ApprovalFlow integration; commitment tracking (PO-level); multi-currency (tracked separately).
 **Original estimate (historical):** 3–4 days (schema + backend + frontend + tests).
 **Value:** High — enables proactive financial control instead of reactive GL review.
 
@@ -233,8 +233,8 @@ Standard `ReportDataTablePage` with:
 ### Phase 4: Tests + Integration — ✅ Done (CRUD + report E2E)
 - ✅ Pest: `BudgetControllerTest`, `BudgetExportTest`, `BudgetVarianceReportTest` + model unit tests
 - ✅ E2E: `tests/e2e/budgets/` (helpers + standard CRUD cases via `generateModuleTests`) — **PR #72**
-- ✅ E2E: `tests/e2e/budget-variance-report/` (required `budget_id` filter, status/account_type, export)
-- Optional: approval flow integration (if `ApprovalFlow` already configured for Budget entity)
+- ✅ E2E: `tests/e2e/budget-variance-report/` (required `budget_id` filter, status/account_type, export) — **PR #75**
+- Optional (product): approval flow integration (if `ApprovalFlow` already configured for Budget entity)
 
 ---
 
@@ -278,4 +278,4 @@ Decisions made for the shipped MVP (kept for context):
 4. **Budget types** — All four types supported in schema (operational, capital, project, revenue).
 5. **Report scope** — Variance by account; department/branch dimension deferred.
 
-**Open follow-ups:** optional ApprovalFlow integration; commitment tracking; multi-currency (tracked separately); optional budget-variance report E2E.
+**Open follow-ups:** optional ApprovalFlow integration; commitment tracking; multi-currency (tracked separately).


### PR DESCRIPTION
## What was done
- Mark budget-variance **report** Playwright E2E as landed via **#75**
- Drop stale "optional report E2E" follow-up wording
- Align `docs/README.md` design-doc status row

## Files changed
- `docs/budget-management-design.md` — status / shipped / Phase 4 / open follow-ups
- `docs/README.md` — design docs table

## Verification
- Docs-only (no code/runtime change)
- [ ] CI — do not poll

## Context
- Independent of open #77 (Sonar MAJOR wave)
- Product gaps unchanged: ApprovalFlow, commitment, multi-currency