### PR TITLE
test: cover SyncEmployeePermissionsAction and SyncPermissionsRequest

### DIFF
--- a/tests/Unit/Actions/Employees/SyncEmployeePermissionsActionTest.php
+++ b/tests/Unit/Actions/Employees/SyncEmployeePermissionsActionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Actions\Employees\SyncEmployeePermissionsAction;
+use App\Models\Employee;
+use App\Models\Permission;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('employees');
+
+test('execute syncs permission ids onto the employee', function () {
+    $employee = Employee::factory()->create();
+    $permissions = Permission::factory()->count(3)->create();
+
+    (new SyncEmployeePermissionsAction)->execute(
+        $employee,
+        $permissions->pluck('id')->all(),
+    );
+
+    expect($employee->permissions()->pluck('permissions.id')->sort()->values()->all())
+        ->toEqual($permissions->pluck('id')->sort()->values()->all());
+});
+
+test('execute replaces existing permissions with the new set', function () {
+    $employee = Employee::factory()->create();
+    $initial = Permission::factory()->count(2)->create();
+    $replacement = Permission::factory()->create();
+
+    $employee->permissions()->sync($initial->pluck('id')->all());
+
+    (new SyncEmployeePermissionsAction)->execute($employee, [$replacement->id]);
+
+    expect($employee->permissions()->pluck('permissions.id')->all())
+        ->toEqual([$replacement->id]);
+});
+
+test('execute with empty array detaches all permissions', function () {
+    $employee = Employee::factory()->create();
+    $permissions = Permission::factory()->count(2)->create();
+    $employee->permissions()->sync($permissions->pluck('id')->all());
+
+    (new SyncEmployeePermissionsAction)->execute($employee, []);
+
+    expect($employee->permissions()->count())->toBe(0);
+});

--- a/tests/Unit/Requests/Employees/SyncPermissionsRequestTest.php
+++ b/tests/Unit/Requests/Employees/SyncPermissionsRequestTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Http\Requests\Employees\SyncPermissionsRequest;
+
+uses()->group('employees');
+
+test('authorize returns true', function () {
+    $request = new SyncPermissionsRequest;
+
+    expect($request->authorize())->toBeTrue();
+});
+
+test('rules returns permissions array validation', function () {
+    $request = new SyncPermissionsRequest;
+
+    expect($request->rules())->toEqual([
+        'permissions' => 'array',
+        'permissions.*' => 'exists:permissions,id',
+    ]);
+});
+
+test('messages returns custom permission validation messages', function () {
+    $request = new SyncPermissionsRequest;
+
+    expect($request->messages())->toEqual([
+        'permissions.array' => 'The permissions must be an array.',
+        'permissions.*.exists' => 'One or more selected permissions do not exist.',
+    ]);
+});


### PR DESCRIPTION
## What was done
- Unit tests for `SyncEmployeePermissionsAction` (attach, replace, detach-all)
- Unit tests for `SyncPermissionsRequest` (authorize, rules, messages)

## Files changed
- `tests/Unit/Actions/Employees/SyncEmployeePermissionsActionTest.php` — action coverage (was 0% Sonar)
- `tests/Unit/Requests/Employees/SyncPermissionsRequestTest.php` — form request coverage (was 0% Sonar)

## Verification
- [x] `./vendor/bin/sail test tests/Unit/Actions/Employees/SyncEmployeePermissionsActionTest.php tests/Unit/Requests/Employees/SyncPermissionsRequestTest.php` — 6 passed
- [ ] CI (do not block)

## Next steps
- Merge when green; independent of PR #81 (HandlesConditions)