### PR TITLE
fix: sidebar active route segment match (HF-3 CoA)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -39,6 +39,6 @@
 
 ## Next agent action
 
-1. User picks: **HF-1/2/3** quick fixes **or** **T1** shell redesign plan  
-2. Do **not** mass Wave 2 capture  
-3. Optional: commit docs+harness on `chore/visual-audit-wave-0-1`
+1. Merge **PR #89** (HF-3) if still open  
+2. User picks **T1** DataTable shell v2 (preferred) **or** **T2** sidebar density  
+3. Do **not** mass Wave 2 capture

--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -20,7 +20,7 @@
 |----|-----|------|--------|
 | HF-1 | P0 | Financial dashboard: negative Cash Balance must not use success green | done (fix/hf1) |
 | HF-2 | P0 | Employees (and wide tables): sticky Actions + horizontal scroll | done (fix/hf2) |
-| HF-3 | P1 | Accounts: fix sidebar active state for Chart of Accounts | open |
+| HF-3 | P1 | Accounts: fix sidebar active state for Chart of Accounts | done (fix/hf3) |
 
 ## Done
 

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -15,10 +15,7 @@ import {
 } from '@/components/ui/sidebar';
 import { useAuth } from '@/contexts/auth-context';
 import { useTranslation } from '@/contexts/i18n-context';
-import {
-    isNavHrefActive,
-    pathMatchesNavHref,
-} from '@/lib/nav-active';
+import { isNavHrefActive, pathMatchesNavHref } from '@/lib/nav-active';
 import { type NavItem } from '@/types';
 import { ChevronRight } from 'lucide-react';
 import { useMemo } from 'react';

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -15,17 +15,43 @@ import {
 } from '@/components/ui/sidebar';
 import { useAuth } from '@/contexts/auth-context';
 import { useTranslation } from '@/contexts/i18n-context';
+import {
+    isNavHrefActive,
+    pathMatchesNavHref,
+} from '@/lib/nav-active';
 import { type NavItem } from '@/types';
 import { ChevronRight } from 'lucide-react';
