### PR TITLE
fix: drop invalid accounts permission from Master Data menu

### DIFF
--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -781,7 +781,6 @@ class MenuSeeder extends Seeder
                     'asset_category',
                     'asset_model',
                     'asset_location',
-                    'accounts',
                     'pipeline',
                 ],
                 'icon' => 'Database',


### PR DESCRIPTION
## What was done
- Removed orphan `'accounts'` from `master.data` group `permissions[]` in MenuSeeder
- Chart of Accounts leaf already correctly uses `account` / `.create` / `.edit` / `.delete`
- SPA path `url => accounts` unchanged

## Why
Static audit MenuSeeder vs PermissionSeeder: only menu key missing from PermissionSeeder was `accounts` (typo/plural). Dead entry in parent group OR gate.

## Files changed
- `database/seeders/MenuSeeder.php` — remove one invalid permission key

## Verification
- [x] Re-diff: menu permissions not in PermissionSeeder = **0**
- [x] `'accounts'` no longer appears in any `permissions => [...]` block
- [x] Leaf Chart of Accounts still `url => accounts`

## Next steps
- After merge: re-seed menus in environments that persist Menu rows from seeder if needed (`sail artisan db:seed --class=MenuSeeder`)
- Optional: merge open #84 (menu/registry path) separately if still open