### PR TITLE
fix: align menu, SPA, and module-registry for asset paths

### DIFF
--- a/docs/module-registry.md
+++ b/docs/module-registry.md
@@ -398,14 +398,16 @@ Semua modul simple CRUD memiliki konfigurasi E2E yang identik kecuali nama:
     - tests/e2e/inventory-valuation-report/inventory-valuation-report.spec.ts
 
 - slug: asset-stocktake-variances
-  route: /asset-stocktake-variances
+  route: /reports/asset-stocktake-variances
   api: /api/asset-stocktake-variances
   export_api: /api/asset-stocktake-variances/export
   search_placeholder: "Search code, name, notes..."
   sortable_columns: [Asset Code, Asset Name, Expected Location, Found Location, Result, Notes, Checked By, Checked At]
-  view_type: dialog
+  view_type: page
   checkbox_header: false
-  note: "Laporan Stocktake Variance (Non-CRUD), menggunakan read-only data table dengan filter."
+  note: "Laporan Stocktake Variance (Non-CRUD). SPA path under /reports/…; API remains /api/asset-stocktake-variances. Sidebar MenuSeeder url: reports/asset-stocktake-variances."
+  tests:
+    - tests/e2e/asset-stocktake-variances/index.spec.ts
 
 - slug: pipelines
   route: /pipelines
@@ -666,11 +668,13 @@ Semua modul simple CRUD memiliki konfigurasi E2E yang identik kecuali nama:
   checkbox_header: false
   note: "Non-CRUD feature for viewing and exporting approval audit trail logs. Read-only Data Table with Detail modal."
 
-- modul: Asset Dashboard
-  group: asset-dashboard
+- slug: asset-dashboard
+  route: /asset-dashboard
+  api: /api/asset-dashboard/data
+  view_type: page
+  note: "Non-CRUD dashboard visualisasi aset (distribution, condition, maintenance, warranty alerts). Requires asset_dashboard permission. Sidebar MenuSeeder: asset_dashboard → asset-dashboard."
   tests:
     - tests/e2e/asset-dashboard/asset-dashboard.spec.ts
-  note: "Non-CRUD feature for visualizing asset distribution, condition, maintenance, and warranty alerts."
 
 - slug: admin-settings
   route: /admin-settings

--- a/docs/user-guide-asset-stocktakes.md
+++ b/docs/user-guide-asset-stocktakes.md
@@ -19,7 +19,7 @@ Fitur utama:
 |------|-------|--------|
 | Asset Stocktakes | `/asset-stocktakes` | Daftar stocktake dengan filter, search, CRUD |
 | Asset Stocktake Perform | `/asset-stocktakes/{ulid}/perform` | Halaman khusus untuk mencatat hasil pengecekan |
-| Asset Stocktake Variance Report | `/asset-stocktake-variances` | Laporan variance hasil stocktake |
+| Asset Stocktake Variance Report | `/reports/asset-stocktake-variances` | Laporan variance hasil stocktake |
 
 ## 1. Daftar Asset Stocktakes
 
@@ -95,7 +95,7 @@ Setelah semua aset selesai dicek:
 
 ## 6. Laporan Variance
 
-Hasil stocktake yang sudah completed dapat dilihat di **Asset Stocktake Variance Report** (`/asset-stocktake-variances`). Laporan ini menampilkan aset yang:
+Hasil stocktake yang sudah completed dapat dilihat di **Asset Stocktake Variance Report** (`/reports/asset-stocktake-variances`). Laporan ini menampilkan aset yang:
 - **Not Found**: Aset tidak ditemukan di lokasi manapun
 - **Relocated**: Aset ditemukan di lokasi yang berbeda dari expected
 - **Damaged**: Aset ditemukan dalam kondisi rusak

--- a/docs/user-guide-assets.md
+++ b/docs/user-guide-assets.md
@@ -31,7 +31,7 @@ Fitur utama:
 | Asset Maintenances | /asset-maintenances | Jadwal dan histori perawatan |
 | Asset Stocktakes | /asset-stocktakes | Stocktake header dengan perform page |
 | Asset Depreciation Runs | /asset-depreciation-runs | Run depresiasi dengan calculate/post/void |
-| Asset Stocktake Variance Report | /asset-stocktake-variances | Laporan variance stocktake |
+| Asset Stocktake Variance Report | /reports/asset-stocktake-variances | Laporan variance stocktake |
 
 ## 1. Manajemen Data Aset
 
@@ -421,7 +421,7 @@ Field form:
 
 ### 7.5 Variance Report
 
-Setelah stocktake completed, variance report tersedia di `/asset-stocktake-variances` menampilkan:
+Setelah stocktake completed, variance report tersedia di `/reports/asset-stocktake-variances` menampilkan:
 - Aset yang tidak ditemukan di lokasi expected
 - Aset yang ditemukan di lokasi berbeda
 - Perbedaan kondisi
@@ -590,7 +590,7 @@ A: Ya, gunakan fitur Import di toolbar halaman Assets. Download template, isi da
 
 ### Q: Bagaimana cara melihat variance stocktake?
 
-A: Setelah stocktake completed, buka halaman `/asset-stocktake-variances` untuk melihat laporan variance semua stocktake.
+A: Setelah stocktake completed, buka halaman `/reports/asset-stocktake-variances` untuk melihat laporan variance semua stocktake.
 
 ### Q: Bisakah depreciation run di-edit setelah posted?
 

--- a/resources/js/pages/reports/asset-stocktake-variances/index.tsx
+++ b/resources/js/pages/reports/asset-stocktake-variances/index.tsx
@@ -16,7 +16,7 @@ export default function StocktakeVarianceReport() {
             title="Stocktake Variance Report"
             breadcrumbs={createReportBreadcrumbs(
                 'Stocktake Variance',
-                '/asset-stocktake-variances',
+                '/reports/asset-stocktake-variances',
             )}
             columns={varianceColumns}
             filterFields={createVarianceFilterFields()}


### PR DESCRIPTION
## What was done
- Canonical SPA path for **Asset Stocktake Variance**: `/reports/asset-stocktake-variances` (matches `MenuSeeder` + `app-routes.tsx`)
- Updated `docs/module-registry.md` route + note + E2E tests list; `view_type: page`
- Replaced legacy `- modul: Asset Dashboard` with full `slug: asset-dashboard` entry (`route`, `api`, note, tests)
- Fixed breadcrumbs on variance report page
- Fixed user-guide links that still pointed at top-level `/asset-stocktake-variances`

## Files changed
- `docs/module-registry.md` — registry alignment
- `docs/user-guide-asset-stocktakes.md`, `docs/user-guide-assets.md` — path docs
- `resources/js/pages/reports/asset-stocktake-variances/index.tsx` — breadcrumb href

## Verification
- [x] Diff script: **85 menu leaves ↔ 85 registry nav routes, 0 gaps**
- [ ] CI (do not wait)

## Next steps
- None required for menu↔registry; optional three-way was already satisfied via app-routes check