### PR TITLE
feat: dashboard & KPI semantics (T4 visual audit)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-08-10  
 **Source:** multimodal-looker Wave 0–1  
-**Policy:** No Wave 2 mass capture until T1–T3 land or shared-shell re-reviewed
+**Policy:** No Wave 2 mass capture until T1–T5 land or shared-shell re-reviewed
 
 ## Open (prioritized)
 
@@ -10,8 +10,8 @@
 |----|-----|-------|-------|--------|-------|
 | T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | **done (PR #90 merged)** | Single toolbar row; sticky Actions (HF-2); semantic Status; bulk bar; pagination chrome. SHELL-02,03,06,10,11; EMP-*; PO-* |
 | T2 | P1 | Sidebar IA & active | AppLayout / nav | **done (PR #91 merged)** | Density + truncation tooltips; active route = HF-3. SHELL-01,09 residual closed with T2 |
-| T3 | P1 | Page header contract | Layout primitive | open (PR #92) | Shared `PageHeader`; Dashboard/Report/Financial shells; accounts ACC-01; stock-movements RSM-02; FD-06 title. SHELL-04 |
-| T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | open | Home content strategy; **danger for negatives**; hide comparison until Compare set; FY visible. FD residual; DASH-*; BS-02 |
+| T3 | P1 | Page header contract | Layout primitive | **done (PR #92 merged)** | Shared `PageHeader`; Dashboard/Report/Financial shells; accounts ACC-01; stock-movements RSM-02; FD-06 title. SHELL-04 |
+| T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | **in progress** (`feat/t4-dashboard-kpi-semantics`) | FD-02 FY URL sync; FD-03 hide YoY when Compare=None; BS-02 signed amount rose chrome; DASH-01 home via DashboardPageShell + KpiCard |
 | T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report density. SHELL-05; RSM-01 |
 
 ## Hotfixes (can ship before full T1)
@@ -31,6 +31,7 @@
 | VA-W1-VISION | multimodal-looker full audit; stop-rule YES |
 | T1 | PR #90 merged into main |
 | T2 | PR #91 merged into main |
+| T3 | PR #92 merged into main |
 
 ## Implementation rules
 
@@ -41,6 +42,6 @@
 
 ## Next agent action
 
-1. Human: merge **PR #92** (T3) when ready  
-2. After merge: pull main; mark T3 done; start **T4**  
+1. Finish T4 verification → commit → push → open PR (T4 only)  
+2. Human merge T4 → then **T5** or light visual re-smoke  
 3. Do **not** mass Wave 2 capture

--- a/resources/js/components/financial-dashboard/SummaryCards.tsx
+++ b/resources/js/components/financial-dashboard/SummaryCards.tsx
@@ -19,6 +19,7 @@ import type {
 interface SummaryCardsProps {
     readonly data?: FinancialDashboardData['kpis'];
     readonly isLoading: boolean;
+    readonly showComparison?: boolean;
 }
 
 function getScopePill(scope?: KpiItem['scope']) {
@@ -67,6 +68,29 @@ function getChangeBadge(change: number, isExpenseOrLiability: boolean = false) {
     );
 }
 
+function comparisonFooter(
+    change: number,
+    isExpenseOrLiability: boolean,
+    scope: KpiItem['scope'] | undefined,
+    showComparison: boolean,
+) {
+    return (
+        <>
+            {showComparison && (
+                <div className="mt-2 flex items-center gap-2">
+                    {getChangeBadge(change, isExpenseOrLiability)}
+                    <span className="text-xs text-muted-foreground">
+                        vs comparison period
+                    </span>
+                </div>
+            )}
+            <div className={showComparison ? 'mt-1.5' : 'mt-2'}>
+                {getScopePill(scope)}
+            </div>
+        </>
+    );
+}
+
 function signedBalanceChrome(
     value: number,
     positive: { borderColor: string; iconColor: string },
@@ -89,6 +113,7 @@ function signedBalanceChrome(
 export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
     data,
     isLoading,
+    showComparison = false,
 }) {
     if (isLoading || !data) {
         return (
@@ -124,18 +149,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             iconColor: 'text-emerald-500',
             value: data.revenue.value,
             formattedValue: formatCurrency(data.revenue.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.revenue.change, false)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.revenue.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.revenue.change,
+                false,
+                data.revenue.scope,
+                showComparison,
             ),
         },
         {
@@ -145,18 +163,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             iconColor: 'text-rose-500',
             value: data.expenses.value,
             formattedValue: formatCurrency(data.expenses.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.expenses.change, true)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.expenses.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.expenses.change,
+                true,
+                data.expenses.scope,
+                showComparison,
             ),
         },
         {
@@ -168,18 +179,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             }),
             value: data.net_income.value,
             formattedValue: formatCurrency(data.net_income.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.net_income.change, false)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.net_income.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.net_income.change,
+                false,
+                data.net_income.scope,
+                showComparison,
             ),
         },
         {
@@ -189,18 +193,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             iconColor: 'text-indigo-500',
             value: data.total_assets.value,
             formattedValue: formatCurrency(data.total_assets.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.total_assets.change, false)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.total_assets.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.total_assets.change,
+                false,
+                data.total_assets.scope,
+                showComparison,
             ),
         },
         {
@@ -210,18 +207,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             iconColor: 'text-amber-500',
             value: data.total_liabilities.value,
             formattedValue: formatCurrency(data.total_liabilities.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.total_liabilities.change, true)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.total_liabilities.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.total_liabilities.change,
+                true,
+                data.total_liabilities.scope,
+                showComparison,
             ),
         },
         {
@@ -233,18 +223,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             }),
             value: data.equity.value,
             formattedValue: formatCurrency(data.equity.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.equity.change, false)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.equity.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.equity.change,
