### PR TITLE
fix: visual audit capture auth settle (/asset-models)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -4,48 +4,15 @@
 **Source:** multimodal-looker Wave 0–1  
 **Policy:** T1–T5 landed on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`, then exception surfaces only.
 
-## Open (prioritized)
+## Themes
 
-| ID | Pri | Theme | Scope | Status | Notes |
-|----|-----|-------|-------|--------|-------|
-| — | — | — | — | **none** | All planned shared-shell themes T1–T5 closed. Next work is re-smoke / exceptions (below). |
-
-## Hotfixes (can ship before full T1)
-
-| ID | Pri | Item | Status |
-|----|-----|------|--------|
-| HF-1 | P0 | Financial dashboard: negative Cash Balance must not use success green | done (fix/hf1) |
-| HF-2 | P0 | Employees (and wide tables): sticky Actions + horizontal scroll | done (fix/hf2) |
-| HF-3 | P1 | Accounts: fix sidebar active state for Chart of Accounts | done (fix/hf3) |
-
-## Done
-
-| ID | Notes |
-|----|-------|
-| VA-W0-SETUP | harness, url-list, visual-audit config, smoke |
-| VA-W1-CAPTURE | 7 routes PNG |
-| VA-W1-VISION | multimodal-looker full audit; stop-rule YES |
-| T1 | PR #90 — DataTable shell v2 |
-| T2 | PR #91 — Sidebar density + active |
-| T3 | PR #92 — Page header contract |
-| T4 | PR #93 — Dashboard & KPI semantics |
-| T5 | PR #94 — Sparse & report density (SHELL-05; RSM-01) |
-
-## Residual / optional (not shared-shell themes)
-
-| ID | Pri | Item | Notes |
-|----|-----|------|-------|
-| PO-05 | P2 | Grand Total column visibility | Product/column config, not shell |
-| BS-01 | P2 | Compare “None” label opacity | Filter UX |
-| SHELL-12 | P3 | Home stub vs financial dashboard | Product decision |
-
-## Implementation rules
-
-- One theme ≈ one `feat/*` or `fix/*` MR (AGENTS.md)
-- Prefer shared chrome over per-module hacks
-- Re-capture only **exception** surfaces later (modals, mobile, dark, My Approvals, asset profile) — not 85 leaves
-- PNGs stay gitignored; cite paths in MR description
-- Agents: **AGENTS.md Tool & Process Concurrency** (≤3 tools/turn; post-kill = 1 tool/turn)
+| ID | Theme | Status |
+|----|-------|--------|
+| T1–T5 | Shared shell | **merged** (#90–#94) |
+| Closeout | BACKLOG / task handoff | **merged** (#95) |
+| Harness | Named presets | **merged** (#97) |
+| EX-1 | My Approvals inbox | **PR #96 open** (may conflict on `task.md`) |
+| EX-auth | Capture auth settle | **PR #98** — rebase onto main after #97 |
 
 ## Harness route selection
 
@@ -62,8 +29,9 @@ VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:8
 
 ## Next agent action
 
-1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login`
-2. ~~Harness allowlist~~ **Done 2026-08-11:** `VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json`
-3. Optional multimodal / human pass on Wave 0–1 PNGs
-4. Exception surface MRs (My Approvals #96, then asset profile / modal) — not mass capture
-5. Optional: fix `/asset-models` capture auth bounce
+1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login` (harness race, not permission).
+2. ~~Harness allowlist~~ **Done 2026-08-11:** `VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json` (**#97 merged**).
+3. ~~Fix `/asset-models` capture~~ **PR #98:** `requireDashboard: true` + one re-login retry; local `VISUAL_AUDIT_ROUTES=/asset-models,/asset-categories,/dashboard` → **3 PASS**. Rebase onto main after #97.
+4. Resolve **#96** merge conflicts (`task.md` vs main; keep My Approvals TSX).
+5. Optional multimodal / human pass on Wave 0–1 PNGs.
+6. Next product: **asset profile** or dense modal (one MR from main after #96/#98).

--- a/task.md
+++ b/task.md
@@ -1,10 +1,10 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-11  
-**Current milestone:** Visual audit — My Approvals chrome (**PR #96**) rebased onto main (post-#97)  
-**Branch:** `feat/va-my-approvals-chrome`  
-**main tip:** includes **#97** harness presets  
-**Open PRs:** [#96](https://github.com/gmedia/erp/pull/96) My Approvals · [#98](https://github.com/gmedia/erp/pull/98) capture auth (MERGEABLE after rebase)  
+**Current milestone:** Visual audit — resolve #98 / #99 conflicts after #96 merge  
+**Branch tip (this work):** `fix/va-asset-models-capture-auth` (rebasing onto main)  
+**main tip:** includes **#96** My Approvals + **#97** harness (`361f28cb`)  
+**Open PRs:** [#98](https://github.com/gmedia/erp/pull/98) capture auth · [#99](https://github.com/gmedia/erp/pull/99) asset profile  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -17,24 +17,21 @@
 ## Done
 
 - Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86)  
-- **HF-1–3** on main  
-- **T1–T5** PRs #90–#94 merged  
-- **Closeout** #95 merged  
-- Full re-smoke **84/85** (`/asset-models` → login; fixed on **#98**)  
-- **Harness allowlist** — **#97 merged** (`VISUAL_AUDIT_PRESET` + `presets.json`)  
-- **My Approvals exception chrome** — this branch / **PR #96**  
-  - Readable type labels; document-first titles; denser cards; `PageHeader` + counts; tab badges; absolute+relative times  
-  - `npm run types` clean  
+- **HF-1–3** · **T1–T5** #90–#94 · **Closeout** #95 · **Harness** #97 · **My Approvals** #96 — **on main**  
+- Full re-smoke **84/85** historically (`/asset-models` → login)  
+- **Capture auth settle** — this branch / **PR #98**  
+  - `requireDashboard: true` + re-login retry on top of #97 presets  
+  - Local 3-route PASS pre-rebase  
 
 ## Themes status
 
 | ID | Theme | Status |
 |----|-------|--------|
 | T1–T5 | Shared shell | **merged** |
-| Closeout | BACKLOG / task | **merged** (#95) |
 | Harness | Named presets | **merged** (#97) |
-| EX-1 | My Approvals inbox | **PR #96** (this branch) |
-| EX-auth | Capture auth settle | **PR #98** |
+| EX-1 | My Approvals inbox | **merged** (#96) |
+| EX-auth | Capture auth settle | **PR #98** (rebasing) |
+| EX-asset-profile | Asset profile densify | **PR #99** |
 
 ## Do not
 
@@ -42,13 +39,27 @@
 - Use default `playwright.config.ts` for visual (`migrate:fresh`)  
 - Commit untracked `e2e/`  
 - Wait on CI  
+- Parallel tool fan-out (≤3 tools/turn; post-kill = 1)  
+
+## Validated (pre-rebase)
+
+```bash
+VISUAL_AUDIT=1 VISUAL_AUDIT_ROUTES=/asset-models,/asset-categories,/dashboard \
+  PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 PLAYWRIGHT_WORKERS=1 \
+  npx playwright test -c playwright.visual-audit.config.ts
+# → 3 passed (re-run after rebase if needed)
+```
 
 ## Recommended next
 
-1. Force-push this branch after rebase → clear #96 conflicts.  
-2. Merge #96 / #98 when green (do not poll CI).  
-3. Next product exception: **asset profile** or dense modal (new branch from main).
+1. Finish rebase #98 → force-with-lease push (MERGEABLE).  
+2. Rebase #99 onto main → resolve `task.md`/`BACKLOG` → push.  
+3. Merge #98 / #99 when ready (no CI wait).  
 
 ## Continuation Prompt
 
-Finish #96 rebase/push. #98 already rebased MERGEABLE. Keep one task per branch. Do not poll CI. Keep `e2e/` untracked.
+```
+Read task.md. Resolve #98 and #99 conflicts vs main (post-#96).
+Prefer rebase; keep capture auth + asset profile chrome.
+Do not poll CI. Keep e2e/ untracked. AGENTS ≤3 tools/turn.
+```

--- a/tests/e2e/visual-audit/capture.spec.ts
+++ b/tests/e2e/visual-audit/capture.spec.ts
@@ -108,12 +108,21 @@ test.describe('visual audit capture', () => {
     test(`capture ${route}`, async ({ page }) => {
       test.setTimeout(90_000);
 
-      await login(page, undefined, undefined, { requireDashboard: false });
+      await login(page, undefined, undefined, { requireDashboard: true });
       await page.setViewportSize({ width: 1440, height: 900 });
-      await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
-      await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);
-      await page.waitForTimeout(500);
+      const gotoTarget = async (): Promise<void> => {
+        await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+        await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);
+        await page.waitForTimeout(500);
+      };
+
+      await gotoTarget();
+
+      if (route !== '/login' && page.url().includes('/login')) {
+        await login(page, undefined, undefined, { requireDashboard: true });
+        await gotoTarget();
+      }
 
       const url = page.url();
       expect(url.includes('/login') && route !== '/login').toBeFalsy();


### PR DESCRIPTION
## What was done
- Hardened visual audit capture: `requireDashboard: true` after login + one re-login/re-goto if still on `/login`
- Root cause: harness race (SPA rehydrate), not missing `asset_model` permission (API `/api/asset-models` 200 for admin)
- Updated `task.md` + `BACKLOG.md` handoff

## Files changed
- `tests/e2e/visual-audit/capture.spec.ts` — auth settle + bounce retry
- `docs/visual-audit/BACKLOG.md` — next actions
- `task.md` — session handoff

## Verification
- [x] `VISUAL_AUDIT=1 VISUAL_AUDIT_ROUTES=/asset-models,/asset-categories,/dashboard PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 PLAYWRIGHT_WORKERS=1 npx playwright test -c playwright.visual-audit.config.ts` → **3 PASS**
- [ ] Full 85-route re-smoke optional after merge
- [ ] Do not commit `e2e/` junk

## Next steps
- Independent of #96 / #97
- After merge: exception surface (asset profile) or full visual re-smoke