### PR TITLE
feat: page header contract (T3 visual audit)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -1,6 +1,6 @@
 # Visual Audit — Backlog
 
-**Last updated:** 2026-08-08  
+**Last updated:** 2026-08-10  
 **Source:** multimodal-looker Wave 0–1  
 **Policy:** No Wave 2 mass capture until T1–T3 land or shared-shell re-reviewed
 
@@ -8,11 +8,11 @@
 
 | ID | Pri | Theme | Scope | Status | Notes |
 |----|-----|-------|-------|--------|-------|
-| T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | open | Single toolbar row; sticky Actions; semantic Status; scroll discipline; bulk bar optional. Fixes SHELL-02,03,06,07,10,11; EMP-*; PO-* |
-| T2 | P1 | Sidebar IA & active | AppLayout / nav | open | Truncation strategy; **correct active route**; density. SHELL-01,08,09; ACC-02 |
-| T3 | P1 | Page header contract | Layout primitive | open | breadcrumb + title + desc + actions; no double title / bare breadcrumb drift. SHELL-04; ACC-01; RSM-02; FD-06 |
-| T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD-01..03; DASH-*; BS-02 |
-| T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report H1 parity. SHELL-05; RSM-01 |
+| T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | open (PR #90) | Single toolbar row; sticky Actions; semantic Status; scroll discipline; bulk bar optional. Fixes SHELL-02,03,06,07,10,11; EMP-*; PO-* |
+| T2 | P1 | Sidebar IA & active | AppLayout / nav | open (PR #91) | Truncation strategy; density residual after HF-3. SHELL-01,08,09 |
+| T3 | P1 | Page header contract | Layout primitive | in PR (`feat/t3-page-header`) | Shared `PageHeader`; Dashboard/Report/Financial shells; accounts ACC-01; stock-movements RSM-02; FD-06 title. SHELL-04 |
+| T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD-01..03 residual; DASH-*; BS-02 |
+| T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report density. SHELL-05; RSM-01 |
 
 ## Hotfixes (can ship before full T1)
 
@@ -39,6 +39,6 @@
 
 ## Next agent action
 
-1. Merge **PR #89** (HF-3) if still open  
-2. User picks **T1** DataTable shell v2 (preferred) **or** **T2** sidebar density  
-3. Do **not** mass Wave 2 capture
+1. Human: merge **PR #90** (T1), **#91** (T2), and T3 PR when green — order flexible  
+2. After merges: pull main; mark T1–T3 done in this table  
+3. Do **not** mass Wave 2 capture; next theme **T4** or residual polish

--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -10,7 +10,7 @@
 |----|-----|-------|-------|--------|-------|
 | T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | open (PR #90) | Single toolbar row; sticky Actions; semantic Status; scroll discipline; bulk bar optional. Fixes SHELL-02,03,06,07,10,11; EMP-*; PO-* |
 | T2 | P1 | Sidebar IA & active | AppLayout / nav | open (PR #91) | Truncation strategy; density residual after HF-3. SHELL-01,08,09 |
-| T3 | P1 | Page header contract | Layout primitive | in PR (`feat/t3-page-header`) | Shared `PageHeader`; Dashboard/Report/Financial shells; accounts ACC-01; stock-movements RSM-02; FD-06 title. SHELL-04 |
+| T3 | P1 | Page header contract | Layout primitive | open (PR #92) | Shared `PageHeader`; Dashboard/Report/Financial shells; accounts ACC-01; stock-movements RSM-02; FD-06 title. SHELL-04 |
 | T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD-01..03 residual; DASH-*; BS-02 |
 | T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report density. SHELL-05; RSM-01 |
 

--- a/resources/js/components/common/DashboardPageShell.tsx
+++ b/resources/js/components/common/DashboardPageShell.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from '@/components/common/PageHeader';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/app-layout';
@@ -40,31 +41,27 @@ export default function DashboardPageShell({
                 <title>{title}</title>
             </Helmet>
             <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 p-4 pb-12 md:p-6">
-                <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
-                    <div>
-                        <h1 className="text-2xl font-bold tracking-tight text-foreground">
-                            {heading}
-                        </h1>
-                        <p className="mt-1 text-muted-foreground">
-                            {description}
-                        </p>
-                    </div>
-                    <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-                        {toolbar}
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => refetch()}
-                            disabled={isLoading}
-                            className="flex items-center gap-2"
-                        >
-                            <RefreshCw
-                                className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`}
-                            />
-                            Refresh Data
-                        </Button>
-                    </div>
-                </div>
+                <PageHeader
+                    title={heading}
+                    description={description}
+                    actions={
+                        <>
+                            {toolbar}
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => refetch()}
+                                disabled={isLoading}
+                                className="flex items-center gap-2"
+                            >
+                                <RefreshCw
+                                    className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`}
+                                />
+                                Refresh Data
+                            </Button>
+                        </>
+                    }
+                />
 
                 {isError && (
                     <Alert variant="destructive" className="mb-4">

--- a/resources/js/components/common/PageHeader.tsx
+++ b/resources/js/components/common/PageHeader.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type PageHeaderProps = {
+    title: string;
+    description?: string;
+    actions?: ReactNode;
+    className?: string;
+    meta?: ReactNode;
+};
+
+export function PageHeader({
+    title,
+    description,
+    actions,
+    className,
+    meta,
+}: Readonly<PageHeaderProps>) {
+    return (
+        <div
+            className={cn(
+                'flex flex-col items-start justify-between gap-4 md:flex-row md:items-center',
+                className,
+            )}
+        >
+            <div className="min-w-0 space-y-1">
+                <h1 className="text-2xl font-bold tracking-tight text-foreground">
+                    {title}
+                </h1>
+                {description ? (
+                    <p className="text-sm text-muted-foreground md:text-base">
+                        {description}
+                    </p>
+                ) : null}
+                {meta ? (
+                    <div className="text-sm text-muted-foreground">{meta}</div>
+                ) : null}
+            </div>
+            {actions ? (
+                <div className="flex w-full flex-col items-stretch gap-3 sm:w-auto sm:flex-row sm:items-center">
+                    {actions}
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+export default PageHeader;

--- a/resources/js/components/common/PageHeader.tsx
+++ b/resources/js/components/common/PageHeader.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
 
 export type PageHeaderProps = {
     title: string;

--- a/resources/js/components/common/ReportDataTablePage.tsx
+++ b/resources/js/components/common/ReportDataTablePage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DataTable } from '@/components/common/DataTableCore';
+import { PageHeader } from '@/components/common/PageHeader';
 import type { FieldDescriptor } from '@/components/common/filters';
 import type { FilterState } from '@/hooks/useCrudFilters';
 import { useCrudFilters } from '@/hooks/useCrudFilters';
@@ -38,6 +39,7 @@ type ReportDataTablePageProps<
     TFilters extends FilterState = FilterState,
 > = {
     title: string;
+    description?: string;
     breadcrumbs: BreadcrumbItem[];
     columns: ColumnDef<TData>[];
     filterFields: FieldDescriptor[];
@@ -55,6 +57,7 @@ export function ReportDataTablePage<
     TFilters extends FilterState = FilterState,
 >({
     title,
+    description,
     breadcrumbs,
     columns,
     filterFields,
@@ -93,6 +96,7 @@ export function ReportDataTablePage<
             </Helmet>
             <AppLayout breadcrumbs={breadcrumbs}>
                 <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                    <PageHeader title={title} description={description} />
                     <div className="rounded-lg bg-white">
                         <DataTable
                             columns={columns}

--- a/resources/js/components/reports/financial/FinancialReportPageShell.tsx
+++ b/resources/js/components/reports/financial/FinancialReportPageShell.tsx
@@ -1,4 +1,5 @@
 import { AsyncSelect } from '@/components/common/AsyncSelect';
+import { PageHeader } from '@/components/common/PageHeader';
 import { Badge } from '@/components/ui/badge';
 import {
     Select,
@@ -295,55 +296,21 @@ export function FinancialReportPageShell({
     } else {
         content = (
             <div className="flex h-full flex-1 flex-col gap-4 p-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex flex-col gap-1">
-                        <h1 className="text-2xl font-bold tracking-tight">
-                            {title}
-                        </h1>
-                        {headerMeta}
-                    </div>
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-                        <div className="w-full sm:w-[220px]">
-                            <Select
-                                value={String(selectedYearId)}
-                                onValueChange={onYearChange}
-                            >
-                                <SelectTrigger>
-                                    <SelectValue placeholder="Fiscal Year" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {fiscalYears.map((fiscalYear) => (
-                                        <SelectItem
-                                            key={fiscalYear.id}
-                                            value={String(fiscalYear.id)}
-                                        >
-                                            {fiscalYear.name}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                        <div className="w-full sm:w-[220px]">
-                            <Select
-                                value={
-                                    comparisonYearId
-                                        ? String(comparisonYearId)
-                                        : 'none'
-                                }
-                                onValueChange={onComparisonChange}
-                            >
-                                <SelectTrigger>
-                                    <SelectValue placeholder="Compare With..." />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="none">None</SelectItem>
-                                    {fiscalYears
-                                        .filter(
-                                            (fiscalYear) =>
-                                                fiscalYear.id !==
-                                                selectedYearId,
-                                        )
-                                        .map((fiscalYear) => (
+                <PageHeader
+                    title={title}
+                    meta={headerMeta}
+                    actions={
+                        <>
+                            <div className="w-full sm:w-[220px]">
+                                <Select
+                                    value={String(selectedYearId)}
+                                    onValueChange={onYearChange}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Fiscal Year" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {fiscalYears.map((fiscalYear) => (
                                             <SelectItem
                                                 key={fiscalYear.id}
                                                 value={String(fiscalYear.id)}
@@ -351,23 +318,59 @@ export function FinancialReportPageShell({
                                                 {fiscalYear.name}
                                             </SelectItem>
                                         ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                        {onBranchChange && (
-                            <div className="w-full sm:w-[200px]">
-                                <AsyncSelect
-                                    url="/api/branches"
-                                    placeholder="All Branches"
-                                    value={branchId ?? ''}
-                                    onValueChange={onBranchChange}
-                                    label="Branch"
-                                />
+                                    </SelectContent>
+                                </Select>
                             </div>
-                        )}
-                        {headerActions}
-                    </div>
-                </div>
+                            <div className="w-full sm:w-[220px]">
+                                <Select
+                                    value={
+                                        comparisonYearId
+                                            ? String(comparisonYearId)
+                                            : 'none'
+                                    }
+                                    onValueChange={onComparisonChange}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Compare With..." />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="none">
+                                            None
+                                        </SelectItem>
+                                        {fiscalYears
+                                            .filter(
+                                                (fiscalYear) =>
+                                                    fiscalYear.id !==
+                                                    selectedYearId,
+                                            )
+                                            .map((fiscalYear) => (
+                                                <SelectItem
+                                                    key={fiscalYear.id}
+                                                    value={String(
+                                                        fiscalYear.id,
+                                                    )}
+                                                >
+                                                    {fiscalYear.name}
+                                                </SelectItem>
+                                            ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            {onBranchChange && (
+                                <div className="w-full sm:w-[200px]">
+                                    <AsyncSelect
+                                        url="/api/branches"
+                                        placeholder="All Branches"
+                                        value={branchId ?? ''}
+                                        onValueChange={onBranchChange}
+                                        label="Branch"
+                                    />
+                                </div>
+                            )}
+                            {headerActions}
+                        </>
+                    }
+                />
 
                 {children}
             </div>

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -10,6 +10,7 @@ import {
     type AccountFormData,
 } from '@/components/accounts/AccountForm';
 import { AccountTree } from '@/components/accounts/AccountTree';
+import { PageHeader } from '@/components/common/PageHeader';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -38,10 +39,8 @@ import axios from 'axios';
 import { toast } from 'sonner';
 
 const breadcrumbs: BreadcrumbItem[] = [
-    {
-        title: 'Chart of Accounts',
-        href: '/accounts',
-    },
+    { title: 'Master Data', href: '#' },
+    { title: 'Chart of Accounts', href: '/accounts' },
 ];
 
 export default function AccountIndex() {
@@ -206,50 +205,45 @@ export default function AccountIndex() {
             </Helmet>
 
             <div className="flex h-full flex-col space-y-6 p-4">
-                <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
-                    <div>
-                        <h1 className="text-2xl font-bold tracking-tight">
-                            Chart of Accounts
-                        </h1>
-                        <p className="text-muted-foreground">
-                            Manage your hierarchical accounts and COA versions.
-                        </p>
-                    </div>
+                <PageHeader
+                    title="Chart of Accounts"
+                    description="Manage hierarchical accounts and COA versions."
+                    actions={
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Select
+                                value={selectedVersionId || ''}
+                                onValueChange={setSelectedVersionId}
+                            >
+                                <SelectTrigger className="w-[320px]">
+                                    <SelectValue placeholder="Select COA Version" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {coaVersions.map((v) => (
+                                        <SelectItem
+                                            key={v.id}
+                                            value={v.id.toString()}
+                                        >
+                                            {v.name} ({v.status})
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
 
-                    <div className="flex items-center gap-2">
-                        <Select
-                            value={selectedVersionId || ''}
-                            onValueChange={setSelectedVersionId}
-                        >
-                            <SelectTrigger className="w-[320px]">
-                                <SelectValue placeholder="Select COA Version" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {coaVersions.map((v) => (
-                                    <SelectItem
-                                        key={v.id}
-                                        value={v.id.toString()}
-                                    >
-                                        {v.name} ({v.status})
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-
-                        <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={handleExport}
-                            disabled={!selectedVersionId || exporting}
-                        >
-                            {exporting ? (
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                            ) : (
-                                <Download className="h-4 w-4" />
-                            )}
-                        </Button>
-                    </div>
-                </div>
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={handleExport}
+                                disabled={!selectedVersionId || exporting}
+                            >
+                                {exporting ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                    <Download className="h-4 w-4" />
+                                )}
+                            </Button>
+                        </div>
+                    }
+                />
 
                 <div className="flex max-w-md items-center gap-2">
                     <div className="relative flex-1">

--- a/resources/js/pages/financial-dashboard/index.tsx
+++ b/resources/js/pages/financial-dashboard/index.tsx
@@ -13,7 +13,7 @@ import { useFinancialDashboard } from '../../hooks/useFinancialDashboard';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
-        title: 'Financial Dashboard',
+        title: 'Financial Overview',
         href: '/financial-dashboard',
     },
 ];
@@ -71,7 +71,7 @@ export default function FinancialDashboard() {
 
     return (
         <DashboardPageShell
-            title="Financial Dashboard"
+            title="Financial Overview"
             heading="Financial Overview"
             description="Monitor key financial metrics, cash flow, and expense trends."
             breadcrumbs={breadcrumbs}

--- a/resources/js/pages/stock-movements/index.tsx
+++ b/resources/js/pages/stock-movements/index.tsx
@@ -14,6 +14,7 @@ export default function StockMovementsPage() {
     return (
         <ReportDataTablePage<StockMovementItem>
             title="Stock Movements"
+            description="Digital stock card — product movements by warehouse, type, and period."
             breadcrumbs={[
                 { title: 'Inventory', href: '#' },
                 { title: 'Stock Movements', href: '/stock-movements' },

--- a/task.md
+++ b/task.md
@@ -1,11 +1,10 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-08  
-**Current milestone:** Visual audit — HF-3 **PR #89** (CI: Quality/Pest/Sonar green; E2E 1 flaky Asset export create — unrelated to nav; failed job re-runned)  
-**Branch:** `fix/hf3-accounts-sidebar-active`  
-**Commits:** `d4b85789` (fix nav-active) · `32ed7582` (docs)  
-**PR:** https://github.com/gmedia/erp/pull/89  
-**Main tip (pre-merge):** `5e9abaa4` (HF-2 #88)  
+**Last updated:** 2026-08-10  
+**Current milestone:** Visual audit — **T3 page header** on `feat/t3-page-header` (ship PR; parallel with #90/#91)  
+**Branch:** `feat/t3-page-header`  
+**Base main tip:** `bf5758d8` (HF-1–3 landed)  
+**Open PRs:** T1 [#90](https://github.com/gmedia/erp/pull/90) · T2 [#91](https://github.com/gmedia/erp/pull/91) · T3 (this branch)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -17,26 +16,24 @@
 
 ## Done
 
-- Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86 merged)
-- **HF-1:** signed-balance KPI chrome (PR #87)
-- **HF-2:** sticky `actions` + horizontal scroll (PR #88)
-- **HF-3:** nav active via segment match + longest-href wins — **PR #89 open** (ACC-02 / SHELL-08)
+- Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86)
+- **HF-1–3** on main (`bf5758d8`)
+- **T1** DataTable shell v2 — PR #90 open  
+- **T2** Sidebar density — PR #91 open  
+- **T3** (this branch):
+  - `PageHeader` primitive (`title` / `description` / `actions` / `meta`)
+  - Wired: `DashboardPageShell`, `ReportDataTablePage` (+ optional `description`), `FinancialReportPageShell`
+  - Pages: stock-movements (RSM-02 description), financial-dashboard (FD-06 “Financial Overview” crumb/title), accounts (ACC-01: crumb Master Data → CoA; single `PageHeader` H1)
 
-## P0 remaining
+## Themes status
 
-1. ~~FD-01 / HF-1~~  
-2. ~~EMP-01 / SHELL-07 / HF-2~~  
-3. ~~ACC-02 / SHELL-08 / HF-3~~ (merge PR #89)
-
-## Themes (user picks next after #89 merge)
-
-| ID | Theme | Why next |
-|----|-------|----------|
-| **T1** | DataTable shell v2 | Highest blast radius: SHELL-02,03,06,07,10,11; EMP-*; PO-* (sticky Actions already in HF-2 — rest of shell) |
-| **T2** | Sidebar IA residual | Truncation + density only (active route done in HF-3) |
-| T3 | Page header contract | breadcrumb/title drift |
-| T4 | Dashboard & KPI | residual after HF-1 |
-| T5 | Sparse & report density | lower pri |
+| ID | Theme | Status |
+|----|-------|--------|
+| T1 | DataTable shell v2 | PR #90 |
+| T2 | Sidebar IA residual | PR #91 |
+| **T3** | Page header contract | **this branch → PR** |
+| T4 | Dashboard & KPI | open after T1–T3 |
+| T5 | Sparse & report density | open |
 
 ## Do not
 
@@ -44,21 +41,26 @@
 - Use default `playwright.config.ts` for visual (migrate:fresh)  
 - Redesign all 85 modules in one MR  
 - Commit local untracked `e2e/` junk  
-- Start T1/T2 on top of unmerged HF-3 branch (new branch from **main after merge**)
+- Wait on CI for #90/#91 (AGENTS: never wait for CI)
 
 ## Recommended next
 
-1. **You:** review/merge **PR #89** (manual smoke: `/accounts` → CoA active, not Department)  
-2. **Agent after merge:** `rtk git checkout main && rtk git pull --ff-only` → branch `feat/t1-datatable-shell-v2` **or** `feat/t2-sidebar-density`  
-3. Prefer **T1** if capacity (shared table chrome); **T2** if small residual sidebar polish only  
-4. Optional light re-smoke 3–5 routes with visual-audit config only  
+1. Finish T3: `npx tsc --noEmit` (or project types script) → commit → push → `gh pr create`  
+2. Human: merge #90 / #91 / T3 when ready  
+3. After merges: pull main; mark T1–T3 done; pick **T4**  
+4. Optional light re-smoke 3–5 routes with **visual-audit config only**
 
-## Files (HF-3 / PR #89)
+## Files (T3)
 
-- `resources/js/lib/nav-active.ts`  
-- `resources/js/components/nav-main.tsx`  
-- `docs/visual-audit/BACKLOG.md`  
+- `resources/js/components/common/PageHeader.tsx`  
+- `resources/js/components/common/DashboardPageShell.tsx`  
+- `resources/js/components/common/ReportDataTablePage.tsx`  
+- `resources/js/components/reports/financial/FinancialReportPageShell.tsx`  
+- `resources/js/pages/accounts/index.tsx`  
+- `resources/js/pages/stock-movements/index.tsx`  
+- `resources/js/pages/financial-dashboard/index.tsx`  
+- `docs/visual-audit/BACKLOG.md` · `task.md`
 
 ## Continuation Prompt
 
-After PR #89 merge: pull main, start **T1 DataTable shell v2** (or T2 sidebar density if user prefers small). One theme = one branch = one MR. Do not Wave 2 mass capture.
+Ship **T3 PR** if not open; do not block on #90/#91 CI. After human merges T1–T3, pull main and start **T4** or residual. One theme = one branch = one MR. No Wave 2 mass capture. Keep `e2e/` untracked.

--- a/task.md
+++ b/task.md
@@ -1,10 +1,11 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-10  
-**Current milestone:** Visual audit — **T3 page header** on `feat/t3-page-header` (ship PR; parallel with #90/#91)  
+**Current milestone:** Visual audit — **T3 shipped PR #92** (parallel with #90/#91)  
 **Branch:** `feat/t3-page-header`  
+**Commits:** `102a26dd` · `0000580f` · `ad2e4112`  
 **Base main tip:** `bf5758d8` (HF-1–3 landed)  
-**Open PRs:** T1 [#90](https://github.com/gmedia/erp/pull/90) · T2 [#91](https://github.com/gmedia/erp/pull/91) · T3 (this branch)  
+**Open PRs:** T1 [#90](https://github.com/gmedia/erp/pull/90) · T2 [#91](https://github.com/gmedia/erp/pull/91) · T3 [#92](https://github.com/gmedia/erp/pull/92)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order


### PR DESCRIPTION
## What was done
- Shared **`PageHeader`** primitive (`title`, `description`, `actions`, `meta`) under AppLayout page bodies
- Wired **DashboardPageShell**, **ReportDataTablePage** (optional `description`), **FinancialReportPageShell**
- **Accounts (ACC-01):** breadcrumb `Master Data → Chart of Accounts`; single H1 via PageHeader (no double-title drift vs chrome)
- **Stock movements (RSM-02):** page description on ReportDataTablePage
- **Financial dashboard (FD-06):** crumb/document title aligned to **Financial Overview**
- Addresses **SHELL-04** page header contract for shared shells

## Files changed
- `resources/js/components/common/PageHeader.tsx` — new
- `resources/js/components/common/DashboardPageShell.tsx`
- `resources/js/components/common/ReportDataTablePage.tsx`
- `resources/js/components/reports/financial/FinancialReportPageShell.tsx`
- `resources/js/pages/accounts/index.tsx`
- `resources/js/pages/stock-movements/index.tsx`
- `resources/js/pages/financial-dashboard/index.tsx`
- `docs/visual-audit/BACKLOG.md`, `task.md` — handoff

## Verification
- [x] `npx tsc --noEmit` / project types — clean
- [ ] Optional visual-audit smoke (do **not** use default playwright — migrate:fresh)
- [ ] CI (do not block agent on this)

## Notes
- Pure EntityCrud pages often remain breadcrumb-only (intentional; no forced H1)
- Untracked local `e2e/` **not** included
- Parallel themes: T1 [#90](https://github.com/gmedia/erp/pull/90), T2 [#91](https://github.com/gmedia/erp/pull/91) — merge order flexible

## Next steps
- Human merge #90 / #91 / this PR when green
- After merges: pull main; mark T1–T3 done; **T4** next
- **No** Wave 2 mass capture