+                false,
+                data.equity.scope,
+                showComparison,
             ),
         },
         {
@@ -256,18 +239,11 @@ export const SummaryCards = memo<SummaryCardsProps>(function SummaryCards({
             }),
             value: data.cash_balance.value,
             formattedValue: formatCurrency(data.cash_balance.value),
-            footer: (
-                <>
-                    <div className="mt-2 flex items-center gap-2">
-                        {getChangeBadge(data.cash_balance.change, false)}
-                        <span className="text-xs text-muted-foreground">
-                            vs comparison period
-                        </span>
-                    </div>
-                    <div className="mt-1.5">
-                        {getScopePill(data.cash_balance.scope)}
-                    </div>
-                </>
+            footer: comparisonFooter(
+                data.cash_balance.change,
+                false,
+                data.cash_balance.scope,
+                showComparison,
             ),
         },
     ];

--- a/resources/js/components/reports/financial/FinancialReportSection.tsx
+++ b/resources/js/components/reports/financial/FinancialReportSection.tsx
@@ -51,14 +51,22 @@ export const financialPositionSectionConfigs: readonly FinancialReportSectionCon
 
 export const getChangeTextClass = (value: number): string => {
     if (value < 0) {
-        return 'text-red-500';
+        return 'text-rose-600 dark:text-rose-400';
     }
 
     if (value > 0) {
-        return 'text-green-600';
+        return 'text-emerald-600 dark:text-emerald-400';
     }
 
     return 'text-muted-foreground';
+};
+
+export const getSignedAmountTextClass = (value: number): string => {
+    if (value < 0) {
+        return 'text-rose-600 dark:text-rose-400';
+    }
+
+    return '';
 };
 
 function AccountRow({
@@ -101,10 +109,24 @@ function AccountRow({
                     <span className="truncate">{node.name}</span>
                 </button>
                 <div className="flex gap-4 text-right tabular-nums">
-                    <div className="w-32">{formatCurrency(node.balance)}</div>
+                    <div
+                        className={cn(
+                            'w-32',
+                            getSignedAmountTextClass(node.balance),
+                        )}
+                    >
+                        {formatCurrency(node.balance)}
+                    </div>
                     {showComparison && (
                         <>
-                            <div className="w-32 text-muted-foreground">
+                            <div
+                                className={cn(
+                                    'w-32 text-muted-foreground',
+                                    getSignedAmountTextClass(
+                                        node.comparison_balance || 0,
+                                    ),
+                                )}
+                            >
                                 {formatCurrency(node.comparison_balance || 0)}
                             </div>
                             <div className={cn('w-28', changeTextClass)}>
@@ -185,12 +207,24 @@ export function FinancialReportSection({
                         </div>
                     </div>
                     <div className="flex gap-4 text-right tabular-nums">
-                        <span className="w-32 text-lg font-bold">
+                        <span
+                            className={cn(
+                                'w-32 text-lg font-bold',
+                                getSignedAmountTextClass(total),
+                            )}
+                        >
                             {formatCurrency(total)}
                         </span>
                         {showComparison && (
                             <>
-                                <span className="w-32 text-lg font-bold text-muted-foreground">
+                                <span
+                                    className={cn(
+                                        'w-32 text-lg font-bold text-muted-foreground',
+                                        getSignedAmountTextClass(
+                                            comparisonTotal || 0,
+                                        ),
+                                    )}
+                                >
                                     {formatCurrency(comparisonTotal || 0)}
                                 </span>
                                 <span

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,11 +1,17 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import DashboardPageShell from '@/components/common/DashboardPageShell';
+import { KpiCard } from '@/components/common/KpiCard';
+import { Card, CardContent } from '@/components/ui/card';
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
-import AppLayout from '@/layouts/app-layout';
 import axios from '@/lib/axios';
 import { type BreadcrumbItem } from '@/types';
 import { formatNumberByRegionalSettings } from '@/utils/number-format';
-import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
+import { useQuery } from '@tanstack/react-query';
+import {
+    Boxes,
+    Building2,
+    Users,
+    Warehouse,
+} from 'lucide-react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -21,98 +27,105 @@ type Totals = {
     assets: number;
 };
 
-export default function Dashboard() {
-    const [totals, setTotals] = useState<Totals | null>(null);
-    const [loading, setLoading] = useState(true);
+async function fetchDashboardTotals(): Promise<Totals> {
+    const res = await axios.get('/api/dashboard');
+    return res.data.data.totals as Totals;
+}
 
-    useEffect(() => {
-        axios
-            .get('/api/dashboard')
-            .then((res) => {
-                setTotals(res.data.data.totals);
-            })
-            .catch(() => {
-                setTotals({
-                    customers: 0,
-                    employees: 0,
-                    suppliers: 0,
-                    assets: 0,
-                });
-            })
-            .finally(() => setLoading(false));
-    }, []);
+export default function Dashboard() {
+    const { data, isLoading, isError, error, refetch } = useQuery({
+        queryKey: ['home-dashboard'],
+        queryFn: fetchDashboardTotals,
+        staleTime: 60_000,
+    });
+
+    const totals: Totals = data ?? {
+        customers: 0,
+        employees: 0,
+        suppliers: 0,
+        assets: 0,
+    };
+
+    const cards = [
+        {
+            title: 'Total Customers',
+            icon: Users,
+            borderColor: 'border-l-blue-500',
+            iconColor: 'text-blue-500',
+            value: totals.customers,
+        },
+        {
+            title: 'Total Employees',
+            icon: Building2,
+            borderColor: 'border-l-emerald-500',
+            iconColor: 'text-emerald-500',
+            value: totals.employees,
+        },
+        {
+            title: 'Total Suppliers',
+            icon: Warehouse,
+            borderColor: 'border-l-amber-500',
+            iconColor: 'text-amber-500',
+            value: totals.suppliers,
+        },
+        {
+            title: 'Total Assets',
+            icon: Boxes,
+            borderColor: 'border-l-indigo-500',
+            iconColor: 'text-indigo-500',
+            value: totals.assets,
+        },
+    ] as const;
 
     return (
-        <AppLayout breadcrumbs={breadcrumbs}>
-            <Helmet>
-                <title>Dashboard</title>
-            </Helmet>
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-                    <Card>
-                        <CardHeader className="pb-2">
-                            <CardTitle className="text-sm font-medium">
-                                Total Customer
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="text-2xl font-semibold tabular-nums">
-                            {loading
-                                ? '—'
-                                : formatNumberByRegionalSettings(
-                                      totals?.customers ?? 0,
-                                  )}
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader className="pb-2">
-                            <CardTitle className="text-sm font-medium">
-                                Total Employee
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="text-2xl font-semibold tabular-nums">
-                            {loading
-                                ? '—'
-                                : formatNumberByRegionalSettings(
-                                      totals?.employees ?? 0,
-                                  )}
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader className="pb-2">
-                            <CardTitle className="text-sm font-medium">
-                                Total Supplier
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="text-2xl font-semibold tabular-nums">
-                            {loading
-                                ? '—'
-                                : formatNumberByRegionalSettings(
-                                      totals?.suppliers ?? 0,
-                                  )}
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader className="pb-2">
-                            <CardTitle className="text-sm font-medium">
-                                Total Asset
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="text-2xl font-semibold tabular-nums">
-                            {loading
-                                ? '—'
-                                : formatNumberByRegionalSettings(
-                                      totals?.assets ?? 0,
-                                  )}
-                        </CardContent>
-                    </Card>
-                </div>
-                <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                </div>
+        <DashboardPageShell
+            title="Dashboard"
+            heading="Dashboard"
+            description="At-a-glance entity counts across customers, people, suppliers, and assets."
+            breadcrumbs={breadcrumbs}
+            isLoading={isLoading}
+            isError={isError}
+            error={error instanceof Error ? error : null}
+            errorMessage="Failed to fetch dashboard totals. Please try refreshing."
+            refetch={() => {
+                void refetch();
+            }}
+        >
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {isLoading
+                    ? (['c1', 'c2', 'c3', 'c4'] as const).map((key) => (
+                          <div
+                              key={key}
+                              className="animate-pulse rounded-lg border bg-card p-6 shadow-sm"
+                          >
+                              <div className="mb-2 h-4 w-28 rounded bg-muted" />
+                              <div className="h-8 w-20 rounded bg-muted" />
+                          </div>
+                      ))
+                    : cards.map((card) => (
+                          <KpiCard
+                              key={card.title}
+                              title={card.title}
+                              icon={card.icon}
+                              value={card.value}
+                              formattedValue={formatNumberByRegionalSettings(
+                                  card.value,
+                              )}
+                              borderColor={card.borderColor}
+                              iconColor={card.iconColor}
+                          />
+                      ))}
             </div>
-        </AppLayout>
+
+            <Card className="relative min-h-[40vh] overflow-hidden border-dashed">
+                <CardContent className="relative flex min-h-[40vh] items-center justify-center p-0">
+                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/15 dark:stroke-neutral-100/15" />
+                    <p className="relative z-10 max-w-sm px-6 text-center text-sm text-muted-foreground">
+                        More operational widgets will appear here. Use Financial
+                        Overview and module dashboards for detailed KPIs.
+                    </p>
+                </CardContent>
+            </Card>
+        </DashboardPageShell>
     );
 }

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -6,12 +6,7 @@ import axios from '@/lib/axios';
 import { type BreadcrumbItem } from '@/types';
 import { formatNumberByRegionalSettings } from '@/utils/number-format';
 import { useQuery } from '@tanstack/react-query';
-import {
-    Boxes,
-    Building2,
-    Users,
-    Warehouse,
-} from 'lucide-react';
+import { Boxes, Building2, Users, Warehouse } from 'lucide-react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {

--- a/resources/js/pages/financial-dashboard/index.tsx
+++ b/resources/js/pages/financial-dashboard/index.tsx
@@ -2,6 +2,7 @@ import DashboardPageShell from '@/components/common/DashboardPageShell';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { BreadcrumbItem } from '@/types';
 import { Info } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AsyncSelect } from '../../components/common/AsyncSelect';
 import { CashFlowSummary } from '../../components/financial-dashboard/CashFlowSummary';
@@ -20,6 +21,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 export default function FinancialDashboard() {
     const [searchParams, setSearchParams] = useSearchParams();
+    const preferredYearSynced = useRef(false);
 
     const fiscalYearId = searchParams.get('fiscal_year_id')
         ? Number(searchParams.get('fiscal_year_id'))
@@ -36,6 +38,28 @@ export default function FinancialDashboard() {
         comparisonYearId,
         branchId,
     });
+
+    useEffect(() => {
+        if (preferredYearSynced.current) {
+            return;
+        }
+        if (fiscalYearId !== null) {
+            preferredYearSynced.current = true;
+            return;
+        }
+        const preferredId = data?.selected_year_id;
+        if (!preferredId) {
+            return;
+        }
+        preferredYearSynced.current = true;
+        const next = new URLSearchParams(searchParams);
+        next.set('fiscal_year_id', preferredId.toString());
+        setSearchParams(next, { replace: true });
+    }, [data?.selected_year_id, fiscalYearId, searchParams, setSearchParams]);
+
+    const resolvedYearId = fiscalYearId ?? data?.selected_year_id ?? null;
+    const hasComparison =
+        comparisonYearId !== null && comparisonYearId !== undefined;
 
     const handleYearChange = (yearId: number | null) => {
         const newParams = new URLSearchParams(searchParams);
@@ -95,7 +119,7 @@ export default function FinancialDashboard() {
                     {data?.fiscal_years && data.fiscal_years.length > 0 && (
                         <FiscalYearSelector
                             fiscalYears={data.fiscal_years}
-                            selectedYearId={fiscalYearId}
+                            selectedYearId={resolvedYearId}
                             comparisonYearId={comparisonYearId}
                             onYearChange={handleYearChange}
                             onComparisonYearChange={handleComparisonYearChange}
@@ -126,7 +150,11 @@ export default function FinancialDashboard() {
             )}
 
             <div className="space-y-6">
-                <SummaryCards data={data?.kpis} isLoading={isLoading} />
+                <SummaryCards
+                    data={data?.kpis}
+                    isLoading={isLoading}
+                    showComparison={hasComparison}
+                />
 
                 <MonthlyTrendChart
                     data={data?.monthly_trends}

--- a/task.md
+++ b/task.md
@@ -1,11 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-10  
-**Current milestone:** Visual audit — **T3** PR #92 after **#90** + **#91** on main  
-**Branch:** `feat/t3-page-header`  
-**T1:** PR #90 **merged**  
-**T2:** PR #91 **merged**  
-**T3 PR:** https://github.com/gmedia/erp/pull/92  
+**Current milestone:** Visual audit — **T4** dashboard & KPI semantics  
+**Branch:** `feat/t4-dashboard-kpi-semantics` @ `6630f30e` + local T4 edits  
+**T1–T3:** PRs #90–#92 **merged** on main  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -21,10 +19,12 @@
 - **HF-1–3** on main  
 - **T1** DataTable shell v2 — **PR #90 merged**  
 - **T2** Sidebar density — **PR #91 merged**  
-- **T3** (this branch / PR #92):
-  - `PageHeader` primitive (`title` / `description` / `actions` / `meta`)
-  - Wired: `DashboardPageShell`, `ReportDataTablePage` (+ optional `description`), `FinancialReportPageShell`
-  - Pages: stock-movements (RSM-02), financial-dashboard (FD-06 “Financial Overview”), accounts (ACC-01)
+- **T3** Page header — **PR #92 merged**  
+- **T4** (this branch, code landed, not yet committed/PR’d):
+  - **FD-02:** sync `fiscal_year_id` query from API `selected_year_id` when URL empty; selector uses `resolvedYearId`
+  - **FD-03:** `SummaryCards` `showComparison` — hide % badges / “vs comparison period” when Compare=None
+  - **BS-02:** `getSignedAmountTextClass` on balance + section totals; change colors → rose/emerald dark-aware
+  - **DASH-01 / SHELL-12:** home `/dashboard` → `DashboardPageShell` + `KpiCard` grid + lighter placeholder
 
 ## Themes status
 
@@ -32,8 +32,8 @@
 |----|-------|--------|
 | T1 | DataTable shell v2 | **merged** (#90) |
 | T2 | Sidebar IA residual | **merged** (#91) |
-| **T3** | Page header contract | **PR #92** |
-| T4 | Dashboard & KPI | open after T3 |
+| T3 | Page header contract | **merged** (#92) |
+| **T4** | Dashboard & KPI | **code on branch** — commit/PR next |
 | T5 | Sparse & report density | open |
 
 ## Do not
@@ -44,23 +44,24 @@
 - Commit local untracked `e2e/` junk  
 - Wait on CI (AGENTS: never wait for CI)
 
+## Validated
+
+- `npm run types` (tsc --noEmit) — clean after T4 edits
+
 ## Recommended next
 
-1. Human: merge **#92** when ready  
-2. After merge: pull main; mark T3 done; pick **T4**  
-3. Optional light re-smoke with **visual-audit config only**
+1. Commit T4 (multi-commit OK) + push + `gh pr create`  
+2. Human merge T4  
+3. Then **T5** or light re-smoke (visual-audit config only)
 
-## Files (T3)
+## Files (T4)
 
-- `resources/js/components/common/PageHeader.tsx`  
-- `resources/js/components/common/DashboardPageShell.tsx`  
-- `resources/js/components/common/ReportDataTablePage.tsx`  
-- `resources/js/components/reports/financial/FinancialReportPageShell.tsx`  
-- `resources/js/pages/accounts/index.tsx`  
-- `resources/js/pages/stock-movements/index.tsx`  
 - `resources/js/pages/financial-dashboard/index.tsx`  
+- `resources/js/components/financial-dashboard/SummaryCards.tsx`  
+- `resources/js/components/reports/financial/FinancialReportSection.tsx`  
+- `resources/js/pages/dashboard.tsx`  
 - `docs/visual-audit/BACKLOG.md` · `task.md`
 
 ## Continuation Prompt
 
-T1 (#90) and T2 (#91) merged. Resolve #92 docs conflicts if needed, push, human merge #92. Then **T4**. No Wave 2 mass capture. Keep `e2e/` untracked.
+T1–T3 merged. On `feat/t4-dashboard-kpi-semantics`: FD-02/03, BS-02, DASH-01 implemented; `tsc` clean. Commit (keep `e2e/` untracked), push, open T4 PR. No Wave 2. After merge → T5.

--- a/task.md
+++ b/task.md
@@ -2,7 +2,8 @@
 
 **Last updated:** 2026-08-10  
 **Current milestone:** Visual audit — **T4** dashboard & KPI semantics  
-**Branch:** `feat/t4-dashboard-kpi-semantics` @ `6630f30e` + local T4 edits  
+**Branch:** `feat/t4-dashboard-kpi-semantics`  
+**T4 PR:** https://github.com/gmedia/erp/pull/93  
 **T1–T3:** PRs #90–#92 **merged** on main  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
@@ -33,7 +34,7 @@
 | T1 | DataTable shell v2 | **merged** (#90) |
 | T2 | Sidebar IA residual | **merged** (#91) |
 | T3 | Page header contract | **merged** (#92) |
-| **T4** | Dashboard & KPI | **code on branch** — commit/PR next |
+| **T4** | Dashboard & KPI | **PR #93** |
 | T5 | Sparse & report density | open |
 
 ## Do not
@@ -50,9 +51,8 @@
 
 ## Recommended next
 
-1. Commit T4 (multi-commit OK) + push + `gh pr create`  
-2. Human merge T4  
-3. Then **T5** or light re-smoke (visual-audit config only)
+1. Human merge **#93**  
+2. Then **T5** or light re-smoke (visual-audit config only)
 
 ## Files (T4)
 
@@ -64,4 +64,4 @@
 
 ## Continuation Prompt
 
-T1–T3 merged. On `feat/t4-dashboard-kpi-semantics`: FD-02/03, BS-02, DASH-01 implemented; `tsc` clean. Commit (keep `e2e/` untracked), push, open T4 PR. No Wave 2. After merge → T5.
+T1–T3 merged. T4 **PR #93** open (FD-02/03, BS-02, DASH-01). Human merge → T5. No Wave 2. Keep `e2e/` untracked.


### PR DESCRIPTION
## What was done
- **FD-02:** When `fiscal_year_id` is missing from the URL, sync API `selected_year_id` via `replace` so FiscalYearSelector shows a concrete year (`resolvedYearId`).
- **FD-03:** Gate financial dashboard YoY / comparison footers on URL `comparison_year_id` (`SummaryCards` `showComparison`).
- **BS-02:** Signed amount rose/emerald chrome on financial report section balances and totals.
- **DASH-01 / SHELL-12:** Home `/dashboard` uses `DashboardPageShell` + shared `KpiCard` grid + lighter placeholder.

## Files changed
- `resources/js/pages/financial-dashboard/index.tsx` — FY URL sync + comparison flag
- `resources/js/components/financial-dashboard/SummaryCards.tsx` — hide comparison UI when Compare=None
- `resources/js/components/reports/financial/FinancialReportSection.tsx` — signed amount classes
- `resources/js/pages/dashboard.tsx` — shell + KpiCards
- `docs/visual-audit/BACKLOG.md` · `task.md` — T3 done, T4 in progress

## Verification
- [x] `npm run types` (tsc --noEmit) clean
- [ ] Optional light re-smoke with **playwright.visual-audit.config.ts only** (not default config)
- [ ] CI (do not block on agent side)

## Next steps
- Human merge this T4 PR
- Then **T5** (sparse & report density) or light visual re-smoke
- **Do not** Wave 2 mass capture; keep untracked `e2e/` out of commits

## Handoff
Branch: `feat/t4-dashboard-kpi-semantics`  
Base: main after T1–T3 (#90–#92)  
Theme: visual audit T4 only