### PR TITLE
feat: densify My Approvals inbox chrome (visual audit)

### DIFF
--- a/resources/js/pages/my-approvals/index.tsx
+++ b/resources/js/pages/my-approvals/index.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from '@/components/common/PageHeader';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -14,9 +15,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
 import axios from '@/lib/axios';
+import { cn } from '@/lib/utils';
 import { ApprovalRequest, ApprovalRequestStep } from '@/types/approval';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { format, formatDistanceToNow, isValid, parseISO } from 'date-fns';
 import { Check, Clock, Eye, Loader2, X } from 'lucide-react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -30,32 +32,134 @@ interface MyApprovalsResponse {
     all: ApprovalRequestStep[];
 }
 
+const APPROVABLE_TYPE_LABELS: Record<string, string> = {
+    PurchaseOrder: 'Purchase Order',
+    PurchaseRequest: 'Purchase Request',
+    SupplierBill: 'Supplier Bill',
+    CustomerInvoice: 'Customer Invoice',
+    ApPayment: 'AP Payment',
+    ArReceipt: 'AR Receipt',
+    CreditNote: 'Credit Note',
+    JournalEntry: 'Journal Entry',
+    StockTransfer: 'Stock Transfer',
+    StockAdjustment: 'Stock Adjustment',
+    GoodsReceipt: 'Goods Receipt',
+    SupplierReturn: 'Supplier Return',
+    InventoryStocktake: 'Inventory Stocktake',
+    Asset: 'Asset',
+    AssetMaintenance: 'Asset Maintenance',
+    AssetMovement: 'Asset Movement',
+    AssetStocktake: 'Asset Stocktake',
+    Budget: 'Budget',
+    PeriodClosing: 'Period Closing',
+    BankReconciliation: 'Bank Reconciliation',
+    RecurringJournal: 'Recurring Journal',
+};
+
+function shortApprovableType(approvableType: string): string {
+    return approvableType.split('\\').pop() ?? approvableType;
+}
+
+function formatApprovableTypeLabel(approvableType: string): string {
+    const short = shortApprovableType(approvableType);
+    if (APPROVABLE_TYPE_LABELS[short]) {
+        return APPROVABLE_TYPE_LABELS[short];
+    }
+    return short.replaceAll(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+function documentTitle(step: ApprovalRequestStep): string {
+    const approvable = step.request.approvable;
+    if (approvable) {
+        const name =
+            (typeof approvable.name === 'string' && approvable.name.trim()) ||
+            (typeof approvable.description === 'string' &&
+                approvable.description.trim()) ||
+            '';
+        const code =
+            typeof approvable.asset_code === 'string'
+                ? approvable.asset_code.trim()
+                : '';
+        if (code && name) {
+            return `${code} · ${name}`;
+        }
+        if (name) {
+            return name;
+        }
+        if (code) {
+            return code;
+        }
+    }
+
+    const stepName =
+        step.flow_step?.name?.trim() || step.flowStep?.name?.trim();
+    if (stepName) {
+        return stepName;
+    }
+
+    return `${formatApprovableTypeLabel(step.request.approvable_type)} #${step.request.approvable_id}`;
+}
+
+function formatSubmittedAt(submittedAt: string | null | undefined): {
+    relative: string;
+    absolute: string;
+} | null {
+    if (!submittedAt) {
+        return null;
+    }
+    const date = parseISO(submittedAt);
+    if (!isValid(date)) {
+        return null;
+    }
+    return {
+        relative: formatDistanceToNow(date, { addSuffix: true }),
+        absolute: format(date, 'dd MMM yyyy HH:mm'),
+    };
+}
+
 function StatusBadge({ status }: Readonly<{ status: string }>) {
     switch (status) {
         case 'pending':
             return (
-                <Badge variant="secondary">
-                    <Clock className="mr-1 h-3 w-3" /> Pending
+                <Badge variant="secondary" className="gap-1 font-normal">
+                    <Clock className="h-3 w-3" /> Pending
                 </Badge>
             );
         case 'approved':
             return (
                 <Badge
                     variant="default"
-                    className="bg-green-600 hover:bg-green-700"
+                    className="gap-1 bg-emerald-600 font-normal hover:bg-emerald-700"
                 >
-                    <Check className="mr-1 h-3 w-3" /> Approved
+                    <Check className="h-3 w-3" /> Approved
                 </Badge>
             );
         case 'rejected':
             return (
-                <Badge variant="destructive">
-                    <X className="mr-1 h-3 w-3" /> Rejected
+                <Badge variant="destructive" className="gap-1 font-normal">
+                    <X className="h-3 w-3" /> Rejected
                 </Badge>
             );
         default:
-            return <Badge variant="outline">{status}</Badge>;
+            return (
+                <Badge variant="outline" className="font-normal">
+                    {status}
+                </Badge>
+            );
     }
+}
+
+function TabCount({ count }: Readonly<{ count: number }>) {
+    return (
+        <span
+            className={cn(
+                'ml-1.5 inline-flex min-w-5 items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold tabular-nums',
+                'bg-muted text-muted-foreground group-data-[state=active]:bg-primary/15 group-data-[state=active]:text-primary',
+            )}
+        >
+            {count}
+        </span>
+    );
 }
 
 export default function MyApprovalsPage() {
@@ -106,9 +210,9 @@ export default function MyApprovalsPage() {
                 queryClient.invalidateQueries({ queryKey: ['my-approvals'] });
                 toast.success(`Request ${actionDialog.type}d successfully`);
             })
-            .catch((error) => {
+            .catch((err) => {
                 toast.error(`Failed to ${actionDialog.type} request`);
-                console.error(error);
+                console.error(err);
             })
             .finally(() => {
                 setProcessing(false);
@@ -116,7 +220,7 @@ export default function MyApprovalsPage() {
     };
 
     const getDocUrl = (request: ApprovalRequest) => {
-        const type = request.approvable_type.split('\\').pop();
+        const type = shortApprovableType(request.approvable_type);
         const id = request.approvable_id;
         const ulid = request.approvable?.ulid;
 
@@ -140,131 +244,154 @@ export default function MyApprovalsPage() {
     ) => {
         if (!items || items.length === 0) {
             return (
-                <div className="mt-4 flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 p-8 text-center">
-                    <Clock className="mb-3 h-10 w-10 text-muted-foreground/50" />
-                    <h3 className="text-lg font-medium">No requests found</h3>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                        You're all caught up!
+                <div className="flex flex-col items-center justify-center rounded-md border border-dashed bg-muted/15 px-4 py-8 text-center">
+                    <Clock className="mb-2 h-8 w-8 text-muted-foreground/40" />
+                    <h3 className="text-sm font-medium">No requests found</h3>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                        You&apos;re all caught up.
                     </p>
                 </div>
             );
         }
 
         return (
-            <div className="mt-4 space-y-4">
-                {items.map((step: ApprovalRequestStep) => (
-                    <Card
-                        key={step.id}
-                        className="transition-all hover:shadow-md"
-                    >
-                        <CardContent className="p-4 sm:p-6">
-                            <div className="flex flex-col gap-4">
-                                <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-                                    <div className="min-w-0 flex-1 space-y-1">
-                                        <div className="flex items-center gap-2">
-                                            <Badge
-                                                variant="outline"
-                                                className="text-[10px] tracking-wider text-muted-foreground uppercase"
-                                            >
-                                                {step.request.approvable_type
-                                                    .split('\\')
-                                                    .pop()}
-                                            </Badge>
-                                            <span className="text-sm font-medium text-muted-foreground">
-                                                Ref #
-                                                {step.request.approvable_id}
-                                            </span>
-                                            <StatusBadge status={step.status} />
-                                        </div>
-                                        <h4 className="text-md mt-2 font-semibold">
-                                            {step.flowStep?.name ||
-                                                'Approval Step'}
-                                        </h4>
-                                        {step.request.approvable && (
-                                            <div className="text-sm font-medium">
-                                                {step.request.approvable
-                                                    .asset_code && (
-                                                    <span className="mr-2 rounded bg-muted px-1 font-mono text-xs">
-                                                        {
-                                                            step.request
-                                                                .approvable
-                                                                .asset_code
-                                                        }
-                                                    </span>
-                                                )}
-                                                {step.request.approvable.name ||
-                                                    step.request.approvable
-                                                        .description}
-                                            </div>
-                                        )}
-                                        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                                            <span>
-                                                Submitted by{' '}
-                                                {step.request.submitter?.name ||
-                                                    'Unknown'}
-                                            </span>
-                                            <span>•</span>
-                                            <span>
-                                                {step.request.submitted_at
-                                                    ? formatDistanceToNow(
-                                                          new Date(
-                                                              step.request
-                                                                  .submitted_at,
-                                                          ),
-                                                          { addSuffix: true },
-                                                      )
-                                                    : ''}
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div className="w-full sm:w-auto sm:shrink-0">
-                                        <Button
-                                            size="sm"
-                                            variant="ghost"
-                                            className="w-full sm:w-auto"
-                                            asChild
-                                        >
-                                            <Link to={getDocUrl(step.request)}>
-                                                <Eye className="mr-2 h-4 w-4" />{' '}
-                                                View Doc
-                                            </Link>
-                                        </Button>
-                                    </div>
-                                </div>
+            <div className="space-y-2">
+                {items.map((step: ApprovalRequestStep) => {
+                    const typeLabel = formatApprovableTypeLabel(
+                        step.request.approvable_type,
+                    );
+                    const title = documentTitle(step);
+                    const stepLabel =
+                        step.flow_step?.name?.trim() ||
+                        step.flowStep?.name?.trim() ||
+                        null;
+                    const submitted = formatSubmittedAt(
+                        step.request.submitted_at,
+                    );
+                    const showStepUnderTitle =
+                        Boolean(stepLabel) && stepLabel !== title;
 
-                                {isPendingTab && (
-                                    <div className="flex w-full flex-wrap items-center gap-2 border-t pt-3">
-                                        <Button
-                                            size="sm"
-                                            variant="outline"
-                                            className="w-full border-emerald-600 bg-emerald-600 text-white transition-colors hover:border-emerald-700 hover:bg-emerald-700 hover:text-white focus-visible:ring-emerald-300 sm:w-auto dark:border-emerald-500 dark:bg-emerald-500 dark:hover:border-emerald-400 dark:hover:bg-emerald-400"
-                                            onClick={() =>
-                                                openActionDialog(
-                                                    'approve',
-                                                    step,
-                                                )
-                                            }
-                                        >
-                                            <Check className="mr-1 h-4 w-4" />{' '}
-                                            Approve
-                                        </Button>
-                                        <Button
-                                            size="sm"
-                                            variant="outline"
-                                            className="w-full border-rose-600 bg-rose-600 text-white transition-colors hover:border-rose-700 hover:bg-rose-700 hover:text-white focus-visible:ring-rose-300 sm:w-auto dark:border-rose-500 dark:bg-rose-500 dark:hover:border-rose-400 dark:hover:bg-rose-400"
-                                            onClick={() =>
-                                                openActionDialog('reject', step)
-                                            }
-                                        >
-                                            <X className="mr-1 h-4 w-4" />{' '}
-                                            Reject
-                                        </Button>
+                    return (
+                        <Card
+                            key={step.id}
+                            className="border-border/80 shadow-none transition-colors hover:bg-muted/20"
+                        >
+                            <CardContent className="p-3 sm:p-3.5">
+                                <div className="flex flex-col gap-2.5">
+                                    <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-start">
+                                        <div className="min-w-0 flex-1 space-y-1">
+                                            <div className="flex flex-wrap items-center gap-1.5">
+                                                <Badge
+                                                    variant="outline"
+                                                    className="h-5 border-border/70 px-1.5 text-[11px] font-medium tracking-normal text-foreground"
+                                                >
+                                                    {typeLabel}
+                                                </Badge>
+                                                <span className="font-mono text-[11px] text-muted-foreground tabular-nums">
+                                                    #{step.request.approvable_id}
+                                                </span>
+                                                <StatusBadge
+                                                    status={step.status}
+                                                />
+                                            </div>
+                                            <h4 className="text-sm leading-snug font-semibold tracking-tight text-foreground">
+                                                {title}
+                                            </h4>
+                                            {showStepUnderTitle ? (
+                                                <p className="text-xs text-muted-foreground">
+                                                    Step: {stepLabel}
+                                                </p>
+                                            ) : null}
+                                            <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
+                                                <span>
+                                                    Submitted by{' '}
+                                                    {step.request.submitter
+                                                        ?.name || 'Unknown'}
+                                                </span>
+                                                {submitted ? (
+                                                    <>
+                                                        <span
+                                                            aria-hidden
+                                                            className="text-border"
+                                                        >
+                                                            ·
+                                                        </span>
+                                                        <time
+                                                            dateTime={
+                                                                step.request
+                                                                    .submitted_at
+                                                            }
+                                                            title={
+                                                                submitted.absolute
+                                                            }
+                                                        >
+                                                            {submitted.relative}
+                                                            <span className="text-muted-foreground/70">
+                                                                {' '}
+                                                                (
+                                                                {
+                                                                    submitted.absolute
+                                                                }
+                                                                )
+                                                            </span>
+                                                        </time>
+                                                    </>
+                                                ) : null}
+                                            </div>
+                                        </div>
+                                        <div className="w-full sm:w-auto sm:shrink-0">
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-8 w-full px-2 sm:w-auto"
+                                                asChild
+                                            >
+                                                <Link
+                                                    to={getDocUrl(step.request)}
+                                                >
+                                                    <Eye className="mr-1.5 h-3.5 w-3.5" />
+                                                    View Doc
+                                                </Link>
+                                            </Button>
+                                        </div>
                                     </div>
-                                )}
-                            </div>
-                        </CardContent>
-                    </Card>
-                ))}
+
+                                    {isPendingTab && (
+                                        <div className="flex w-full flex-wrap items-center gap-1.5 border-t border-border/60 pt-2">
+                                            <Button
+                                                size="sm"
+                                                className="h-8 w-full border-0 bg-emerald-600 text-white hover:bg-emerald-700 focus-visible:ring-emerald-300 sm:w-auto dark:bg-emerald-600 dark:hover:bg-emerald-500"
+                                                onClick={() =>
+                                                    openActionDialog(
+                                                        'approve',
+                                                        step,
+                                                    )
+                                                }
+                                            >
+                                                <Check className="mr-1 h-3.5 w-3.5" />
+                                                Approve
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="destructive"
+                                                className="h-8 w-full sm:w-auto"
+                                                onClick={() =>
+                                                    openActionDialog(
+                                                        'reject',
+                                                        step,
+                                                    )
+                                                }
+                                            >
+                                                <X className="mr-1 h-3.5 w-3.5" />
+                                                Reject
+                                            </Button>
+                                        </div>
+                                    )}
+                                </div>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
             </div>
         );
     };
@@ -282,48 +409,69 @@ export default function MyApprovalsPage() {
                 </title>
             </Helmet>
 
-            <div className="mx-auto max-w-6xl space-y-6 p-4 sm:p-6">
-                <div>
-                    <h1 className="text-3xl font-bold tracking-tight">
-                        Approval Inbox
-                    </h1>
-                    <p className="mt-2 text-muted-foreground">
-                        Manage all documents and requests requiring your
-                        attention.
-                    </p>
-                </div>
+            <div className="mx-auto max-w-5xl space-y-4 p-4 sm:p-5">
+                <PageHeader
+                    title="My Approvals"
+                    description="Review and act on documents waiting for your decision."
+                    meta={
+                        !isLoading && !error ? (
+                            <span>
+                                {pending.length} pending · {approved.length}{' '}
+                                approved · {rejected.length} rejected
+                            </span>
+                        ) : undefined
+                    }
+                />
 
                 {isLoading && (
-                    <div className="flex items-center gap-2 rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+                    <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2.5 text-sm text-muted-foreground">
                         <Loader2 className="h-4 w-4 animate-spin" />
                         Loading approvals...
                     </div>
                 )}
 
                 {error && (
-                    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                    <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive">
                         Failed to load approvals. Please refresh and try again.
                     </div>
                 )}
 
-                <Tabs defaultValue="pending" className="w-full">
-                    <TabsList className="grid w-full grid-cols-4 lg:w-[500px]">
-                        <TabsTrigger value="pending">Pending</TabsTrigger>
-                        <TabsTrigger value="approved">Approved</TabsTrigger>
-                        <TabsTrigger value="rejected">Rejected</TabsTrigger>
-                        <TabsTrigger value="all">All</TabsTrigger>
+                <Tabs defaultValue="pending" className="w-full gap-3">
+                    <TabsList className="grid h-9 w-full grid-cols-4 lg:w-[28rem]">
+                        <TabsTrigger value="pending" className="group text-xs sm:text-sm">
+                            Pending
+                            <TabCount count={pending.length} />
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="approved"
+                            className="group text-xs sm:text-sm"
+                        >
+                            Approved
+                            <TabCount count={approved.length} />
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="rejected"
+                            className="group text-xs sm:text-sm"
+                        >
+                            Rejected
+                            <TabCount count={rejected.length} />
+                        </TabsTrigger>
+                        <TabsTrigger value="all" className="group text-xs sm:text-sm">
+                            All
+                            <TabCount count={all.length} />
+                        </TabsTrigger>
                     </TabsList>
 
-                    <TabsContent value="pending" className="mt-6">
+                    <TabsContent value="pending" className="mt-0">
                         {renderList(pending, true)}
                     </TabsContent>
-                    <TabsContent value="approved" className="mt-6">
+                    <TabsContent value="approved" className="mt-0">
                         {renderList(approved, false)}
                     </TabsContent>
-                    <TabsContent value="rejected" className="mt-6">
+                    <TabsContent value="rejected" className="mt-0">
                         {renderList(rejected, false)}
                     </TabsContent>
-                    <TabsContent value="all" className="mt-6">
+                    <TabsContent value="all" className="mt-0">
                         {renderList(all, false)}
                     </TabsContent>
                 </Tabs>

--- a/resources/js/pages/my-approvals/index.tsx
+++ b/resources/js/pages/my-approvals/index.tsx
@@ -288,7 +288,8 @@ export default function MyApprovalsPage() {
                                                     {typeLabel}
                                                 </Badge>
                                                 <span className="font-mono text-[11px] text-muted-foreground tabular-nums">
-                                                    #{step.request.approvable_id}
+                                                    #
+                                                    {step.request.approvable_id}
                                                 </span>
                                                 <StatusBadge
                                                     status={step.status}
@@ -438,7 +439,10 @@ export default function MyApprovalsPage() {
 
                 <Tabs defaultValue="pending" className="w-full gap-3">
                     <TabsList className="grid h-9 w-full grid-cols-4 lg:w-[28rem]">
-                        <TabsTrigger value="pending" className="group text-xs sm:text-sm">
+                        <TabsTrigger
+                            value="pending"
+                            className="group text-xs sm:text-sm"
+                        >
                             Pending
                             <TabCount count={pending.length} />
                         </TabsTrigger>
@@ -456,7 +460,10 @@ export default function MyApprovalsPage() {
                             Rejected
                             <TabCount count={rejected.length} />
                         </TabsTrigger>
-                        <TabsTrigger value="all" className="group text-xs sm:text-sm">
+                        <TabsTrigger
+                            value="all"
+                            className="group text-xs sm:text-sm"
+                        >
                             All
                             <TabCount count={all.length} />
                         </TabsTrigger>

--- a/task.md
+++ b/task.md
@@ -1,10 +1,10 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-11  
-**Current milestone:** Visual audit — T1–T5 + closeout merged; harness presets open; My Approvals open  
-**Branch tip (this work):** `chore/va-harness-allowlist` @ `485a2203`  
-**main tip (when last pulled):** `e1e1bd20` (closeout #95)  
-**Open PRs:** [#96](https://github.com/gmedia/erp/pull/96) My Approvals · [#97](https://github.com/gmedia/erp/pull/97) harness presets  
+**Current milestone:** Visual audit — My Approvals chrome (**PR #96**) rebased onto main (post-#97)  
+**Branch:** `feat/va-my-approvals-chrome`  
+**main tip:** includes **#97** harness presets  
+**Open PRs:** [#96](https://github.com/gmedia/erp/pull/96) My Approvals · [#98](https://github.com/gmedia/erp/pull/98) capture auth (MERGEABLE after rebase)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -20,17 +20,21 @@
 - **HF-1–3** on main  
 - **T1–T5** PRs #90–#94 merged  
 - **Closeout** #95 merged  
-- Full re-smoke **84/85** (`/asset-models` → login)  
-- **My Approvals chrome** — PR **#96** (branch `feat/va-my-approvals-chrome`)  
-- **Harness allowlist** — PR **#97** (`VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json`)
+- Full re-smoke **84/85** (`/asset-models` → login; fixed on **#98**)  
+- **Harness allowlist** — **#97 merged** (`VISUAL_AUDIT_PRESET` + `presets.json`)  
+- **My Approvals exception chrome** — this branch / **PR #96**  
+  - Readable type labels; document-first titles; denser cards; `PageHeader` + counts; tab badges; absolute+relative times  
+  - `npm run types` clean  
 
 ## Themes status
 
 | ID | Theme | Status |
 |----|-------|--------|
 | T1–T5 | Shared shell | **merged** |
-| EX-1 | My Approvals inbox | **PR #96 open** |
-| Harness | Named presets | **PR #97 open** |
+| Closeout | BACKLOG / task | **merged** (#95) |
+| Harness | Named presets | **merged** (#97) |
+| EX-1 | My Approvals inbox | **PR #96** (this branch) |
+| EX-auth | Capture auth settle | **PR #98** |
 
 ## Do not
 
@@ -38,31 +42,13 @@
 - Use default `playwright.config.ts` for visual (`migrate:fresh`)  
 - Commit untracked `e2e/`  
 - Wait on CI  
-- Parallel tool fan-out (≤3 tools/turn; post-kill = 1)
-
-## Selective capture (PR #97)
-
-```bash
-VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
-  npx playwright test -c playwright.visual-audit.config.ts
-```
-
-Presets: `shells` | `wave-0` | `exceptions` | `dashboards` | `smoke`  
-Or: `VISUAL_AUDIT_ROUTES=/dashboard,/my-approvals`  
-Without preset/routes → full 85 (avoid on low RAM).
 
 ## Recommended next
 
-1. Merge **#96** / **#97** when ready (no CI wait)  
-2. Optional: `PRESET=smoke` or `shells` local re-smoke  
-3. Next exception: **asset profile** or dense modal (new branch from main)  
-4. Optional: fix `/asset-models` capture auth bounce  
+1. Force-push this branch after rebase → clear #96 conflicts.  
+2. Merge #96 / #98 when green (do not poll CI).  
+3. Next product exception: **asset profile** or dense modal (new branch from main).
 
 ## Continuation Prompt
 
-```
-Read task.md. Open PRs #96 (My Approvals) and #97 (harness presets).
-Do not poll CI. Next shippable: merge those or start exception surface
-(asset profile / modal) from main. Prefer VISUAL_AUDIT_PRESET=shells for re-smoke.
-Keep e2e/ untracked. AGENTS concurrency ≤3 tools/turn.
-```
+Finish #96 rebase/push. #98 already rebased MERGEABLE. Keep one task per branch. Do not poll CI. Keep `e2e/` untracked.


### PR DESCRIPTION
## What was done
- My Approvals exception-surface chrome after T1–T5 shared-shell wave
- Human-readable approvable type labels (not `PURCHASEORDER` all-caps)
- Document-first card titles; step name as secondary line when useful
- Denser cards (`p-3`, tighter gaps, no heavy shadow)
- `PageHeader` + pending/approved/rejected meta counts
- Tab badges with counts; slightly denser tab chrome
- Relative + absolute submitted time (`title` + visible absolute)

## Files changed
- `resources/js/pages/my-approvals/index.tsx` — inbox UI only

## Verification
- [x] `npm run types` clean
- [ ] Manual smoke at `/my-approvals` (optional)
- [ ] Do **not** wait on CI

## Next steps
- Optional: re-capture `wave-0/my-approvals.png` with visual-audit config
- Later: asset profile / modal exception surfaces; harness allowlist; residual FINDINGS