### PR TITLE
feat: DataTable shell v2 (T1)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -8,8 +8,8 @@
 
 | ID | Pri | Theme | Scope | Status | Notes |
 |----|-----|-------|-------|--------|-------|
-| T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | open | Single toolbar row; sticky Actions; semantic Status; scroll discipline; bulk bar optional. Fixes SHELL-02,03,06,07,10,11; EMP-*; PO-* |
-| T2 | P1 | Sidebar IA & active | AppLayout / nav | open | Truncation strategy; **correct active route**; density. SHELL-01,08,09; ACC-02 |
+| T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | in progress (`feat/t1-datatable-shell-v2`) | Single toolbar row; sticky Actions (HF-2); semantic Status; bulk bar; pagination chrome. SHELL-02,03,06,10,11; EMP-*; PO-* |
+| T2 | P1 | Sidebar IA & active | AppLayout / nav | partial | **Active route done (HF-3)**; truncation/density still open. SHELL-01,09 |
 | T3 | P1 | Page header contract | Layout primitive | open | breadcrumb + title + desc + actions; no double title / bare breadcrumb drift. SHELL-04; ACC-01; RSM-02; FD-06 |
 | T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD-01..03; DASH-*; BS-02 |
 | T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report H1 parity. SHELL-05; RSM-01 |

