### PR TITLE
feat: sidebar density and truncation tooltips (T2)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -1,6 +1,6 @@
 # Visual Audit — Backlog
 
-**Last updated:** 2026-08-08  
+**Last updated:** 2026-08-10  
 **Source:** multimodal-looker Wave 0–1  
 **Policy:** No Wave 2 mass capture until T1–T3 land or shared-shell re-reviewed
 
@@ -8,8 +8,8 @@
 
 | ID | Pri | Theme | Scope | Status | Notes |
 |----|-----|-------|-------|--------|-------|
-| T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | open | Single toolbar row; sticky Actions; semantic Status; scroll discipline; bulk bar optional. Fixes SHELL-02,03,06,07,10,11; EMP-*; PO-* |
-| T2 | P1 | Sidebar IA & active | AppLayout / nav | open | Truncation strategy; **correct active route**; density. SHELL-01,08,09; ACC-02 |
+| T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | in progress | PR #90 — shell v2; sticky Actions already HF-2 |
+| T2 | P1 | Sidebar IA & active | AppLayout / nav | in progress | Density + truncation tooltips; active route = HF-3. SHELL-01,09 residual; SHELL-08/ACC-02 done HF-3 |
 | T3 | P1 | Page header contract | Layout primitive | open | breadcrumb + title + desc + actions; no double title / bare breadcrumb drift. SHELL-04; ACC-01; RSM-02; FD-06 |
 | T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD-01..03; DASH-*; BS-02 |
 | T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report H1 parity. SHELL-05; RSM-01 |
@@ -39,6 +39,6 @@
 
 ## Next agent action
 
-1. Merge **PR #89** (HF-3) if still open  
-2. User picks **T1** DataTable shell v2 (preferred) **or** **T2** sidebar density  
+1. Merge **PR #90** (T1) and **T2** sidebar density PR when ready  
+2. Then **T3** page header contract (or T4/T5)  
 3. Do **not** mass Wave 2 capture

--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -9,7 +9,7 @@
 | ID | Pri | Theme | Scope | Status | Notes |
 |----|-----|-------|-------|--------|-------|
 | T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | in progress | PR #90 — shell v2; sticky Actions already HF-2 |
-| T2 | P1 | Sidebar IA & active | AppLayout / nav | in progress | Density + truncation tooltips; active route = HF-3. SHELL-01,09 residual; SHELL-08/ACC-02 done HF-3 |
+| T2 | P1 | Sidebar IA & active | AppLayout / nav | in progress | **PR #91** — density + truncation tooltips; active route = HF-3. SHELL-01,09 residual; SHELL-08/ACC-02 done HF-3 |
 | T3 | P1 | Page header contract | Layout primitive | open | breadcrumb + title + desc + actions; no double title / bare breadcrumb drift. SHELL-04; ACC-01; RSM-02; FD-06 |
 | T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD-01..03; DASH-*; BS-02 |
 | T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report H1 parity. SHELL-05; RSM-01 |
@@ -39,6 +39,6 @@
 
 ## Next agent action
 