+import { useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
+
+function collectNavHrefs(items: NavItem[]): string[] {
+    const hrefs: string[] = [];
+
+    for (const item of items) {
+        if (item.href && item.href !== '#') {
+            hrefs.push(item.href);
+        }
+        if (item.children?.length) {
+            for (const child of item.children) {
+                if (child.href && child.href !== '#') {
+                    hrefs.push(child.href);
+                }
+            }
+        }
+    }
+
+    return hrefs;
+}
 
 export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
     const { pendingApprovalsCount } = useAuth();
     const location = useLocation();
     const pendingCount = pendingApprovalsCount || 0;
     const { t } = useTranslation();
+
+    const allHrefs = useMemo(() => collectNavHrefs(items), [items]);
 
     return (
         <SidebarGroup className="px-2 py-0">
@@ -37,7 +63,10 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                             key={item.title}
                             asChild
                             defaultOpen={item.children.some((child) =>
-                                location.pathname.startsWith(child.href),
+                                pathMatchesNavHref(
+                                    location.pathname,
+                                    child.href,
+                                ),
                             )}
                             className="group/collapsible"
                         >
@@ -59,8 +88,10 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                                             >
                                                 <SidebarMenuSubButton
                                                     asChild
-                                                    isActive={location.pathname.startsWith(
+                                                    isActive={isNavHrefActive(
+                                                        location.pathname,
                                                         subItem.href,
+                                                        allHrefs,
                                                     )}
                                                 >
                                                     <Link to={subItem.href}>
@@ -95,8 +126,10 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                         <SidebarMenuItem key={item.title}>
                             <SidebarMenuButton
                                 asChild
-                                isActive={location.pathname.startsWith(
+                                isActive={isNavHrefActive(
+                                    location.pathname,
                                     item.href,
+                                    allHrefs,
                                 )}
                                 tooltip={{ children: item.title }}
                             >

--- a/resources/js/lib/nav-active.ts
+++ b/resources/js/lib/nav-active.ts
@@ -1,0 +1,57 @@
+export function normalizeNavPath(path: string): string {
+    if (!path || path === '#') {
+        return '';
+    }
+
+    const trimmed = path.replace(/\/+$/, '');
+    if (trimmed === '') {
+        return '/';
+    }
+
+    return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+export function pathMatchesNavHref(pathname: string, href: string): boolean {
+    const path = normalizeNavPath(pathname);
+    const base = normalizeNavPath(href);
+
+    if (!path || !base) {
+        return false;
+    }
+
+    return path === base || path.startsWith(`${base}/`);
+}
+
+export function resolveActiveNavHref(
+    pathname: string,
+    hrefs: readonly string[],
+): string {
+    let best = '';
+    let bestLen = -1;
+
+    for (const href of hrefs) {
+        if (!pathMatchesNavHref(pathname, href)) {
+            continue;
+        }
+        const normalized = normalizeNavPath(href);
+        if (normalized.length > bestLen) {
+            best = normalized;
+            bestLen = normalized.length;
+        }
+    }
+
+    return best;
+}
+
+export function isNavHrefActive(
+    pathname: string,
+    href: string,
+    allHrefs: readonly string[],
+): boolean {
+    const active = resolveActiveNavHref(pathname, allHrefs);
+    if (!active) {
+        return false;
+    }
+
+    return normalizeNavPath(href) === active;
+}

--- a/task.md
+++ b/task.md
@@ -1,9 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-2 sticky DataTable Actions (PR pending)  
-**Branch:** `fix/hf2-datatable-sticky-actions`  
-**Main tip:** `5245260d` (HF-1 #87 merged)  
+**Current milestone:** Visual audit — HF-3 CoA sidebar active (PR pending)  
+**Branch:** `fix/hf3-accounts-sidebar-active`  
+**Main tip:** `5e9abaa4` (HF-2 #88 merged)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -16,14 +16,15 @@
 ## Done
 
 - Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86 merged)
-- **HF-1:** signed-balance KPI chrome — Cash / Net Income / Equity rose when &lt; 0 (PR #87)
-- **HF-2:** sticky `actions` column + allow horizontal scroll on shared `DataTable` (`DataTableCore`); `createActionsColumn` size 56
+- **HF-1:** signed-balance KPI chrome (PR #87)
+- **HF-2:** sticky `actions` + horizontal scroll (PR #88)
+- **HF-3:** nav active via segment match + longest-href wins (`nav-active.ts` + `nav-main.tsx`) — ACC-02 / SHELL-08
 
 ## P0 remaining
 
 1. ~~FD-01 / HF-1~~  
-2. ~~EMP-01 / SHELL-07 / HF-2~~ (this branch)  
-3. **ACC-02 / SHELL-08** Wrong sidebar active on Chart of Accounts → **HF-3**
+2. ~~EMP-01 / SHELL-07 / HF-2~~  
+3. ~~ACC-02 / SHELL-08 / HF-3~~ (this branch)
 
 ## Themes (user picks next)
 
@@ -35,17 +36,18 @@ T1 DataTable shell · T2 Sidebar · T3 Page header · T4 KPI semantics · T5 Spa
 - Use default `playwright.config.ts` for visual (migrate:fresh)  
 - Redesign all 85 modules in one MR  
 
-## Recommended next (after HF-2 PR merge)
+## Recommended next (after HF-3 PR merge)
 
-1. HF-3 Accounts sidebar active  
-2. Then T1 shell if capacity  
+1. **T1** DataTable shell v2 if capacity  
+2. Or **T2** remaining sidebar IA (truncation/density) — active route fixed in HF-3  
+3. Optional light re-smoke 3–5 routes with visual-audit config only  
 
-## Files (HF-2)
+## Files (HF-3)
 
-- `resources/js/components/common/DataTableCore.tsx`  
-- `resources/js/utils/columns.tsx`  
+- `resources/js/lib/nav-active.ts`  
+- `resources/js/components/nav-main.tsx`  
 - `docs/visual-audit/BACKLOG.md`  
 
 ## Continuation Prompt
 
-After HF-2 merge: implement HF-3 CoA sidebar active on `fix/hf3-*` from main. Do not Wave 2 mass capture.
+After HF-3 merge: start T1 DataTable shell or T2 sidebar density on `feat/*` from main. Do not Wave 2 mass capture.

--- a/task.md
+++ b/task.md
@@ -1,9 +1,11 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-3 CoA sidebar active (PR pending)  
+**Current milestone:** Visual audit — HF-3 shipped as **PR #89** (await user merge)  
 **Branch:** `fix/hf3-accounts-sidebar-active`  
-**Main tip:** `5e9abaa4` (HF-2 #88 merged)  
+**Commits:** `d4b85789` (fix nav-active) · `32ed7582` (docs)  
+**PR:** https://github.com/gmedia/erp/pull/89  
+**Main tip (pre-merge):** `5e9abaa4` (HF-2 #88)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -18,31 +20,40 @@
 - Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86 merged)
 - **HF-1:** signed-balance KPI chrome (PR #87)
 - **HF-2:** sticky `actions` + horizontal scroll (PR #88)
-- **HF-3:** nav active via segment match + longest-href wins (`nav-active.ts` + `nav-main.tsx`) — ACC-02 / SHELL-08
+- **HF-3:** nav active via segment match + longest-href wins — **PR #89 open** (ACC-02 / SHELL-08)
 
 ## P0 remaining
 
 1. ~~FD-01 / HF-1~~  
 2. ~~EMP-01 / SHELL-07 / HF-2~~  
-3. ~~ACC-02 / SHELL-08 / HF-3~~ (this branch)
+3. ~~ACC-02 / SHELL-08 / HF-3~~ (merge PR #89)
 
-## Themes (user picks next)
+## Themes (user picks next after #89 merge)
 
-T1 DataTable shell · T2 Sidebar · T3 Page header · T4 KPI semantics · T5 Sparse density  
+| ID | Theme | Why next |
+|----|-------|----------|
+| **T1** | DataTable shell v2 | Highest blast radius: SHELL-02,03,06,07,10,11; EMP-*; PO-* (sticky Actions already in HF-2 — rest of shell) |
+| **T2** | Sidebar IA residual | Truncation + density only (active route done in HF-3) |
+| T3 | Page header contract | breadcrumb/title drift |
+| T4 | Dashboard & KPI | residual after HF-1 |
+| T5 | Sparse & report density | lower pri |
 
 ## Do not
 
 - Mass-capture Wave 2 / remaining 78 routes  
 - Use default `playwright.config.ts` for visual (migrate:fresh)  
 - Redesign all 85 modules in one MR  
+- Commit local untracked `e2e/` junk  
+- Start T1/T2 on top of unmerged HF-3 branch (new branch from **main after merge**)
 
-## Recommended next (after HF-3 PR merge)
+## Recommended next
 
-1. **T1** DataTable shell v2 if capacity  
-2. Or **T2** remaining sidebar IA (truncation/density) — active route fixed in HF-3  
-3. Optional light re-smoke 3–5 routes with visual-audit config only  
+1. **You:** review/merge **PR #89** (manual smoke: `/accounts` → CoA active, not Department)  
+2. **Agent after merge:** `rtk git checkout main && rtk git pull --ff-only` → branch `feat/t1-datatable-shell-v2` **or** `feat/t2-sidebar-density`  
+3. Prefer **T1** if capacity (shared table chrome); **T2** if small residual sidebar polish only  
+4. Optional light re-smoke 3–5 routes with visual-audit config only  
 
-## Files (HF-3)
+## Files (HF-3 / PR #89)
 
 - `resources/js/lib/nav-active.ts`  
 - `resources/js/components/nav-main.tsx`  
@@ -50,4 +61,4 @@ T1 DataTable shell · T2 Sidebar · T3 Page header · T4 KPI semantics · T5 Spa
 
 ## Continuation Prompt
 
-After HF-3 merge: start T1 DataTable shell or T2 sidebar density on `feat/*` from main. Do not Wave 2 mass capture.
+After PR #89 merge: pull main, start **T1 DataTable shell v2** (or T2 sidebar density if user prefers small). One theme = one branch = one MR. Do not Wave 2 mass capture.

--- a/task.md
+++ b/task.md
@@ -1,7 +1,7 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-3 shipped as **PR #89** (await user merge)  
+**Current milestone:** Visual audit — HF-3 **PR #89** (CI: Quality/Pest/Sonar green; E2E 1 flaky Asset export create — unrelated to nav; failed job re-runned)  
 **Branch:** `fix/hf3-accounts-sidebar-active`  
 **Commits:** `d4b85789` (fix nav-active) · `32ed7582` (docs)  
 **PR:** https://github.com/gmedia/erp/pull/89  


### PR DESCRIPTION
## What was done
- Replace naive `pathname.startsWith(href)` nav active with segment-safe match + longest-href wins (`nav-active.ts`)
- Wire `NavMain` to collect all menu hrefs and mark only the most specific match active
- Fixes ACC-02 / SHELL-08 (Department highlighted while on Chart of Accounts)
- Mark HF-3 done in BACKLOG + refresh `task.md`

## Files changed
- `resources/js/lib/nav-active.ts` — normalize / match / resolve active href
- `resources/js/components/nav-main.tsx` — use helpers for leaf + collapsible open
- `docs/visual-audit/BACKLOG.md` — HF-3 done
- `task.md` — handoff after HF-3

## Verification
- [ ] Manual: open `/accounts` → sidebar **Chart of Accounts** active, not Department
- [ ] Manual: open `/account-mappings`, `/departments`, nested `/accounts/{id}` if any
- [ ] CI (not waited by agent)

## Next steps
- After merge: **T1** DataTable shell v2 or **T2** sidebar density/truncation
- Do **not** mass-capture Wave 2