### PR TITLE
feat: T5 sparse & report density (visual audit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,17 @@
 - One `git status`/`log` combined in a **single** bash script
 - User explicitly orders parallel research (“fire explore agents”)
 
+### Post-kill recovery (MANDATORY)
+
+1. After OpenCode kill / interrupt: **strict serial** — **1 tool call per assistant turn** until the interrupted task is finished or stable.
+2. Do **not** re-fire explore/librarian/oracle swarms to “catch up”.
+3. Resume from `task.md` + `git status` only; re-apply unfinished edits **one file at a time**.
+4. Prefer completing a small shippable slice (commit/PR) over re-planning the whole theme.
+
+### Why this exists
+
+Host RAM/CPU is limited. Parallel `Read`/`Edit`/`task` batches have **killed OpenCode mid-T5** (and earlier sessions). Session survival > agent throughput.
+
 ## Workflow
 
 ```

--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -11,8 +11,8 @@
 | T1 | P0–P1 | DataTable shell v2 | EntityCrudPage / shared table | **done (PR #90 merged)** | Single toolbar row; sticky Actions (HF-2); semantic Status; bulk bar; pagination chrome. SHELL-02,03,06,10,11; EMP-*; PO-* |
 | T2 | P1 | Sidebar IA & active | AppLayout / nav | **done (PR #91 merged)** | Density + truncation tooltips; active route = HF-3. SHELL-01,09 residual closed with T2 |
 | T3 | P1 | Page header contract | Layout primitive | **done (PR #92 merged)** | Shared `PageHeader`; Dashboard/Report/Financial shells; accounts ACC-01; stock-movements RSM-02; FD-06 title. SHELL-04 |
-| T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | **in progress** (`feat/t4-dashboard-kpi-semantics`) | FD-02 FY URL sync; FD-03 hide YoY when Compare=None; BS-02 signed amount rose chrome; DASH-01 home via DashboardPageShell + KpiCard |
-| T5 | P1–P2 | Sparse & report density | ReportDataTable + list | open | Summary strip / empty panels; report density. SHELL-05; RSM-01 |
+| T4 | P0–P1 | Dashboard & KPI semantics | Home + financial dash + amounts | **done (PR #93 merged)** | FD-02 FY URL sync; FD-03 hide YoY when Compare=None; BS-02 signed amount rose chrome; DASH-01 home via DashboardPageShell + KpiCard |
+| T5 | P1–P2 | Sparse & report density | ReportDataTable + list | **in progress (this PR)** | Content-height shells (drop h-full flex-1 void); denser DataTable + pagination. SHELL-05; RSM-01 |
 
 ## Hotfixes (can ship before full T1)
 
@@ -32,6 +32,7 @@
 | T1 | PR #90 merged into main |
 | T2 | PR #91 merged into main |
 | T3 | PR #92 merged into main |
+| T4 | PR #93 merged into main |
 
 ## Implementation rules
 
@@ -42,6 +43,7 @@
 
 ## Next agent action
 
-1. Finish T4 verification → commit → push → open PR (T4 only)  
-2. Human merge T4 → then **T5** or light visual re-smoke  
-3. Do **not** mass Wave 2 capture
+1. Finish **T5** PR: types → commit → push → `gh pr create`  
+2. After T5 merge (or shared-shell re-review): consider unfreezing selective Wave 2 capture  
+3. Do **not** mass Wave 2 capture yet  
+4. Agents: respect **AGENTS.md Tool & Process Concurrency** (max 3 tools/turn; post-kill = 1 tool/turn)

--- a/resources/js/components/common/CrudPage.tsx
+++ b/resources/js/components/common/CrudPage.tsx
@@ -202,8 +202,8 @@ export function CrudPage<
             </Helmet>
 
             <AppLayout breadcrumbs={config.breadcrumbs}>
-                <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                    <div className="rounded-lg bg-white">
+                <div className="flex w-full flex-col gap-3 overflow-x-auto p-4">
+                    <div className="rounded-lg border border-border/60 bg-card shadow-sm">
                         <config.DataTableComponent {...dataTableProps} />
                     </div>
                 </div>

--- a/resources/js/components/common/DataTableCore.tsx
+++ b/resources/js/components/common/DataTableCore.tsx
@@ -345,7 +345,7 @@ export function DataTable<T>({
                         <TableCell
                             key={cell.id}
                             className={cn(
-                                'border-border',
+                                'border-border px-2 py-1.5',
                                 isActions && STICKY_ACTIONS_CELL,
                             )}
                         >
@@ -363,7 +363,7 @@ export function DataTable<T>({
             <TableRow>
                 <TableCell
                     colSpan={columnsWithActions.length}
-                    className="h-24 text-center text-muted-foreground"
+                    className="h-16 py-6 text-center text-sm text-muted-foreground"
                 >
                     No results.
                 </TableCell>
@@ -372,7 +372,7 @@ export function DataTable<T>({
     }
 
     return (
-        <div className="w-full bg-background text-foreground">
+        <div className="w-full space-y-2 bg-card p-3 text-foreground sm:p-4">
             <DataTableToolbar
                 searchValue={searchValue}
                 onSearchChange={setSearchValue}
@@ -431,7 +431,7 @@ export function DataTable<T>({
 
             <div className="overflow-hidden rounded-md border border-border">
                 <Table className="min-w-max">
-                    <TableHeader className="bg-muted">
+                    <TableHeader className="bg-muted/80">
                         {table.getHeaderGroups().map((headerGroup) => (
                             <TableRow key={headerGroup.id}>
                                 {headerGroup.headers.map((header) => {
@@ -441,7 +441,7 @@ export function DataTable<T>({
                                         <TableHead
                                             key={header.id}
                                             className={cn(
-                                                'border-border select-none',
+                                                'h-9 border-border select-none px-2 py-1.5 text-xs',
                                                 isActions &&
                                                     STICKY_ACTIONS_HEAD,
                                             )}
@@ -463,7 +463,7 @@ export function DataTable<T>({
                 </Table>
             </div>
 
-            <div className="mt-1 border-t border-border/60">
+            <div className="border-t border-border/50 pt-1">
                 <DataTablePagination
                     pagination={pagination}
                     onPageChange={handlePageChange}

--- a/resources/js/components/common/DataTableCore.tsx
+++ b/resources/js/components/common/DataTableCore.tsx
@@ -441,7 +441,7 @@ export function DataTable<T>({
                                         <TableHead
                                             key={header.id}
                                             className={cn(
-                                                'h-9 border-border select-none px-2 py-1.5 text-xs',
+                                                'h-9 border-border px-2 py-1.5 text-xs select-none',
                                                 isActions &&
                                                     STICKY_ACTIONS_HEAD,
                                             )}

--- a/resources/js/components/common/DataTablePage.tsx
+++ b/resources/js/components/common/DataTablePage.tsx
@@ -72,9 +72,9 @@ export function DataTablePage<
                 <title>{title}</title>
             </Helmet>
             <AppLayout breadcrumbs={breadcrumbs}>
-                <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="flex w-full flex-col gap-3 overflow-x-auto p-4">
                     {children}
-                    <div className="rounded-lg bg-white">
+                    <div className="rounded-lg border border-border/60 bg-card shadow-sm">
                         <DataTable
                             columns={columns}
                             data={data}

--- a/resources/js/components/common/PaginationControls.tsx
+++ b/resources/js/components/common/PaginationControls.tsx
@@ -35,14 +35,14 @@ export function PaginationControls({
     renderPageNumbers: () => React.ReactNode;
 }>) {
     return (
-        <div className="flex flex-col gap-3 py-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="flex flex-col gap-2 py-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
                 <p className="whitespace-nowrap">Rows per page</p>
                 <Select
                     value={String(pagination.per_page)}
                     onValueChange={onPageSizeChange}
                 >
-                    <SelectTrigger className="w-[70px] border-border bg-background">
+                    <SelectTrigger className="h-8 w-[70px] border-border bg-background">
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent className="border-border bg-background text-foreground">

--- a/resources/js/components/common/ReportDataTablePage.tsx
+++ b/resources/js/components/common/ReportDataTablePage.tsx
@@ -95,9 +95,9 @@ export function ReportDataTablePage<
                 <title>{title}</title>
             </Helmet>
             <AppLayout breadcrumbs={breadcrumbs}>
-                <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="flex w-full flex-col gap-3 overflow-x-auto p-4">
                     <PageHeader title={title} description={description} />
-                    <div className="rounded-lg bg-white">
+                    <div className="rounded-lg border border-border/60 bg-card shadow-sm">
                         <DataTable
                             columns={columns}
                             data={data}

--- a/resources/js/components/reports/financial/FinancialReportPageShell.tsx
+++ b/resources/js/components/reports/financial/FinancialReportPageShell.tsx
@@ -295,7 +295,7 @@ export function FinancialReportPageShell({
         );
     } else {
         content = (
-            <div className="flex h-full flex-1 flex-col gap-4 p-4">
+            <div className="flex w-full flex-col gap-3 p-4">
                 <PageHeader
                     title={title}
                     meta={headerMeta}

--- a/resources/js/components/reports/financial/FinancialTableReportPage.tsx
+++ b/resources/js/components/reports/financial/FinancialTableReportPage.tsx
@@ -237,7 +237,7 @@ export function SingleYearFinancialReportPageShell({
         );
     } else {
         content = (
-            <div className="flex h-full flex-1 flex-col gap-4 p-4">
+            <div className="flex w-full flex-col gap-3 p-4">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="flex flex-col gap-1">
                         <h1 className="text-2xl font-bold tracking-tight">

--- a/task.md
+++ b/task.md
@@ -1,10 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-10  
-**Current milestone:** Visual audit — **T4** dashboard & KPI semantics  
-**Branch:** `feat/t4-dashboard-kpi-semantics`  
-**T4 PR:** https://github.com/gmedia/erp/pull/93  
-**T1–T3:** PRs #90–#92 **merged** on main  
+**Current milestone:** Visual audit — **T1–T4 merged**; next **T5** or light re-smoke  
+**Branch:** `main` @ `ab4cb0d8` (T4 #93 squash)  
+**T1–T4:** PRs #90–#93 **merged**  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -18,14 +17,10 @@
 
 - Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86)  
 - **HF-1–3** on main  
-- **T1** DataTable shell v2 — **PR #90 merged**  
-- **T2** Sidebar density — **PR #91 merged**  
-- **T3** Page header — **PR #92 merged**  
-- **T4** (this branch, code landed, not yet committed/PR’d):
-  - **FD-02:** sync `fiscal_year_id` query from API `selected_year_id` when URL empty; selector uses `resolvedYearId`
-  - **FD-03:** `SummaryCards` `showComparison` — hide % badges / “vs comparison period” when Compare=None
-  - **BS-02:** `getSignedAmountTextClass` on balance + section totals; change colors → rose/emerald dark-aware
-  - **DASH-01 / SHELL-12:** home `/dashboard` → `DashboardPageShell` + `KpiCard` grid + lighter placeholder
+- **T1** DataTable shell v2 — **#90**  
+- **T2** Sidebar density — **#91**  
+- **T3** Page header — **#92**  
+- **T4** Dashboard & KPI — **#93** (FD-02/03, BS-02, DASH-01)
 
 ## Themes status
 
@@ -34,34 +29,32 @@
 | T1 | DataTable shell v2 | **merged** (#90) |
 | T2 | Sidebar IA residual | **merged** (#91) |
 | T3 | Page header contract | **merged** (#92) |
-| **T4** | Dashboard & KPI | **PR #93** |
-| T5 | Sparse & report density | open |
+| T4 | Dashboard & KPI | **merged** (#93) |
+| **T5** | Sparse & report density | **open** — next implementation theme |
 
 ## Do not
 
-- Mass-capture Wave 2 / remaining 78 routes  
+- Mass-capture Wave 2 / remaining 78 routes until T5 lands **or** shared-shell re-reviewed  
 - Use default `playwright.config.ts` for visual (migrate:fresh)  
 - Redesign all 85 modules in one MR  
 - Commit local untracked `e2e/` junk  
 - Wait on CI (AGENTS: never wait for CI)
 
-## Validated
+## Recommended next (pick one)
 
-- `npm run types` (tsc --noEmit) — clean after T4 edits
+### A — **T5** (recommended default)
+- Branch from main: `feat/t5-sparse-report-density`
+- Scope (BACKLOG): SHELL-05, RSM-01 — summary strip / empty panels; report density on `ReportDataTablePage` + sparse list surfaces
+- One theme = one PR
 
-## Recommended next
+### B — Light visual re-smoke (optional before/after T5)
+- **Only** `playwright.visual-audit.config.ts` (never default config)
+- 1 worker; base `http://127.0.0.1:82`; admin login
+- Re-capture Wave 0–1 exception routes only if needed; PNGs gitignored
 
-1. Human merge **#93**  
-2. Then **T5** or light re-smoke (visual-audit config only)
-
-## Files (T4)
-
-- `resources/js/pages/financial-dashboard/index.tsx`  
-- `resources/js/components/financial-dashboard/SummaryCards.tsx`  
-- `resources/js/components/reports/financial/FinancialReportSection.tsx`  
-- `resources/js/pages/dashboard.tsx`  
-- `docs/visual-audit/BACKLOG.md` · `task.md`
+### C — Shared-shell re-review
+- multimodal-looker on post-T1–T4 chrome before unfreezing Wave 2 mass capture
 
 ## Continuation Prompt
 
-T1–T3 merged. T4 **PR #93** open (FD-02/03, BS-02, DASH-01). Human merge → T5. No Wave 2. Keep `e2e/` untracked.
+Main at `ab4cb0d8` (T4 #93 merged). Start **T5** from main or optional visual-audit re-smoke. No Wave 2 mass capture yet. Keep `e2e/` untracked.


### PR DESCRIPTION
## What was done
- Shared list/report shells no longer stretch to full viewport (`h-full` / `flex-1` void) — content-height layout with tighter gaps
- Denser DataTable header/cell/empty-row and pagination chrome
- Financial report shells aligned (gap / height)
- `AGENTS.md`: hard process budget (≤3 tools/turn, post-kill serial) after OpenCode kill mid-T5
- Visual-audit BACKLOG + `task.md` handoff for T5

Addresses SHELL-05 sparse empty canvas and report density (RSM-oriented shared shells).

## Files changed
- `resources/js/components/common/{CrudPage,DataTablePage,ReportDataTablePage,DataTableCore,PaginationControls}.tsx`
- `resources/js/components/reports/financial/{FinancialReportPageShell,FinancialTableReportPage}.tsx`
- `AGENTS.md`, `docs/visual-audit/BACKLOG.md`, `task.md`

## Verification
- [x] `npm run types` clean (pre-commit)
- [ ] Optional visual re-smoke via `playwright.visual-audit.config.ts` only
- [ ] CI (do not block on this)

## Next steps
- After merge: mark BACKLOG T5 done
- Wave 2 mass capture still frozen until human re-review of shared shells if desired
- Do not commit untracked `e2e/`