### PR TITLE
fix: sticky DataTable Actions for wide tables (HF-2)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -19,7 +19,7 @@
 | ID | Pri | Item | Status |
 |----|-----|------|--------|
 | HF-1 | P0 | Financial dashboard: negative Cash Balance must not use success green | done (fix/hf1) |
-| HF-2 | P0 | Employees (and wide tables): sticky Actions + horizontal scroll | open |
+| HF-2 | P0 | Employees (and wide tables): sticky Actions + horizontal scroll | done (fix/hf2) |
 | HF-3 | P1 | Accounts: fix sidebar active state for Chart of Accounts | open |
 
 ## Done

--- a/resources/js/components/common/DataTableCore.tsx
+++ b/resources/js/components/common/DataTableCore.tsx
@@ -25,8 +25,14 @@ import {
 } from '@tanstack/react-table';
 
 import { useExport } from '@/hooks/useExport';
+import { cn } from '@/lib/utils';
 import * as React from 'react';
 import type { FieldDescriptor } from './filters';
+
+const STICKY_ACTIONS_CELL =
+    'sticky right-0 z-10 bg-background shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.15)] dark:shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.45)]';
+const STICKY_ACTIONS_HEAD =
+    'sticky right-0 z-20 bg-muted shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.15)] dark:shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.45)]';
 
 // Helper function to safely extract placeholder from filter fields
 function getPlaceholderFromFilterFields(
@@ -299,7 +305,7 @@ export function DataTable<T>({
     if (isLoading) {
         tableContent = loadingRows.map((rowKey) => (
             <TableRow key={rowKey}>
-                {columns.map((column) => {
+                {columnsWithActions.map((column) => {
                     let columnKey = 'loading-column';
                     if ('id' in column && column.id) {
                         columnKey = String(column.id);
@@ -308,11 +314,15 @@ export function DataTable<T>({
                     } else if (typeof column.header === 'string') {
                         columnKey = column.header;
                     }
+                    const isActions = columnKey === 'actions';
 
                     return (
                         <TableCell
                             key={`${rowKey}-${columnKey}`}
-                            className="border-border"
+                            className={cn(
+                                'border-border',
+                                isActions && STICKY_ACTIONS_CELL,
+                            )}
                         >
                             <Skeleton className="h-4 w-full bg-muted" />
                         </TableCell>
@@ -327,21 +337,30 @@ export function DataTable<T>({
                 data-state={row.getIsSelected() && 'selected'}
                 className="hover:bg-muted/50"
             >
-                {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="border-border">
-                        {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                        )}
-                    </TableCell>
-                ))}
+                {row.getVisibleCells().map((cell) => {
+                    const isActions = cell.column.id === 'actions';
+                    return (
+                        <TableCell
+                            key={cell.id}
+                            className={cn(
+                                'border-border',
+                                isActions && STICKY_ACTIONS_CELL,
+                            )}
+                        >
+                            {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext(),
+                            )}
+                        </TableCell>
+                    );
+                })}
             </TableRow>
         ));
     } else {
         tableContent = (
             <TableRow>
                 <TableCell
-                    colSpan={columns.length}
+                    colSpan={columnsWithActions.length}
                     className="h-24 text-center text-muted-foreground"
                 >
                     No results.
@@ -387,26 +406,33 @@ export function DataTable<T>({
                 table={table}
             />
 
-            {/* Table */}
-            <div className="overflow-hidden rounded-md border border-border">
-                <Table>
+            <div className="rounded-md border border-border">
+                <Table className="min-w-max">
                     <TableHeader className="bg-muted">
                         {table.getHeaderGroups().map((headerGroup) => (
                             <TableRow key={headerGroup.id}>
-                                {headerGroup.headers.map((header) => (
-                                    <TableHead
-                                        key={header.id}
-                                        className="border-border select-none"
-                                    >
-                                        {header.isPlaceholder
-                                            ? null
-                                            : flexRender(
-                                                  header.column.columnDef
-                                                      .header,
-                                                  header.getContext(),
-                                              )}
-                                    </TableHead>
-                                ))}
+                                {headerGroup.headers.map((header) => {
+                                    const isActions =
+                                        header.column.id === 'actions';
+                                    return (
+                                        <TableHead
+                                            key={header.id}
+                                            className={cn(
+                                                'border-border select-none',
+                                                isActions &&
+                                                    STICKY_ACTIONS_HEAD,
+                                            )}
+                                        >
+                                            {header.isPlaceholder
+                                                ? null
+                                                : flexRender(
+                                                      header.column.columnDef
+                                                          .header,
+                                                      header.getContext(),
+                                                  )}
+                                        </TableHead>
+                                    );
+                                })}
                             </TableRow>
                         ))}
                     </TableHeader>

--- a/resources/js/utils/columns.tsx
+++ b/resources/js/utils/columns.tsx
@@ -362,6 +362,7 @@ export function createActionsColumn<T = Record<string, unknown>>(
     return {
         id: 'actions',
         enableHiding,
+        size: 56,
         meta: {
             viewPath,
         },

--- a/task.md
+++ b/task.md
@@ -1,9 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-1 (negative cash semantics) in progress on branch  
-**Branch:** `fix/hf1-financial-cash-negative-color`  
-**Main tip:** `aee84afe` (chore visual audit Wave 0–1 #86 merged)  
+**Current milestone:** Visual audit — HF-2 sticky DataTable Actions (PR pending)  
+**Branch:** `fix/hf2-datatable-sticky-actions`  
+**Main tip:** `5245260d` (HF-1 #87 merged)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -16,13 +16,14 @@
 ## Done
 
 - Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86 merged)
-- **HF-1:** signed-balance KPI chrome — Cash / Net Income / Equity use rose when value &lt; 0; `KpiCard.valueClassName`; net cash flow bar rose when negative
+- **HF-1:** signed-balance KPI chrome — Cash / Net Income / Equity rose when &lt; 0 (PR #87)
+- **HF-2:** sticky `actions` column + allow horizontal scroll on shared `DataTable` (`DataTableCore`); `createActionsColumn` size 56
 
 ## P0 remaining
 
-1. ~~**FD-01** Negative cash balance styled green~~ → HF-1 (this branch)  
-2. **EMP-01 / SHELL-07** Wide tables clip Actions → HF-2  
-3. **ACC-02 / SHELL-08** Wrong sidebar active on Chart of Accounts → HF-3  
+1. ~~FD-01 / HF-1~~  
+2. ~~EMP-01 / SHELL-07 / HF-2~~ (this branch)  
+3. **ACC-02 / SHELL-08** Wrong sidebar active on Chart of Accounts → **HF-3**
 
 ## Themes (user picks next)
 
@@ -34,19 +35,17 @@ T1 DataTable shell · T2 Sidebar · T3 Page header · T4 KPI semantics · T5 Spa
 - Use default `playwright.config.ts` for visual (migrate:fresh)  
 - Redesign all 85 modules in one MR  
 
-## Recommended next (after HF-1 PR)
+## Recommended next (after HF-2 PR merge)
 
-1. HF-2 sticky Actions  
-2. HF-3 Accounts sidebar active  
-3. Then T1 shell if capacity  
+1. HF-3 Accounts sidebar active  
+2. Then T1 shell if capacity  
 
-## Files (HF-1)
+## Files (HF-2)
 
-- `resources/js/components/common/KpiCard.tsx`  
-- `resources/js/components/financial-dashboard/SummaryCards.tsx`  
-- `resources/js/components/financial-dashboard/CashFlowSummary.tsx`  
+- `resources/js/components/common/DataTableCore.tsx`  
+- `resources/js/utils/columns.tsx`  
 - `docs/visual-audit/BACKLOG.md`  
 
 ## Continuation Prompt
 
-Continue HF-1 PR if open; else implement HF-2 sticky DataTable Actions on a new `fix/hf2-*` branch from main. Do not Wave 2 mass capture.
+After HF-2 merge: implement HF-3 CoA sidebar active on `fix/hf3-*` from main. Do not Wave 2 mass capture.


### PR DESCRIPTION
## What was done
- Sticky right `actions` column (header + body + loading) on shared `DataTableCore`
- Outer table wrapper no longer clips horizontal scroll (`overflow-hidden` removed); `Table` already has `overflow-x-auto`
- `min-w-max` on table so wide column sets scroll instead of crushing Actions
- `createActionsColumn` `size: 56` for a stable actions width
- BACKLOG HF-2 → done; `task.md` handoff updated

## Files changed
- `resources/js/components/common/DataTableCore.tsx` — sticky Actions + scroll shell
- `resources/js/utils/columns.tsx` — actions column size
- `docs/visual-audit/BACKLOG.md` — HF-2 status
- `task.md` — handoff

## Verification
- [ ] Manual: `/employees` (or any wide CRUD) — scroll horizontally; Actions stay visible
- [ ] Light UI check only (host RAM tight; no full e2e suite)
- [ ] CI (do not block on agent)

## Next steps
- After merge: **HF-3** Chart of Accounts sidebar active
- Do **not** Wave 2 mass visual capture