### PR TITLE
test: cover ValidatesAllocationOverflow trait with 9 Pest tests

### DIFF
--- a/tests/Unit/Requests/Concerns/ValidatesAllocationOverflowHarness.php
+++ b/tests/Unit/Requests/Concerns/ValidatesAllocationOverflowHarness.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Requests\Concerns;
 
 use App\Http\Requests\Concerns\ValidatesAllocationOverflow;
+use Closure;
 use Illuminate\Contracts\Validation\Validator;
 
 /**
@@ -13,7 +14,7 @@ class ValidatesAllocationOverflowHarness
     use ValidatesAllocationOverflow;
 
     /**
-     * @param array<string, mixed> $input
+     * @param  array<string, mixed>  $input
      */
     public function __construct(private array $input)
     {
@@ -30,7 +31,7 @@ class ValidatesAllocationOverflowHarness
         string $inputKey,
         string $referenceIdKey,
         string $errorMessagePrefix,
-        \Closure $getMaxAllocationFor,
+        Closure $getMaxAllocationFor,
     ): void {
         $this->validateAllocationOverflow(
             $validator,

--- a/tests/Unit/Requests/Concerns/ValidatesAllocationOverflowHarness.php
+++ b/tests/Unit/Requests/Concerns/ValidatesAllocationOverflowHarness.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Requests\Concerns;
+
+use App\Http\Requests\Concerns\ValidatesAllocationOverflow;
+use Illuminate\Contracts\Validation\Validator;
+
+/**
+ * Harness exposing protected validateAllocationOverflow for unit testing.
+ */
+class ValidatesAllocationOverflowHarness
+{
+    use ValidatesAllocationOverflow;
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    public function __construct(private array $input)
+    {
+        // Intentionally empty. Input is injected for test control.
+    }
+
+    public function input(string $key, mixed $default = null): mixed
+    {
+        return $this->input[$key] ?? $default;
+    }
+
+    public function runValidateAllocationOverflow(
+        Validator $validator,
+        string $inputKey,
+        string $referenceIdKey,
+        string $errorMessagePrefix,
+        \Closure $getMaxAllocationFor,
+    ): void {
+        $this->validateAllocationOverflow(
+            $validator,
+            $inputKey,
+            $referenceIdKey,
+            $errorMessagePrefix,
+            $getMaxAllocationFor,
+        );
+    }
+}

--- a/tests/Unit/Requests/Concerns/ValidatesAllocationOverflowTest.php
+++ b/tests/Unit/Requests/Concerns/ValidatesAllocationOverflowTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use Illuminate\Contracts\Validation\Validator;
+use Tests\Unit\Requests\Concerns\ValidatesAllocationOverflowHarness;
+
+uses()->group('validates-allocation-overflow');
+
+function mockValidator(): array
+{
+    $errors = Mockery::mock();
+    $validator = Mockery::mock(Validator::class);
+    $validator->shouldReceive('errors')->andReturn($errors);
+
+    return [$validator, $errors];
+}
+
+test('does not add error when allocated_amount is within max', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')->never();
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => 1, 'allocated_amount' => 100],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => 200.0,
+    );
+});
+
+test('does not add error when allocated_amount equals max', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')->never();
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => 1, 'allocated_amount' => 150],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => 150.0,
+    );
+});
+
+test('adds error when allocated_amount exceeds max allocation', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')
+        ->once()
+        ->with(
+            'allocations.0.allocated_amount',
+            'Exceeds maximum: 50',
+        );
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => 1, 'allocated_amount' => 100],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => 50.0,
+    );
+});
+
+test('skips allocation with empty reference id', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')->never();
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => '', 'allocated_amount' => 999],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => 0.0,
+    );
+});
+
+test('skips allocation with missing allocated_amount', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')->never();
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => 1, 'allocated_amount' => ''],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => 0.0,
+    );
+});
+
+test('skips allocation when max allocation is null', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')->never();
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => 1, 'allocated_amount' => 500],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => null,
+    );
+});
+
+test('validates multiple allocations independently', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')
+        ->once()
+        ->with(
+            'allocations.1.allocated_amount',
+            'Limit: 25',
+        );
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [
+            ['invoice_id' => 1, 'allocated_amount' => 50],
+            ['invoice_id' => 2, 'allocated_amount' => 100],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Limit',
+        fn (int $id) => match ($id) {
+            1 => 100.0,
+            2 => 25.0,
+            default => null,
+        },
+    );
+});
+
+test('uses custom input key and reference id key', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')
+        ->once()
+        ->with(
+            'items.0.allocated_amount',
+            'Over limit: 10',
+        );
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'items' => [
+            ['ref_id' => 5, 'allocated_amount' => 20],
+        ],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'items',
+        'ref_id',
+        'Over limit',
+        fn (int $id) => 10.0,
+    );
+});
+
+test('empty allocations array does not trigger errors', function () {
+    [$validator, $errors] = mockValidator();
+    $errors->shouldReceive('add')->never();
+
+    $harness = new ValidatesAllocationOverflowHarness([
+        'allocations' => [],
+    ]);
+
+    $harness->runValidateAllocationOverflow(
+        $validator,
+        'allocations',
+        'invoice_id',
+        'Exceeds maximum',
+        fn (int $id) => 0.0,
+    );
+});


### PR DESCRIPTION
## What was done
- Added unit test harness `ValidatesAllocationOverflowHarness` exposing protected trait method
- Added 9 Pest tests covering all branches:
  - Within max (no error)
  - Equals max (no error)
  - Exceeds max (adds error with formatted message)
  - Empty reference ID (skip)
  - Missing allocated_amount (skip)
  - Null max allocation (skip)
  - Multiple allocations (only failing one flagged)
  - Custom input/reference ID keys
  - Empty allocations array (no error)

## Files changed
- `tests/Unit/Requests/Concerns/ValidatesAllocationOverflowHarness.php` — new test harness
- `tests/Unit/Requests/Concerns/ValidatesAllocationOverflowTest.php` — 9 Pest tests

## Verification
- [x] sail test tests/Unit/Requests/Concerns/ValidatesAllocationOverflowTest.php — 9 passed

## Next steps
- Merge when green; continue to FortifyServiceProvider (0%, 4 lines) or TestSmtpMail (50%, 6 uncovered)