### PR TITLE
chore: visual-audit harness route presets (selective capture)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -1,8 +1,8 @@
 # Visual Audit — Backlog
 
-**Last updated:** 2026-08-10  
+**Last updated:** 2026-08-11  
 **Source:** multimodal-looker Wave 0–1  
-**Policy:** T1–T5 landed on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke of Wave 0–1 shells, then exception surfaces only.
+**Policy:** T1–T5 landed on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`, then exception surfaces only.
 
 ## Open (prioritized)
 
@@ -47,9 +47,23 @@
 - PNGs stay gitignored; cite paths in MR description
 - Agents: **AGENTS.md Tool & Process Concurrency** (≤3 tools/turn; post-kill = 1 tool/turn)
 
+## Harness route selection
+
+| Priority | Env | Effect |
+|----------|-----|--------|
+| 1 | `VISUAL_AUDIT_ROUTES=/a,/b` | Comma list only |
+| 2 | `VISUAL_AUDIT_PRESET=shells` | Named set in `presets.json` (`shells`, `wave-0`, `exceptions`, `dashboards`, `smoke`) |
+| 3 | (none) | Full `url-list.json` (85) — avoid on low-RAM hosts |
+
+```bash
+VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
+  npx playwright test -c playwright.visual-audit.config.ts
+```
+
 ## Next agent action
 
-1. ~~Selective re-smoke~~ **Done 2026-08-10:** `VISUAL_AUDIT=1` + `playwright.visual-audit.config.ts` — **84/85 PASS**; **FAIL** `/asset-models` (bounced to `/login`). Note: harness walks full `url-list.json` (85), not Wave 0–1 only — treat as opportunistic full leaf pass; PNGs gitignored under `docs/visual-audit/waves/`  
-2. Optional multimodal / human pass on key Wave 0–1 PNGs (employees, departments, PO, stock-movement report, dashboard, FD, accounts, balance-sheet)  
-3. If clean: one **exception surface** MR (My Approvals **or** asset profile **or** modal) — not a second mass capture  
-4. Optional: add route filter to visual-audit harness so “selective” ≠ all 85  
+1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login`
+2. ~~Harness allowlist~~ **Done 2026-08-11:** `VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json`
+3. Optional multimodal / human pass on Wave 0–1 PNGs
+4. Exception surface MRs (My Approvals #96, then asset profile / modal) — not mass capture
+5. Optional: fix `/asset-models` capture auth bounce

--- a/docs/visual-audit/presets.json
+++ b/docs/visual-audit/presets.json
@@ -1,0 +1,55 @@
+{
+  "description": "Named route sets for VISUAL_AUDIT_PRESET. Used by tests/e2e/visual-audit/capture.spec.ts. Prefer presets over full url-list.json (85 routes) on constrained hosts.",
+  "presets": {
+    "wave-0": {
+      "note": "Original Wave 0 shell sample (shared chrome review)",
+      "routes": [
+        "/dashboard",
+        "/financial-dashboard",
+        "/employees",
+        "/departments",
+        "/purchase-orders",
+        "/accounts",
+        "/reports/balance-sheet",
+        "/reports/stock-movement"
+      ]
+    },
+    "shells": {
+      "note": "Alias of wave-0 — selective re-smoke after T1–T5",
+      "routes": [
+        "/dashboard",
+        "/financial-dashboard",
+        "/employees",
+        "/departments",
+        "/purchase-orders",
+        "/accounts",
+        "/reports/balance-sheet",
+        "/reports/stock-movement"
+      ]
+    },
+    "exceptions": {
+      "note": "Non-DataTable / exception surfaces (post shared-shell)",
+      "routes": [
+        "/my-approvals",
+        "/assets",
+        "/accounts",
+        "/dashboard",
+        "/financial-dashboard"
+      ]
+    },
+    "dashboards": {
+      "note": "KPI / home dashboards only",
+      "routes": [
+        "/dashboard",
+        "/financial-dashboard",
+        "/aging-dashboard",
+        "/asset-dashboard",
+        "/pipeline-dashboard"
+      ]
+    },
+    "smoke": {
+      "note": "Minimal 3-route harness check",
+      "routes": ["/dashboard", "/departments", "/employees"]
+    }
+  }
+}

--- a/playwright.visual-audit.config.ts
+++ b/playwright.visual-audit.config.ts
@@ -4,8 +4,21 @@ import { defineConfig } from '@playwright/test';
  * Visual audit only: no migrate:fresh, no global seed.
  * Requires app already up (Sail) with usable admin login.
  *
- * VISUAL_AUDIT=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
- *   npx playwright test -c playwright.visual-audit.config.ts
+ * Full catalog (85 routes — heavy; avoid on low-RAM hosts):
+ *   VISUAL_AUDIT=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
+ *     npx playwright test -c playwright.visual-audit.config.ts
+ *
+ * Selective re-smoke (recommended):
+ *   VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
+ *     npx playwright test -c playwright.visual-audit.config.ts
+ *
+ * Ad-hoc routes:
+ *   VISUAL_AUDIT=1 VISUAL_AUDIT_ROUTES=/dashboard,/my-approvals \
+ *     PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
+ *     npx playwright test -c playwright.visual-audit.config.ts
+ *
+ * Presets: docs/visual-audit/presets.json (shells, wave-0, exceptions, dashboards, smoke)
+ * Workers forced to 1 — do not raise on this host.
  */
 export default defineConfig({
   testDir: 'tests/e2e/visual-audit',

--- a/task.md
+++ b/task.md
@@ -1,9 +1,10 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-10  
-**Current milestone:** Visual audit — **T1–T5 merged**; next = selective re-smoke / exception surfaces  
-**Branch:** `main` @ `03c22267` (T5 #94 squash)  
-**T1–T5:** PRs #90–#94 **merged**  
+**Last updated:** 2026-08-11  
+**Current milestone:** Visual audit — T1–T5 + closeout merged; harness presets open; My Approvals open  
+**Branch tip (this work):** `chore/va-harness-allowlist` @ `485a2203`  
+**main tip (when last pulled):** `e1e1bd20` (closeout #95)  
+**Open PRs:** [#96](https://github.com/gmedia/erp/pull/96) My Approvals · [#97](https://github.com/gmedia/erp/pull/97) harness presets  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -17,52 +18,51 @@
 
 - Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86)  
 - **HF-1–3** on main  
-- **T1** DataTable shell v2 — **#90**  
-- **T2** Sidebar density — **#91**  
-- **T3** Page header — **#92**  
-- **T4** Dashboard & KPI — **#93** (FD-02/03, BS-02, DASH-01)  
-- **T5** Sparse & report density — **#94** (SHELL-05; denser list/report shells)
+- **T1–T5** PRs #90–#94 merged  
+- **Closeout** #95 merged  
+- Full re-smoke **84/85** (`/asset-models` → login)  
+- **My Approvals chrome** — PR **#96** (branch `feat/va-my-approvals-chrome`)  
+- **Harness allowlist** — PR **#97** (`VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json`)
 
 ## Themes status
 
 | ID | Theme | Status |
 |----|-------|--------|
-| T1 | DataTable shell v2 | **merged** (#90) |
-| T2 | Sidebar IA residual | **merged** (#91) |
-| T3 | Page header contract | **merged** (#92) |
-| T4 | Dashboard & KPI | **merged** (#93) |
-| T5 | Sparse & report density | **merged** (#94) |
+| T1–T5 | Shared shell | **merged** |
+| EX-1 | My Approvals inbox | **PR #96 open** |
+| Harness | Named presets | **PR #97 open** |
 
 ## Do not
 
-- Mass-capture Wave 2 / remaining ~78 routes (exception surfaces only after re-smoke)  
-- Use default `playwright.config.ts` for visual (migrate:fresh)  
-- Redesign all 85 modules in one MR  
-- Commit local untracked `e2e/` junk  
-- Wait on CI (AGENTS: never wait for CI)  
-- Parallel tool fan-out (AGENTS: ≤3 tools/turn; post-kill = 1)
+- Mass-capture Wave 2 / remaining ~78 routes  
+- Use default `playwright.config.ts` for visual (`migrate:fresh`)  
+- Commit untracked `e2e/`  
+- Wait on CI  
+- Parallel tool fan-out (≤3 tools/turn; post-kill = 1)
 
-## Re-smoke (2026-08-10)
+## Selective capture (PR #97)
 
-- Command: `VISUAL_AUDIT=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 npx playwright test -c playwright.visual-audit.config.ts`
-- Result: **84 pass / 1 fail** (`/asset-models` → login bounce)
-- PNGs: `docs/visual-audit/waves/**` (gitignored). Harness uses full MenuSeeder url-list (85), not Wave 0–1 subset
+```bash
+VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
+  npx playwright test -c playwright.visual-audit.config.ts
+```
 
-## Recommended next (pick one)
+Presets: `shells` | `wave-0` | `exceptions` | `dashboards` | `smoke`  
+Or: `VISUAL_AUDIT_ROUTES=/dashboard,/my-approvals`  
+Without preset/routes → full 85 (avoid on low RAM).
 
-### A — Human / multimodal spot-check (recommended)
-- Review Wave 0–1 shell PNGs post-T5 (SHELL-05 density, no T1–T4 regressions)
-- Optionally fix `/asset-models` auth/permission for visual capture
+## Recommended next
 
-### B — Exception surface (one MR)
-- My Approvals **or** asset profile **or** dense modal — not full leaf inventory
-
-### C — Residual FINDINGS (optional product)
-- PO-05 Grand Total column; BS-01 Compare label; SHELL-12 home vs FD product call
-
-### D — Harness improvement (optional chore)
-- Env allowlist so re-smoke can be truly selective (7–8 routes)
+1. Merge **#96** / **#97** when ready (no CI wait)  
+2. Optional: `PRESET=smoke` or `shells` local re-smoke  
+3. Next exception: **asset profile** or dense modal (new branch from main)  
+4. Optional: fix `/asset-models` capture auth bounce  
 
 ## Continuation Prompt
 
-Closeout PR #95 open. Main tip pre-closeout: `03c22267` (T5 #94). Re-smoke 84/85 done (asset-models fail). Next: spot-check PNGs or one exception-surface MR. Keep `e2e/` untracked.
+```
+Read task.md. Open PRs #96 (My Approvals) and #97 (harness presets).
+Do not poll CI. Next shippable: merge those or start exception surface
+(asset profile / modal) from main. Prefer VISUAL_AUDIT_PRESET=shells for re-smoke.
+Keep e2e/ untracked. AGENTS concurrency ≤3 tools/turn.
+```

--- a/tests/e2e/visual-audit/capture.spec.ts
+++ b/tests/e2e/visual-audit/capture.spec.ts
@@ -1,11 +1,17 @@
 /**
  * Opt-in visual audit capture (VISUAL_AUDIT=1). Not part of default E2E.
  *
- * VISUAL_AUDIT=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 PLAYWRIGHT_WORKERS=1 \
- *   npx playwright test tests/e2e/visual-audit/capture.spec.ts
+ * Prefer visual-audit config (no migrate:fresh):
+ *   VISUAL_AUDIT=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 \
+ *     npx playwright test -c playwright.visual-audit.config.ts
  *
- * VISUAL_AUDIT_ROUTES=/dashboard,/departments
- * VISUAL_AUDIT_WAVE=wave-0
+ * Route selection (first match wins):
+ *   1. VISUAL_AUDIT_ROUTES=/dashboard,/departments   — comma-separated
+ *   2. VISUAL_AUDIT_PRESET=shells|wave-0|exceptions|dashboards|smoke
+ *      — named sets in docs/visual-audit/presets.json
+ *   3. Full docs/visual-audit/url-list.json (85 routes) — avoid on low-RAM hosts
+ *
+ *   VISUAL_AUDIT_WAVE=wave-0   — PNG output dir under docs/visual-audit/waves/
  */
 import { test, expect } from '@playwright/test';
 import { mkdirSync, readFileSync, existsSync } from 'node:fs';
@@ -16,23 +22,71 @@ const enabled = process.env.VISUAL_AUDIT === '1';
 const wave = process.env.VISUAL_AUDIT_WAVE ?? 'wave-0';
 const outDir = join('docs/visual-audit/waves', wave);
 const urlListPath = 'docs/visual-audit/url-list.json';
+const presetsPath = 'docs/visual-audit/presets.json';
 
-function loadRoutes(): string[] {
-  const override = process.env.VISUAL_AUDIT_ROUTES?.trim();
-  if (override) {
-    return override
-      .split(',')
-      .map((r) => r.trim())
-      .filter(Boolean)
-      .map((r) => (r.startsWith('/') ? r : `/${r}`));
+type PresetsFile = {
+  presets?: Record<string, { routes?: string[]; note?: string }>;
+};
+
+function normalizeRoute(r: string): string {
+  const t = r.trim();
+  if (!t) {
+    return '';
   }
 
+  return t.startsWith('/') ? t : `/${t}`;
+}
+
+function parseCommaRoutes(raw: string): string[] {
+  return raw
+    .split(',')
+    .map(normalizeRoute)
+    .filter(Boolean);
+}
+
+function loadPresetRoutes(name: string): string[] {
+  if (!existsSync(presetsPath)) {
+    throw new Error(
+      `VISUAL_AUDIT_PRESET=${name} set but ${presetsPath} is missing`,
+    );
+  }
+
+  const file = JSON.parse(readFileSync(presetsPath, 'utf8')) as PresetsFile;
+  const preset = file.presets?.[name];
+  if (!preset?.routes?.length) {
+    const known = Object.keys(file.presets ?? {}).join(', ') || '(none)';
+    throw new Error(
+      `Unknown VISUAL_AUDIT_PRESET="${name}". Known: ${known}`,
+    );
+  }
+
+  return preset.routes.map(normalizeRoute).filter(Boolean);
+}
+
+function loadFullUrlList(): string[] {
   if (!existsSync(urlListPath)) {
     return ['/dashboard'];
   }
 
-  const raw = JSON.parse(readFileSync(urlListPath, 'utf8')) as { routes?: string[] };
+  const raw = JSON.parse(readFileSync(urlListPath, 'utf8')) as {
+    routes?: string[];
+  };
+
   return raw.routes?.length ? raw.routes : ['/dashboard'];
+}
+
+function loadRoutes(): string[] {
+  const override = process.env.VISUAL_AUDIT_ROUTES?.trim();
+  if (override) {
+    return parseCommaRoutes(override);
+  }
+
+  const preset = process.env.VISUAL_AUDIT_PRESET?.trim();
+  if (preset) {
+    return loadPresetRoutes(preset);
+  }
+
+  return loadFullUrlList();
 }
 
 const routes = loadRoutes();


### PR DESCRIPTION
## What was done
- Named route presets in `docs/visual-audit/presets.json` (`shells`, `wave-0`, `exceptions`, `dashboards`, `smoke`)
- Capture harness: `VISUAL_AUDIT_ROUTES` → `VISUAL_AUDIT_PRESET` → full `url-list.json`
- Document selection order + example in BACKLOG; config header examples updated

## Files changed
- `docs/visual-audit/presets.json` — preset definitions (all routes ⊆ url-list)
- `tests/e2e/visual-audit/capture.spec.ts` — preset loader
- `playwright.visual-audit.config.ts` — usage notes
- `docs/visual-audit/BACKLOG.md` — harness table + next actions

## Verification
- [x] All preset routes exist in `url-list.json`
- [ ] Optional: `VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=smoke PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 npx playwright test -c playwright.visual-audit.config.ts`
- [ ] Do **not** use default Playwright config (`migrate:fresh`)
- [ ] Never commit `e2e/` or PNG waves

## Next steps
- Merge when ready (no CI wait required for this chore)
- Prefer `VISUAL_AUDIT_PRESET=shells` for re-smoke after shell changes
- Optional: fix `/asset-models` login bounce; next exception surface after #96

Independent of PR #96 (My Approvals).