-1. Merge **PR #90** (T1) and **T2** sidebar density PR when ready  
+1. Merge **PR #90** (T1) and **PR #91** (T2) when ready  
 2. Then **T3** page header contract (or T4/T5)  
 3. Do **not** mass Wave 2 capture

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -13,6 +13,11 @@ import {
     SidebarMenuSubButton,
     SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { useAuth } from '@/contexts/auth-context';
 import { useTranslation } from '@/contexts/i18n-context';
 import { isNavHrefActive, pathMatchesNavHref } from '@/lib/nav-active';
@@ -70,11 +75,14 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                             <SidebarMenuItem>
                                 <CollapsibleTrigger asChild>
                                     <SidebarMenuButton
+                                        size="sm"
                                         tooltip={{ children: item.title }}
                                     >
                                         {item.icon && <item.icon />}
-                                        <span>{item.title}</span>
-                                        <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                                        <span className="min-w-0 flex-1 truncate">
+                                            {item.title}
+                                        </span>
+                                        <ChevronRight className="ml-auto size-4 shrink-0 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                                     </SidebarMenuButton>
                                 </CollapsibleTrigger>
                                 <CollapsibleContent>
@@ -83,36 +91,53 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                                             <SidebarMenuSubItem
                                                 key={subItem.title}
                                             >
-                                                <SidebarMenuSubButton
-                                                    asChild
-                                                    isActive={isNavHrefActive(
-                                                        location.pathname,
-                                                        subItem.href,
-                                                        allHrefs,
-                                                    )}
-                                                >
-                                                    <Link to={subItem.href}>
-                                                        {subItem.icon && (
-                                                            <subItem.icon />
-                                                        )}
-                                                        <span>
-                                                            {subItem.title}
-                                                        </span>
-                                                        {subItem.href ===
-                                                            '/my-approvals' &&
-                                                            pendingCount >
-                                                                0 && (
-                                                                <Badge
-                                                                    variant="destructive"
-                                                                    className="ml-auto flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full px-1 text-[10px]"
-                                                                >
-                                                                    {
-                                                                        pendingCount
-                                                                    }
-                                                                </Badge>
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <SidebarMenuSubButton
+                                                            asChild
+                                                            size="sm"
+                                                            isActive={isNavHrefActive(
+                                                                location.pathname,
+                                                                subItem.href,
+                                                                allHrefs,
                                                             )}
-                                                    </Link>
-                                                </SidebarMenuSubButton>
+                                                        >
+                                                            <Link
+                                                                to={
+                                                                    subItem.href
+                                                                }
+                                                            >
+                                                                {subItem.icon && (
+                                                                    <subItem.icon />
+                                                                )}
+                                                                <span className="min-w-0 flex-1 truncate">
+                                                                    {
+                                                                        subItem.title
+                                                                    }
+                                                                </span>
+                                                                {subItem.href ===
+                                                                    '/my-approvals' &&
+                                                                    pendingCount >
+                                                                        0 && (
+                                                                        <Badge
+                                                                            variant="destructive"
+                                                                            className="ml-auto flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full px-1 text-[10px]"
+                                                                        >
+                                                                            {
+                                                                                pendingCount
+                                                                            }
+                                                                        </Badge>
+                                                                    )}
+                                                            </Link>
+                                                        </SidebarMenuSubButton>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent
+                                                        side="right"
+                                                        align="center"
+                                                    >
+                                                        {subItem.title}
+                                                    </TooltipContent>
+                                                </Tooltip>
                                             </SidebarMenuSubItem>
                                         ))}
                                     </SidebarMenuSub>
@@ -123,6 +148,7 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                         <SidebarMenuItem key={item.title}>
                             <SidebarMenuButton
                                 asChild
