### PR TITLE
feat: densify asset profile chrome (visual audit EX)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-08-11  
 **Source:** multimodal-looker Wave 0–1  
-**Policy:** T1–T5 landed on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`, then exception surfaces only.
+**Policy:** T1–T5 + harness presets on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`, then exception surfaces only.
 
 ## Themes
 
@@ -11,8 +11,54 @@
 | T1–T5 | Shared shell | **merged** (#90–#94) |
 | Closeout | BACKLOG / task handoff | **merged** (#95) |
 | Harness | Named presets | **merged** (#97) |
-| EX-1 | My Approvals inbox | **PR #96 open** (may conflict on `task.md`) |
-| EX-auth | Capture auth settle | **PR #98** — rebase onto main after #97 |
+| EX-1 | My Approvals inbox | **merged** (#96) |
+| EX-auth | Capture auth settle | **merged** (#98) |
+| EX-asset-profile | Asset profile chrome | **PR #99** (rebasing) |
+
+## Exception rows
+
+| ID | Pri | Theme | Scope | Status | Notes |
+|----|-----|-------|-------|--------|-------|
+| EX-1 | P1 | My Approvals chrome | `/my-approvals` | **merged #96** | Densify inbox |
+| EX-auth | P1 | Capture auth settle | visual harness | **merged #98** | `requireDashboard` + re-login |
+| EX-asset-profile | P1 | Asset profile chrome | `/assets/:ulid` | **PR #99** | PageHeader + compact tabs/cards |
+
+## Hotfixes (can ship before full T1)
+
+| ID | Pri | Item | Status |
+|----|-----|------|--------|
+| HF-1 | P0 | Financial dashboard: negative Cash Balance must not use success green | done (fix/hf1) |
+| HF-2 | P0 | Employees (and wide tables): sticky Actions + horizontal scroll | done (fix/hf2) |
+| HF-3 | P1 | Accounts: fix sidebar active state for Chart of Accounts | done (fix/hf3) |
+
+## Done
+
+| ID | Notes |
+|----|-------|
+| VA-W0-SETUP | harness, url-list, visual-audit config, smoke |
+| VA-W1-CAPTURE | 7 routes PNG |
+| VA-W1-VISION | multimodal-looker full audit; stop-rule YES |
+| T1 | PR #90 — DataTable shell v2 |
+| T2 | PR #91 — Sidebar density + active |
+| T3 | PR #92 — Page header contract |
+| T4 | PR #93 — Dashboard & KPI semantics |
+| T5 | PR #94 — Sparse & report density (SHELL-05; RSM-01) |
+
+## Residual / optional (not shared-shell themes)
+
+| ID | Pri | Item | Notes |
+|----|-----|------|-------|
+| PO-05 | P2 | Grand Total column visibility | Product/column config, not shell |
+| BS-01 | P2 | Compare “None” label opacity | Filter UX |
+| SHELL-12 | P3 | Home stub vs financial dashboard | Product decision |
+
+## Implementation rules
+
+- One theme ≈ one `feat/*` or `fix/*` MR (AGENTS.md)
+- Prefer shared chrome over per-module hacks
+- Re-capture only **exception** surfaces later (modals, mobile, dark, My Approvals, asset profile) — not 85 leaves
+- PNGs stay gitignored; cite paths in MR description
+- Agents: **AGENTS.md Tool & Process Concurrency** (≤3 tools/turn; post-kill = 1 tool/turn)
 
 ## Harness route selection
 
@@ -29,9 +75,9 @@ VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:8
 
 ## Next agent action
 
-1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login` (harness race, not permission).
+1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login` (fixed **#98 merged**).
 2. ~~Harness allowlist~~ **Done 2026-08-11:** `VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json` (**#97 merged**).
-3. ~~Fix `/asset-models` capture~~ **PR #98:** `requireDashboard: true` + one re-login retry; local `VISUAL_AUDIT_ROUTES=/asset-models,/asset-categories,/dashboard` → **3 PASS**. Rebase onto main after #97.
-4. Resolve **#96** merge conflicts (`task.md` vs main; keep My Approvals TSX).
-5. Optional multimodal / human pass on Wave 0–1 PNGs.
-6. Next product: **asset profile** or dense modal (one MR from main after #96/#98).
+3. ~~#96 / #98~~ **merged** on main.
+4. Finish **#99** rebase → MERGEABLE → merge when ready (no CI wait).
+5. Optional: selective capture of asset profile URL only; multimodal on Wave 0–1 PNGs.
+6. Optional residual FINDINGS (PO-05 / BS-01 / SHELL-12) only with product call — not mass Wave 2.

--- a/resources/js/pages/assets/profile.tsx
+++ b/resources/js/pages/assets/profile.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ApprovalHistoryTimeline } from '@/components/approvals/ApprovalHistoryTimeline';
+import { PageHeader } from '@/components/common/PageHeader';
 import { EntityStateActions } from '@/components/pipeline/EntityStateActions';
 import { EntityStateTimeline } from '@/components/pipeline/EntityStateTimeline';
 import { Badge } from '@/components/ui/badge';
@@ -42,7 +43,6 @@ import {
     Hash,
     History,
     Info,
-    Layers,
     Loader2,
     MapPin,
     Package,
@@ -215,158 +215,138 @@ export default function AssetProfile() {
                 <title>{`Asset Profile - ${item.asset_code}`}</title>
             </Helmet>
 
-            <div className="flex flex-col gap-6 p-6">
-                {/* Header Section - Enhanced */}
-                <div className="relative overflow-hidden rounded-xl border bg-gradient-to-r from-primary/5 via-primary/10 to-transparent p-6">
-                    <div className="absolute top-0 right-0 -z-10 h-64 w-64 opacity-20">
-                        <Package className="h-full w-full text-primary/30" />
-                    </div>
-                    <div className="flex flex-col justify-between gap-6 md:flex-row md:items-start">
-                        <div className="flex items-start gap-4">
-                            {/* Icon Box */}
-                            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary shadow-sm">
-                                <Layers className="h-8 w-8" />
-                            </div>
-                            <div className="space-y-2">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
-                                        {item.name}
-                                    </h1>
-                                    <Badge
-                                        variant="outline"
-                                        className="px-3 py-1 font-mono text-sm"
-                                    >
-                                        {item.asset_code}
-                                    </Badge>
-                                </div>
-                                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                                    <span className="flex items-center gap-1">
-                                        <Package className="h-4 w-4" />
-                                        {item.category?.name || 'Uncategorized'}
+            <div className="flex flex-col gap-4 p-4 md:p-6">
+                <PageHeader
+                    title={item.name}
+                    meta={
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                            <Badge
+                                variant="outline"
+                                className="font-mono text-xs"
+                            >
+                                {item.asset_code}
+                            </Badge>
+                            <span className="inline-flex items-center gap-1">
+                                <Package className="h-3.5 w-3.5" />
+                                {item.category?.name || 'Uncategorized'}
+                            </span>
+                            <span className="hidden text-muted-foreground sm:inline">
+                                ·
+                            </span>
+                            <span className="inline-flex items-center gap-1">
+                                <Settings className="h-3.5 w-3.5" />
+                                {item.model?.model_name || 'Generic Model'}
+                            </span>
+                            {item.model?.manufacturer ? (
+                                <>
+                                    <span className="hidden text-muted-foreground sm:inline">
+                                        ·
                                     </span>
-                                    <span className="hidden sm:inline">•</span>
-                                    <span className="flex items-center gap-1">
-                                        <Settings className="h-4 w-4" />
-                                        {item.model?.model_name ||
-                                            'Generic Model'}
-                                    </span>
-                                    {item.model?.manufacturer && (
-                                        <>
-                                            <span className="hidden sm:inline">
-                                                •
-                                            </span>
-                                            <span>
-                                                {item.model.manufacturer}
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                            </div>
+                                    <span>{item.model.manufacturer}</span>
+                                </>
+                            ) : null}
                         </div>
-
-                        <div className="flex flex-wrap items-center gap-4">
-                            {item.qrcode_url && (
-                                <div className="flex flex-col items-center gap-2">
-                                    <div className="rounded-lg border border-primary/10 bg-white p-2 shadow-sm">
+                    }
+                    actions={
+                        <>
+                            {item.qrcode_url ? (
+                                <div className="flex items-center gap-2">
+                                    <div className="rounded-md border bg-background p-1">
                                         <QRCodeSVG
                                             value={item.qrcode_url || ''}
-                                            size={80}
+                                            size={56}
                                             level="H"
-                                            className="qr-code-svg h-20 w-20"
+                                            className="qr-code-svg h-14 w-14"
                                         />
                                     </div>
                                     <Button
-                                        variant="ghost"
+                                        variant="outline"
                                         size="sm"
-                                        className="h-8 gap-2 text-xs text-primary hover:bg-primary/5 hover:text-primary"
+                                        className="h-8 gap-1.5 text-xs"
                                         onClick={handlePrint}
                                     >
                                         <Printer className="h-3.5 w-3.5" />
                                         Print QR
                                     </Button>
                                 </div>
-                            )}
-                            <div className="flex flex-col gap-2">
-                                <EntityStateActions
-                                    entityType="asset"
-                                    entityId={item.ulid}
-                                    onStateChange={handleStateChange}
-                                />
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                            ) : null}
+                            <EntityStateActions
+                                entityType="asset"
+                                entityId={item.ulid}
+                                onStateChange={handleStateChange}
+                            />
+                        </>
+                    }
+                />
 
                 <Tabs defaultValue="summary" className="w-full">
-                    <TabsList className="mb-4 grid !h-auto w-full grid-cols-2 gap-2 bg-muted/50 p-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7">
+                    <TabsList className="mb-2 grid !h-auto w-full grid-cols-2 gap-1 bg-muted/50 p-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7">
                         <TabsTrigger
                             value="summary"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <Info className="mr-2 h-4 w-4" />
+                            <Info className="hidden h-3.5 w-3.5 sm:block" />
                             Summary
                         </TabsTrigger>
                         <TabsTrigger
                             value="movements"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <History className="mr-2 h-4 w-4" />
+                            <History className="hidden h-3.5 w-3.5 sm:block" />
                             Movements
                         </TabsTrigger>
                         <TabsTrigger
                             value="maintenance"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <Wrench className="mr-2 h-4 w-4" />
+                            <Wrench className="hidden h-3.5 w-3.5 sm:block" />
                             Maintenance
                         </TabsTrigger>
                         <TabsTrigger
                             value="stocktake"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <ClipboardCheck className="mr-2 h-4 w-4" />
+                            <ClipboardCheck className="hidden h-3.5 w-3.5 sm:block" />
                             Stocktake
                         </TabsTrigger>
                         <TabsTrigger
                             value="depreciation"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <TrendingDown className="mr-2 h-4 w-4" />
+                            <TrendingDown className="hidden h-3.5 w-3.5 sm:block" />
                             Depreciation
                         </TabsTrigger>
                         <TabsTrigger
                             value="timeline"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <History className="mr-2 h-4 w-4" />
+                            <History className="hidden h-3.5 w-3.5 sm:block" />
                             Timeline
                         </TabsTrigger>
                         <TabsTrigger
                             value="approvals"
-                            className="data-[state=active]:bg-background data-[state=active]:shadow-sm"
+                            className="gap-1.5 text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm sm:text-sm"
                         >
-                            <History className="mr-2 h-4 w-4" />
+                            <History className="hidden h-3.5 w-3.5 sm:block" />
                             Approvals
                         </TabsTrigger>
                     </TabsList>
 
                     {/* Summary Tab */}
-                    <TabsContent value="summary" className="mt-6 space-y-6">
-                        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    <TabsContent value="summary" className="mt-3 space-y-4">
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                             {/* General Information */}
                             <Card
                                 className="group transition-all duration-200 hover:border-primary/30 hover:shadow-md"
                                 data-testid="summary-general-info"
                             >
-                                <CardHeader className="pb-3">
+                                <CardHeader className="px-4 py-3">
                                     <CardTitle className="flex items-center gap-2 text-sm font-medium">
-                                        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
-                                            <Info className="h-4 w-4" />
-                                        </div>
+                                        <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                                         <span>General Information</span>
                                     </CardTitle>
                                 </CardHeader>
-                                <CardContent className="space-y-4">
+                                <CardContent className="space-y-3 px-4 pb-4">
                                     <div className="flex items-center justify-between text-sm">
                                         <span className="flex items-center gap-2 text-muted-foreground">
                                             <Hash className="h-3.5 w-3.5" />
@@ -414,15 +394,13 @@ export default function AssetProfile() {
                                 className="group transition-all duration-200 hover:border-primary/30 hover:shadow-md"
                                 data-testid="summary-location-info"
                             >
-                                <CardHeader className="pb-3">
+                                <CardHeader className="px-4 py-3">
                                     <CardTitle className="flex items-center gap-2 text-sm font-medium">
-                                        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400">
-                                            <MapPin className="h-4 w-4" />
-                                        </div>
+                                        <MapPin className="h-4 w-4 text-green-600 dark:text-green-400" />
                                         <span>Current Location & PIC</span>
                                     </CardTitle>
                                 </CardHeader>
-                                <CardContent className="space-y-4">
+                                <CardContent className="space-y-3 px-4 pb-4">
                                     <div className="flex items-center justify-between text-sm">
                                         <span className="flex items-center gap-2 text-muted-foreground">
                                             <Building2 className="h-3.5 w-3.5" />
@@ -484,15 +462,13 @@ export default function AssetProfile() {
                                 className="group transition-all duration-200 hover:border-primary/30 hover:shadow-md"
                                 data-testid="summary-financial-info"
                             >
-                                <CardHeader className="pb-3">
+                                <CardHeader className="px-4 py-3">
                                     <CardTitle className="flex items-center gap-2 text-sm font-medium">
-                                        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400">
-                                            <CircleDollarSign className="h-4 w-4" />
-                                        </div>
+                                        <CircleDollarSign className="h-4 w-4 text-amber-600 dark:text-amber-400" />
                                         <span>Financial Summary</span>
                                     </CardTitle>
                                 </CardHeader>
-                                <CardContent className="space-y-4">
+                                <CardContent className="space-y-3 px-4 pb-4">
                                     <div className="flex items-center justify-between text-sm">
                                         <span className="text-muted-foreground">
                                             Purchase Cost
@@ -556,15 +532,13 @@ export default function AssetProfile() {
 
                         {item.notes && (
                             <Card className="transition-all duration-200 hover:shadow-md">
-                                <CardHeader className="pb-3">
+                                <CardHeader className="px-4 py-3">
                                     <CardTitle className="flex items-center gap-2 text-sm font-medium">
-                                        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                            <Info className="h-4 w-4" />
-                                        </div>
+                                        <Info className="h-4 w-4 text-muted-foreground" />
                                         <span>Notes</span>
                                     </CardTitle>
                                 </CardHeader>
-                                <CardContent>
+                                <CardContent className="px-4 pb-4">
                                     <p className="text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground">
                                         {item.notes}
                                     </p>
@@ -574,7 +548,7 @@ export default function AssetProfile() {
                     </TabsContent>
 
                     {/* Movements Tab */}
-                    <TabsContent value="movements" className="mt-6">
+                    <TabsContent value="movements" className="mt-3">
                         <Card className="overflow-hidden">
                             <CardContent className="p-0">
                                 {item.movements?.length ? (
@@ -713,7 +687,7 @@ export default function AssetProfile() {
                     </TabsContent>
 
                     {/* Maintenance Tab */}
-                    <TabsContent value="maintenance" className="mt-6">
+                    <TabsContent value="maintenance" className="mt-3">
                         <Card className="overflow-hidden">
                             <CardContent className="p-0">
                                 {item.maintenances?.length ? (
@@ -811,7 +785,7 @@ export default function AssetProfile() {
                     </TabsContent>
 
                     {/* Stocktake Tab */}
-                    <TabsContent value="stocktake" className="mt-6">
+                    <TabsContent value="stocktake" className="mt-3">
                         <Card className="overflow-hidden">
                             <CardContent className="p-0">
                                 {item.stocktake_items?.length ? (
@@ -900,7 +874,7 @@ export default function AssetProfile() {
                     </TabsContent>
 
                     {/* Depreciation Tab */}
-                    <TabsContent value="depreciation" className="mt-6">
+                    <TabsContent value="depreciation" className="mt-3">
                         <Card className="overflow-hidden">
                             <CardContent className="p-0">
                                 {item.depreciation_lines?.length ? (
@@ -988,7 +962,7 @@ export default function AssetProfile() {
                     </TabsContent>
 
                     {/* Timeline Tab */}
-                    <TabsContent value="timeline" className="mt-6">
+                    <TabsContent value="timeline" className="mt-3">
                         <EntityStateTimeline
                             key={timelineKey}
                             entityType="asset"
@@ -997,7 +971,7 @@ export default function AssetProfile() {
                     </TabsContent>
 
                     {/* Approvals Tab */}
-                    <TabsContent value="approvals" className="mt-6">
+                    <TabsContent value="approvals" className="mt-3">
                         <ApprovalHistoryTimeline
                             entityType="asset"
                             entityId={item.ulid}

--- a/task.md
+++ b/task.md
@@ -1,9 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-11  
-**Current milestone:** Visual audit — #98 merged; finish #99 rebase  
-**Branch tip (this work):** `feat/va-asset-profile-chrome` (rebasing onto main)  
-**main tip:** **#96** My Approvals + **#97** harness + **#98** capture auth  
+**Current milestone:** Visual audit — #98 merged; #99 rebased onto main  
+**Branch tip (this work):** `feat/va-asset-profile-chrome`  
+**main tip:** **#96** + **#97** + **#98**  
 **Open PRs:** [#99](https://github.com/gmedia/erp/pull/99) asset profile  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
@@ -16,7 +16,7 @@
 
 ## Done
 
-- Wave 0–1 · **HF-1–3** · **T1–T5** · **Closeout #95** · **Harness #97** · **My Approvals #96** · **Capture auth #98** — **on main**  
+- T1–T5 · Closeout #95 · Harness #97 · My Approvals **#96** · Capture auth **#98** — **on main**  
 - **Asset profile chrome** — this branch / **PR #99**  
   - Gradient hero → `PageHeader`; compact tabs/cards; QR + EntityState* kept  
   - `npm run types` clean  
@@ -25,25 +25,22 @@
 
 | ID | Theme | Status |
 |----|-------|--------|
-| T1–T5 | Shared shell | **merged** |
-| Harness | Named presets | **merged** (#97) |
-| EX-1 | My Approvals inbox | **merged** (#96) |
-| EX-auth | Capture auth settle | **merged** (#98) |
+| T1–T5 / Harness / EX-1 / EX-auth | shell + presets + My Approvals + capture | **merged** |
 | EX-asset-profile | Asset profile densify | **PR #99** (rebasing) |
 
 ## Do not
 
-- Mass Wave 2 · default playwright visual · commit `e2e/` · wait on CI · fan-out >3 tools/turn  
+- Mass Wave 2 · commit `e2e/` · wait/poll CI · stack more work on this PR  
 
 ## Recommended next
 
-1. Finish #99 rebase → force-with-lease → MERGEABLE.  
-2. Merge #99 when ready (no CI wait).  
+1. Finish rebase → force-with-lease → MERGEABLE.  
+2. User merges **#99** when ready.  
 3. No mass Wave 2.
 
 ## Continuation Prompt
 
 ```
 Read task.md. #98 merged. Finish #99 rebase/push if needed.
-Do not poll CI. Keep e2e/ untracked. AGENTS ≤3 tools/turn.
+Do not poll CI. Keep e2e/ untracked.
 ```

--- a/task.md
+++ b/task.md
@@ -1,10 +1,10 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-11  
-**Current milestone:** Visual audit — resolve #98 / #99 conflicts after #96 merge  
-**Branch tip (this work):** `fix/va-asset-models-capture-auth` (rebasing onto main)  
-**main tip:** includes **#96** My Approvals + **#97** harness (`361f28cb`)  
-**Open PRs:** [#98](https://github.com/gmedia/erp/pull/98) capture auth · [#99](https://github.com/gmedia/erp/pull/99) asset profile  
+**Current milestone:** Visual audit — #98 merged; finish #99 rebase  
+**Branch tip (this work):** `feat/va-asset-profile-chrome` (rebasing onto main)  
+**main tip:** **#96** My Approvals + **#97** harness + **#98** capture auth  
+**Open PRs:** [#99](https://github.com/gmedia/erp/pull/99) asset profile  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -16,12 +16,10 @@
 
 ## Done
 
-- Wave 0–1 harness + plan + FINDINGS/BACKLOG (PR #86)  
-- **HF-1–3** · **T1–T5** #90–#94 · **Closeout** #95 · **Harness** #97 · **My Approvals** #96 — **on main**  
-- Full re-smoke **84/85** historically (`/asset-models` → login)  
-- **Capture auth settle** — this branch / **PR #98**  
-  - `requireDashboard: true` + re-login retry on top of #97 presets  
-  - Local 3-route PASS pre-rebase  
+- Wave 0–1 · **HF-1–3** · **T1–T5** · **Closeout #95** · **Harness #97** · **My Approvals #96** · **Capture auth #98** — **on main**  
+- **Asset profile chrome** — this branch / **PR #99**  
+  - Gradient hero → `PageHeader`; compact tabs/cards; QR + EntityState* kept  
+  - `npm run types` clean  
 
 ## Themes status
 
@@ -30,36 +28,22 @@
 | T1–T5 | Shared shell | **merged** |
 | Harness | Named presets | **merged** (#97) |
 | EX-1 | My Approvals inbox | **merged** (#96) |
-| EX-auth | Capture auth settle | **PR #98** (rebasing) |
-| EX-asset-profile | Asset profile densify | **PR #99** |
+| EX-auth | Capture auth settle | **merged** (#98) |
+| EX-asset-profile | Asset profile densify | **PR #99** (rebasing) |
 
 ## Do not
 
-- Mass-capture Wave 2 / remaining ~78 routes  
-- Use default `playwright.config.ts` for visual (`migrate:fresh`)  
-- Commit untracked `e2e/`  
-- Wait on CI  
-- Parallel tool fan-out (≤3 tools/turn; post-kill = 1)  
-
-## Validated (pre-rebase)
-
-```bash
-VISUAL_AUDIT=1 VISUAL_AUDIT_ROUTES=/asset-models,/asset-categories,/dashboard \
-  PLAYWRIGHT_BASE_URL=http://127.0.0.1:82 PLAYWRIGHT_WORKERS=1 \
-  npx playwright test -c playwright.visual-audit.config.ts
-# → 3 passed (re-run after rebase if needed)
-```
+- Mass Wave 2 · default playwright visual · commit `e2e/` · wait on CI · fan-out >3 tools/turn  
 
 ## Recommended next
 
-1. Finish rebase #98 → force-with-lease push (MERGEABLE).  
-2. Rebase #99 onto main → resolve `task.md`/`BACKLOG` → push.  
-3. Merge #98 / #99 when ready (no CI wait).  
+1. Finish #99 rebase → force-with-lease → MERGEABLE.  
+2. Merge #99 when ready (no CI wait).  
+3. No mass Wave 2.
 
 ## Continuation Prompt
 
 ```
-Read task.md. Resolve #98 and #99 conflicts vs main (post-#96).
-Prefer rebase; keep capture auth + asset profile chrome.
+Read task.md. #98 merged. Finish #99 rebase/push if needed.
 Do not poll CI. Keep e2e/ untracked. AGENTS ≤3 tools/turn.
 ```


### PR DESCRIPTION
## What was done
- Densify Asset Profile SPA chrome for visual-audit exception work
- Replace gradient hero + Layers icon box with shared `PageHeader`
- Compact tabs (smaller icons on sm+, tighter gaps), card headers, page padding
- Preserve Print QR (`handlePrint` + `qr-code-svg`), EntityStateActions, all 7 tabs

## Files changed
- `resources/js/pages/assets/profile.tsx` — chrome densify only

## Verification
- [x] `npm run types` clean
- [ ] Optional: selective visual capture of asset profile route
- [ ] CI (do not wait)

## Next steps
- Update `task.md` / BACKLOG for EX-asset-profile after merge
- User merges #96/#98 when ready — independent of this PR

## Handoff
- Branch: `feat/va-asset-profile-chrome` @ `d2549021`
- Base: main `ebf00e4e` (#97 harness)
- Do not commit untracked `e2e/`