--- a/resources/js/components/common/DataTableCore.tsx
+++ b/resources/js/components/common/DataTableCore.tsx
@@ -3,6 +3,7 @@
 import { GenericActions } from '@/components/common/ActionsDropdown';
 import { DataTablePagination } from '@/components/common/DataTablePagination';
 import { DataTableToolbar } from '@/components/common/DataTableToolbar';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -265,6 +266,7 @@ export function DataTable<T>({
         },
         onColumnVisibilityChange: setColumnVisibility,
         onRowSelectionChange: setRowSelection,
+        enableRowSelection: true,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         manualPagination: true,
@@ -406,7 +408,28 @@ export function DataTable<T>({
                 table={table}
             />
 
-            <div className="rounded-md border border-border">
+            {Object.keys(rowSelection).length > 0 && (
+                <div
+                    className="mb-2 flex items-center gap-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
+                    data-testid="bulk-selection-bar"
+                    role="status"
+                >
+                    <span className="font-medium text-foreground">
+                        {Object.keys(rowSelection).length} selected
+                    </span>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 px-2"
+                        onClick={() => setRowSelection({})}
+                    >
+                        Clear selection
+                    </Button>
+                </div>
+            )}
+
+            <div className="overflow-hidden rounded-md border border-border">
                 <Table className="min-w-max">
                     <TableHeader className="bg-muted">
                         {table.getHeaderGroups().map((headerGroup) => (
@@ -440,14 +463,15 @@ export function DataTable<T>({
                 </Table>
             </div>
 
-            {/* Pagination */}
-            <DataTablePagination
-                pagination={pagination}
-                onPageChange={handlePageChange}
-                onPageSizeChange={(per_page: number) =>
-                    handlePageSizeChange(per_page.toString())
-                }
-            />
+            <div className="mt-1 border-t border-border/60">
+                <DataTablePagination
+                    pagination={pagination}
+                    onPageChange={handlePageChange}
+                    onPageSizeChange={(per_page: number) =>
+                        handlePageSizeChange(per_page.toString())
+                    }
+                />
+            </div>
         </div>
     );
 }

--- a/resources/js/components/common/DataTableToolbar.tsx
+++ b/resources/js/components/common/DataTableToolbar.tsx
@@ -92,7 +92,7 @@ export function DataTableToolbar<T>({
                     value={searchValue}
                     onChange={handleSearchChange}
                     onKeyDown={handleSearchKeyDown}
-                    className="h-9 min-w-[12rem] max-w-sm flex-1 border-border bg-background placeholder:text-muted-foreground sm:flex-none"
+                    className="h-9 max-w-sm min-w-[12rem] flex-1 border-border bg-background placeholder:text-muted-foreground sm:flex-none"
                     data-testid="search-input"
                 />
 

--- a/resources/js/components/common/DataTableToolbar.tsx
+++ b/resources/js/components/common/DataTableToolbar.tsx
@@ -86,19 +86,17 @@ export function DataTableToolbar<T>({
 
     return (
         <>
-            {/* Toolbar */}
-            <div className="flex flex-col gap-4 py-4 lg:flex-row lg:items-center lg:justify-between">
-                <div className="flex w-full items-center">
-                    <Input
-                        placeholder={searchPlaceholder}
-                        value={searchValue}
-                        onChange={handleSearchChange}
-                        onKeyDown={handleSearchKeyDown}
-                        className="max-w-sm border-border bg-background placeholder:text-muted-foreground"
-                        data-testid="search-input"
-                    />
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 py-4">
+                <Input
+                    placeholder={searchPlaceholder}
+                    value={searchValue}
+                    onChange={handleSearchChange}
+                    onKeyDown={handleSearchKeyDown}
+                    className="h-9 min-w-[12rem] max-w-sm flex-1 border-border bg-background placeholder:text-muted-foreground sm:flex-none"
+                    data-testid="search-input"
+                />
+
+                <div className="ml-auto flex flex-wrap items-center gap-2">
                     <Button
                         variant="outline"
                         size="sm"

--- a/resources/js/components/common/PaginationControls.tsx
+++ b/resources/js/components/common/PaginationControls.tsx
@@ -35,9 +35,9 @@ export function PaginationControls({
     renderPageNumbers: () => React.ReactNode;
 }>) {
     return (
-        <div className="flex items-center justify-between py-4 text-sm text-muted-foreground">
-            <div className="flex items-center space-x-2">
-                <p>Rows per page</p>
+        <div className="flex flex-col gap-3 py-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                <p className="whitespace-nowrap">Rows per page</p>
                 <Select
                     value={String(pagination.per_page)}
                     onValueChange={onPageSizeChange}
@@ -53,13 +53,13 @@ export function PaginationControls({
                         <SelectItem value="100">100</SelectItem>
                     </SelectContent>
                 </Select>
-                <p>
+                <p className="text-foreground/80">
                     Showing {pagination.from} to {pagination.to} of{' '}
                     {pagination.total} entries
                 </p>
             </div>
 
-            <Pagination>
+            <Pagination className="mx-0 w-auto justify-end">
                 <PaginationContent>
                     <PaginationItem>
                         <PaginationPrevious

--- a/resources/js/components/employees/EmployeeColumns.tsx
+++ b/resources/js/components/employees/EmployeeColumns.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Badge } from '@/components/ui/badge';
-import { ColumnDef } from '@tanstack/react-table';
-
+import { statusBadgeVariant } from '@/lib/status-badge';
+import { Employee } from '@/types/entity';
 import {
     createActionsColumn,
     createEmailColumn,
@@ -11,8 +11,7 @@ import {
     createSortingHeader,
     createTextColumn,
 } from '@/utils/columns';
-
-import { Employee } from '@/types/entity';
+import { ColumnDef } from '@tanstack/react-table';
 
 const formatCurrency = (value: string | null | undefined): string => {
     if (!value) {
@@ -63,10 +62,9 @@ export const employeeColumns: ColumnDef<Employee>[] = [
                 return <div>-</div>;
             }
 
+            const label = status === 'intern' ? 'Intern' : 'Regular';
             return (
-                <Badge variant={status === 'intern' ? 'secondary' : 'default'}>
-                    {status === 'intern' ? 'Intern' : 'Regular'}
-                </Badge>
+                <Badge variant={statusBadgeVariant(status)}>{label}</Badge>
             );
         },
     },

--- a/resources/js/components/employees/EmployeeColumns.tsx
+++ b/resources/js/components/employees/EmployeeColumns.tsx
@@ -63,9 +63,7 @@ export const employeeColumns: ColumnDef<Employee>[] = [
             }
 
             const label = status === 'intern' ? 'Intern' : 'Regular';
-            return (
-                <Badge variant={statusBadgeVariant(status)}>{label}</Badge>
-            );
+            return <Badge variant={statusBadgeVariant(status)}>{label}</Badge>;
         },
     },
     createEmailColumn<Employee>({ accessorKey: 'email', label: 'Email' }),

--- a/resources/js/components/purchase-orders/PurchaseOrderColumns.tsx
+++ b/resources/js/components/purchase-orders/PurchaseOrderColumns.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge } from '@/components/ui/badge';
+import { formatStatusLabel, statusBadgeVariant } from '@/lib/status-badge';
 import { PurchaseOrder } from '@/types/purchase-order';
 import {
     createActionsColumn,
@@ -21,7 +22,9 @@ const renderWarehouseCell = ({ row }: { row: { original: PurchaseOrder } }) => (
 );
 
 const renderStatusCell = ({ row }: { row: { original: PurchaseOrder } }) => (
-    <Badge variant="outline">{row.original.status.replace('_', ' ')}</Badge>
+    <Badge variant={statusBadgeVariant(row.original.status)}>
+        {formatStatusLabel(row.original.status)}
+    </Badge>
 );
 
 export const purchaseOrderColumns: ColumnDef<PurchaseOrder>[] = [

--- a/resources/js/lib/status-badge.ts
+++ b/resources/js/lib/status-badge.ts
@@ -1,0 +1,49 @@
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+const NEUTRAL: BadgeVariant = 'outline';
+const POSITIVE: BadgeVariant = 'default';
+const MUTED: BadgeVariant = 'secondary';
+const DANGER: BadgeVariant = 'destructive';
+
+export function statusBadgeVariant(status: string | null | undefined): BadgeVariant {
+    if (!status) {
+        return NEUTRAL;
+    }
+
+    const key = status.toLowerCase().replace(/\s+/g, '_');
+
+    switch (key) {
+        case 'regular':
+        case 'active':
+        case 'confirmed':
+        case 'fully_received':
+        case 'closed':
+        case 'approved':
+        case 'posted':
+        case 'completed':
+            return POSITIVE;
+
+        case 'intern':
+        case 'draft':
+        case 'pending':
+        case 'pending_approval':
+        case 'partially_received':
+        case 'open':
+        case 'inactive':
+            return MUTED;
+
+        case 'rejected':
+        case 'cancelled':
+        case 'canceled':
+        case 'failed':
+        case 'overdue':
+            return DANGER;
+
+        default:
+            return NEUTRAL;
+    }
+}
+
+export function formatStatusLabel(status: string): string {
+    return status.replaceAll('_', ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/resources/js/lib/status-badge.ts
+++ b/resources/js/lib/status-badge.ts
@@ -5,7 +5,9 @@ const POSITIVE: BadgeVariant = 'default';
 const MUTED: BadgeVariant = 'secondary';
 const DANGER: BadgeVariant = 'destructive';
 
-export function statusBadgeVariant(status: string | null | undefined): BadgeVariant {
+export function statusBadgeVariant(
+    status: string | null | undefined,
+): BadgeVariant {
     if (!status) {
         return NEUTRAL;
     }

--- a/task.md
+++ b/task.md
@@ -1,64 +1,63 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-3 **PR #89** (CI: Quality/Pest/Sonar green; E2E 1 flaky Asset export create — unrelated to nav; failed job re-runned)  
-**Branch:** `fix/hf3-accounts-sidebar-active`  
-**Commits:** `d4b85789` (fix nav-active) · `32ed7582` (docs)  
-**PR:** https://github.com/gmedia/erp/pull/89  
-**Main tip (pre-merge):** `5e9abaa4` (HF-2 #88)  
+**Last updated:** 2026-08-09  
+**Current milestone:** Visual audit — **T1 DataTable shell v2** (in progress)  
+**Branch:** `feat/t1-datatable-shell-v2` (from main `bf5758d8`)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
 
 1. `task.md` (this)  
-2. `docs/visual-audit/BACKLOG.md` (T1–T5 + hotfixes)  
+2. `docs/visual-audit/BACKLOG.md`  
 3. `docs/visual-audit/FINDINGS.md`  
-4. `docs/visual-audit-plan.md` (program; stop-rule applied)
+4. `docs/visual-audit-plan.md`
 
 ## Done
 
-- Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86 merged)
-- **HF-1:** signed-balance KPI chrome (PR #87)
-- **HF-2:** sticky `actions` + horizontal scroll (PR #88)
-- **HF-3:** nav active via segment match + longest-href wins — **PR #89 open** (ACC-02 / SHELL-08)
+| ID | PR | Notes |
+|----|-----|--------|
+| Wave 0–1 | #86 | harness, plan, FINDINGS freeze |
+| HF-1 | #87 | signed KPI danger chrome |
+| HF-2 | #88 | sticky DataTable Actions + scroll |
+| HF-3 | #89 | nav segment match + longest-href (CoA) |
 
-## P0 remaining
+## What changed this session (T1 WIP)
 
-1. ~~FD-01 / HF-1~~  
-2. ~~EMP-01 / SHELL-07 / HF-2~~  
-3. ~~ACC-02 / SHELL-08 / HF-3~~ (merge PR #89)
+Shared chrome (not committed yet unless agent commits next):
 
-## Themes (user picks next after #89 merge)
+- `DataTableToolbar.tsx` — single flex-wrap row; search + `ml-auto` actions (SHELL-02/03)
+- `DataTableCore.tsx` — bulk selection bar + clear; `enableRowSelection`; table border wrap; pagination footer chrome; Button import (SHELL-10/11)
+- `PaginationControls.tsx` — responsive footer layout, stronger “Showing…” text (SHELL-11)
+- `lib/status-badge.ts` — shared `statusBadgeVariant` / `formatStatusLabel`
+- `EmployeeColumns.tsx` + `PurchaseOrderColumns.tsx` — semantic Badge variants (SHELL-06 / EMP-03 / PO-01)
+- `BACKLOG.md` — T1 in progress; T2 active-route partial (HF-3)
 
-| ID | Theme | Why next |
-|----|-------|----------|
-| **T1** | DataTable shell v2 | Highest blast radius: SHELL-02,03,06,07,10,11; EMP-*; PO-* (sticky Actions already in HF-2 — rest of shell) |
-| **T2** | Sidebar IA residual | Truncation + density only (active route done in HF-3) |
-| T3 | Page header contract | breadcrumb/title drift |
-| T4 | Dashboard & KPI | residual after HF-1 |
-| T5 | Sparse & report density | lower pri |
+Sticky Actions (HF-2) **unchanged**.
+
+## Themes remaining
+
+| ID | Pri | Theme | Status |
+|----|-----|-------|--------|
+| **T1** | P0–P1 | DataTable shell v2 | **WIP on branch** — finish verify + PR |
+| **T2** | P1 | Sidebar residual | Truncation + density only |
+| T3 | P1 | Page header contract | open |
+| T4 | P0–P1 | Dashboard & KPI residual | open |
+| T5 | P1–P2 | Sparse & report density | open |
 
 ## Do not
 
-- Mass-capture Wave 2 / remaining 78 routes  
-- Use default `playwright.config.ts` for visual (migrate:fresh)  
-- Redesign all 85 modules in one MR  
-- Commit local untracked `e2e/` junk  
-- Start T1/T2 on top of unmerged HF-3 branch (new branch from **main after merge**)
+- Wave 2 mass capture (~78 routes)  
+- Default `playwright.config.ts` for visual (`migrate:fresh`)  
+- Multi-theme one MR  
+- Commit untracked `e2e/`
 
 ## Recommended next
 
-1. **You:** review/merge **PR #89** (manual smoke: `/accounts` → CoA active, not Department)  
-2. **Agent after merge:** `rtk git checkout main && rtk git pull --ff-only` → branch `feat/t1-datatable-shell-v2` **or** `feat/t2-sidebar-density`  
-3. Prefer **T1** if capacity (shared table chrome); **T2** if small residual sidebar polish only  
-4. Optional light re-smoke 3–5 routes with visual-audit config only  
-
-## Files (HF-3 / PR #89)
-
-- `resources/js/lib/nav-active.ts`  
-- `resources/js/components/nav-main.tsx`  
-- `docs/visual-audit/BACKLOG.md`  
+1. `npm run types` (or sail) on touched TS  
+2. Optional light smoke: `/employees`, `/purchase-orders`, `/departments`  
+3. Commit + push + **one PR** for T1 only  
+4. Mark BACKLOG T1 done after merge  
 
 ## Continuation Prompt
 
-After PR #89 merge: pull main, start **T1 DataTable shell v2** (or T2 sidebar density if user prefers small). One theme = one branch = one MR. Do not Wave 2 mass capture.
+Finish T1: verify types/lint, commit on `feat/t1-datatable-shell-v2`, open MR with handoff. No Wave 2. Do not include `e2e/`.

--- a/task.md
+++ b/task.md
@@ -1,8 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-09  
-**Current milestone:** Visual audit — **T1 DataTable shell v2** (in progress)  
-**Branch:** `feat/t1-datatable-shell-v2` (from main `bf5758d8`)  
+**Current milestone:** Visual audit — **T1 DataTable shell v2** → **PR #90**  
+**Branch:** `feat/t1-datatable-shell-v2` @ `2b63e4d0` (from main `bf5758d8`)  
+**PR:** https://github.com/gmedia/erp/pull/90  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -21,18 +22,23 @@
 | HF-2 | #88 | sticky DataTable Actions + scroll |
 | HF-3 | #89 | nav segment match + longest-href (CoA) |
 
-## What changed this session (T1 WIP)
+## What changed this session (T1 → PR #90)
 
-Shared chrome (not committed yet unless agent commits next):
+Commits on branch (4 atomic):
 
-- `DataTableToolbar.tsx` — single flex-wrap row; search + `ml-auto` actions (SHELL-02/03)
-- `DataTableCore.tsx` — bulk selection bar + clear; `enableRowSelection`; table border wrap; pagination footer chrome; Button import (SHELL-10/11)
-- `PaginationControls.tsx` — responsive footer layout, stronger “Showing…” text (SHELL-11)
-- `lib/status-badge.ts` — shared `statusBadgeVariant` / `formatStatusLabel`
-- `EmployeeColumns.tsx` + `PurchaseOrderColumns.tsx` — semantic Badge variants (SHELL-06 / EMP-03 / PO-01)
-- `BACKLOG.md` — T1 in progress; T2 active-route partial (HF-3)
+1. `a2ad8777` feat: semantic status badges for employees and POs  
+2. `0c71b883` feat: single-row DataTable toolbar layout  
+3. `aec6123e` feat: DataTable bulk bar and pagination chrome  
+4. `2b63e4d0` docs: mark T1 DataTable shell in progress  
 
-Sticky Actions (HF-2) **unchanged**.
+- `DataTableToolbar.tsx` — single flex-wrap row (SHELL-02/03)  
+- `DataTableCore.tsx` — bulk bar + shell (SHELL-10/11)  
+- `PaginationControls.tsx` — footer chrome  
+- `lib/status-badge.ts` + EMP/PO columns — SHELL-06  
+- Sticky Actions (HF-2) **unchanged**  
+- `e2e/` left untracked  
+
+Validated: `tsc --noEmit` clean.
 
 ## Themes remaining
 
@@ -53,11 +59,11 @@ Sticky Actions (HF-2) **unchanged**.
 
 ## Recommended next
 
-1. `npm run types` (or sail) on touched TS  
-2. Optional light smoke: `/employees`, `/purchase-orders`, `/departments`  
-3. Commit + push + **one PR** for T1 only  
-4. Mark BACKLOG T1 done after merge  
+1. Review/merge **PR #90** when ready (do not block on local CI wait)  
+2. After merge: mark BACKLOG T1 done; pull main  
+3. Optional: T2 sidebar density **or** light visual re-smoke  
+4. **No** Wave 2 mass capture  
 
 ## Continuation Prompt
 
-Finish T1: verify types/lint, commit on `feat/t1-datatable-shell-v2`, open MR with handoff. No Wave 2. Do not include `e2e/`.
+PR #90 open for T1. Merge when green, update BACKLOG T1 → done, then T2 residual or re-smoke. No Wave 2.


### PR DESCRIPTION
## What was done
- Single-row DataTable toolbar (search + trailing actions) — SHELL-02/03
- Bulk selection bar with clear (`data-testid="bulk-selection-bar"`) — SHELL-10
- Table border shell + responsive pagination chrome — SHELL-11
- Shared `statusBadgeVariant` / `formatStatusLabel`; EMP + PO Status badges — SHELL-06
- BACKLOG/task.md handoff for T1
- Does **not** redo HF-2 sticky Actions

## Files changed
- `resources/js/lib/status-badge.ts` — new status → Badge variant map
- `resources/js/components/employees/EmployeeColumns.tsx` — semantic employment status
- `resources/js/components/purchase-orders/PurchaseOrderColumns.tsx` — semantic PO status
- `resources/js/components/common/DataTableToolbar.tsx` — single-row layout
- `resources/js/components/common/DataTableCore.tsx` — bulk bar, enableRowSelection, shell
- `resources/js/components/common/PaginationControls.tsx` — footer chrome
- `docs/visual-audit/BACKLOG.md`, `task.md` — T1 tracking

## Verification
- [x] `tsc --noEmit` clean
- [ ] Optional smoke: `/employees`, `/purchase-orders`, `/departments`
- [ ] CI (do not block merge wait locally)

## Next steps
- Merge when green; mark BACKLOG T1 done
- Optional T2 sidebar density (truncation only; active route = HF-3)
- **No** Wave 2 mass capture