+                                size="sm"
                                 isActive={isNavHrefActive(
                                     location.pathname,
                                     item.href,
@@ -132,7 +158,9 @@ export function NavMain({ items = [] }: Readonly<{ items: NavItem[] }>) {
                             >
                                 <Link to={item.href}>
                                     {item.icon && <item.icon />}
-                                    <span>{item.title}</span>
+                                    <span className="min-w-0 flex-1 truncate">
+                                        {item.title}
+                                    </span>
                                     {item.href === '/my-approvals' &&
                                         pendingCount > 0 && (
                                             <Badge

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -25,7 +25,7 @@ import {
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
-const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH = "17.5rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
@@ -535,7 +535,7 @@ function SidebarMenuButton({
   } & VariantProps<typeof sidebarMenuButtonVariants>
 >) {
   const Comp = asChild ? Slot : "button"
-  const { isMobile, state } = useSidebar()
+  const { isMobile } = useSidebar()
 
   const button = (
     <Comp
@@ -564,7 +564,7 @@ function SidebarMenuButton({
       <TooltipContent
         side="right"
         align="center"
-        hidden={state !== "collapsed" || isMobile}
+        hidden={isMobile}
         {...tooltip}
       />
     </Tooltip>
@@ -681,7 +681,7 @@ function SidebarMenuSub({
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-0.5 border-l px-2 py-0.5",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -726,10 +726,10 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
-        size === "sm" && "text-xs",
-        size === "md" && "text-sm",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-6.5 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-3.5 [&>svg]:shrink-0",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[active=true]:shadow-[inset_2px_0_0_0_hsl(var(--sidebar-primary))]",
+        size === "sm" && "h-6 text-xs",
+        size === "md" && "h-6.5 text-sm",
         "group-data-[collapsible=icon]:hidden",
         className
       )}

--- a/task.md
+++ b/task.md
@@ -1,64 +1,52 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-3 **PR #89** (CI: Quality/Pest/Sonar green; E2E 1 flaky Asset export create — unrelated to nav; failed job re-runned)  
-**Branch:** `fix/hf3-accounts-sidebar-active`  
-**Commits:** `d4b85789` (fix nav-active) · `32ed7582` (docs)  
-**PR:** https://github.com/gmedia/erp/pull/89  
-**Main tip (pre-merge):** `5e9abaa4` (HF-2 #88)  
+**Last updated:** 2026-08-10  
+**Current milestone:** Visual audit — **T2** sidebar density (parallel to **T1 PR #90**)  
+**Branch:** `feat/t2-sidebar-density`  
+**Base main:** `bf5758d8` (HF-1–3 merged)  
+**T1 PR (separate):** https://github.com/gmedia/erp/pull/90  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
 
 1. `task.md` (this)  
-2. `docs/visual-audit/BACKLOG.md` (T1–T5 + hotfixes)  
+2. `docs/visual-audit/BACKLOG.md`  
 3. `docs/visual-audit/FINDINGS.md`  
-4. `docs/visual-audit-plan.md` (program; stop-rule applied)
+4. `docs/visual-audit-plan.md`
 
 ## Done
 
-- Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86 merged)
-- **HF-1:** signed-balance KPI chrome (PR #87)
-- **HF-2:** sticky `actions` + horizontal scroll (PR #88)
-- **HF-3:** nav active via segment match + longest-href wins — **PR #89 open** (ACC-02 / SHELL-08)
+- Wave 0–1 + HF-1 #87 · HF-2 #88 · HF-3 #89 on main  
+- **T1** DataTable shell v2 — **PR #90** open (`feat/t1-datatable-shell-v2`)  
+- **T2** (this branch): sidebar width 17.5rem; denser subnav; stronger active child (font + inset bar); label truncate + tooltips while expanded (not only icon mode)
 
-## P0 remaining
+## Themes
 
-1. ~~FD-01 / HF-1~~  
-2. ~~EMP-01 / SHELL-07 / HF-2~~  
-3. ~~ACC-02 / SHELL-08 / HF-3~~ (merge PR #89)
-
-## Themes (user picks next after #89 merge)
-
-| ID | Theme | Why next |
-|----|-------|----------|
-| **T1** | DataTable shell v2 | Highest blast radius: SHELL-02,03,06,07,10,11; EMP-*; PO-* (sticky Actions already in HF-2 — rest of shell) |
-| **T2** | Sidebar IA residual | Truncation + density only (active route done in HF-3) |
-| T3 | Page header contract | breadcrumb/title drift |
-| T4 | Dashboard & KPI | residual after HF-1 |
-| T5 | Sparse & report density | lower pri |
+| ID | Status |
+|----|--------|
+| T1 | PR #90 open |
+| **T2** | **in progress** this branch |
+| T3–T5 | open |
 
 ## Do not
 
-- Mass-capture Wave 2 / remaining 78 routes  
-- Use default `playwright.config.ts` for visual (migrate:fresh)  
-- Redesign all 85 modules in one MR  
-- Commit local untracked `e2e/` junk  
-- Start T1/T2 on top of unmerged HF-3 branch (new branch from **main after merge**)
+- Mass Wave 2 capture  
+- Default playwright visual (`migrate:fresh`)  
+- Commit untracked `e2e/`  
+- Wait on CI; one theme = one branch = one MR  
 
-## Recommended next
+## Files (T2)
 
-1. **You:** review/merge **PR #89** (manual smoke: `/accounts` → CoA active, not Department)  
-2. **Agent after merge:** `rtk git checkout main && rtk git pull --ff-only` → branch `feat/t1-datatable-shell-v2` **or** `feat/t2-sidebar-density`  
-3. Prefer **T1** if capacity (shared table chrome); **T2** if small residual sidebar polish only  
-4. Optional light re-smoke 3–5 routes with visual-audit config only  
-
-## Files (HF-3 / PR #89)
-
-- `resources/js/lib/nav-active.ts`  
+- `resources/js/components/ui/sidebar.tsx`  
 - `resources/js/components/nav-main.tsx`  
 - `docs/visual-audit/BACKLOG.md`  
 
+## Recommended next
+
+1. Finish commit + push + `gh pr create` for T2  
+2. Human: merge #90 then T2 (or reverse — low conflict risk)  
+3. Next theme: **T3** page header  
+
 ## Continuation Prompt
 
-After PR #89 merge: pull main, start **T1 DataTable shell v2** (or T2 sidebar density if user prefers small). One theme = one branch = one MR. Do not Wave 2 mass capture.
+Ship T2 PR if not open; after merge pull main; start T3 page header contract. No Wave 2 mass capture.

--- a/task.md
+++ b/task.md
@@ -1,10 +1,11 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-10  
-**Current milestone:** Visual audit — **T2** sidebar density (parallel to **T1 PR #90**)  
-**Branch:** `feat/t2-sidebar-density`  
+**Current milestone:** Visual audit — **T2** shipped as PR (parallel to **T1**)  
+**Branch:** `feat/t2-sidebar-density` @ `9847058c`  
 **Base main:** `bf5758d8` (HF-1–3 merged)  
-**T1 PR (separate):** https://github.com/gmedia/erp/pull/90  
+**T1 PR:** https://github.com/gmedia/erp/pull/90  
+**T2 PR:** https://github.com/gmedia/erp/pull/91  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -18,14 +19,14 @@
 
 - Wave 0–1 + HF-1 #87 · HF-2 #88 · HF-3 #89 on main  
 - **T1** DataTable shell v2 — **PR #90** open (`feat/t1-datatable-shell-v2`)  
-- **T2** (this branch): sidebar width 17.5rem; denser subnav; stronger active child (font + inset bar); label truncate + tooltips while expanded (not only icon mode)
+- **T2** sidebar density/truncation — **PR #91** open (`feat/t2-sidebar-density`)
 
 ## Themes
 
 | ID | Status |
 |----|--------|
 | T1 | PR #90 open |
-| **T2** | **in progress** this branch |
+| **T2** | PR #91 open |
 | T3–T5 | open |
 
 ## Do not
@@ -43,10 +44,10 @@
 
 ## Recommended next
 
-1. Finish commit + push + `gh pr create` for T2  
-2. Human: merge #90 then T2 (or reverse — low conflict risk)  
-3. Next theme: **T3** page header  
+1. Human: merge #90 and/or #91 (order flexible; low conflict risk)  
+2. After merges: pull main; mark BACKLOG T1/T2 done  
+3. Next theme: **T3** page header contract  
 
 ## Continuation Prompt
 
-Ship T2 PR if not open; after merge pull main; start T3 page header contract. No Wave 2 mass capture.
+After #90/#91 merge: pull main, update BACKLOG, branch `feat/t3-page-header` for page header contract. No Wave 2 mass capture. Do not wait on CI.


### PR DESCRIPTION
## What was done
- Wider sidebar rail (`16rem` → `17.5rem`) for longer labels
- Denser subnav rows and icons; stronger active child (medium weight + inset primary bar)
- Tooltips while expanded (not only icon-collapsed) + `NavMain` `size="sm"`, truncate, nested tooltips
- BACKLOG/task handoff for T2 in progress

## Files changed
- `resources/js/components/ui/sidebar.tsx` — width, density, active chrome, tooltip visibility
- `resources/js/components/nav-main.tsx` — sm buttons, truncate, subitem tooltips
- `docs/visual-audit/BACKLOG.md`, `task.md` — handoff

## Verification
- [x] `npx tsc --noEmit` clean
- [ ] visual smoke of nested menus (optional)
- [ ] CI (do not wait)

## Next steps
- Merge independently of #90 (low conflict risk)
- After merge: mark BACKLOG T2 done; next theme **T3** page header
- Wave 2 mass capture still frozen

## Handoff
- Addresses visual-audit SHELL-01 / SHELL-09 residual (active route already HF-3)
- Does not touch DataTable / T1 branch