### PR TITLE
feat: densify shared view/form modal chrome (visual audit EX)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -13,7 +13,8 @@
 | Harness | Named presets | **merged** (#97) |
 | EX-1 | My Approvals inbox | **merged** (#96) |
 | EX-auth | Capture auth settle | **merged** (#98) |
-| EX-asset-profile | Asset profile chrome | **PR #99** (rebasing) |
+| EX-asset-profile | Asset profile chrome | **merged** (#99) |
+| EX-modal | View/form modal chrome | **this branch** |
 
 ## Exception rows
 
@@ -21,7 +22,8 @@
 |----|-----|-------|-------|--------|-------|
 | EX-1 | P1 | My Approvals chrome | `/my-approvals` | **merged #96** | Densify inbox |
 | EX-auth | P1 | Capture auth settle | visual harness | **merged #98** | `requireDashboard` + re-login |
-| EX-asset-profile | P1 | Asset profile chrome | `/assets/:ulid` | **PR #99** | PageHeader + compact tabs/cards |
+| EX-asset-profile | P1 | Asset profile chrome | `/assets/:ulid` | **merged #99** | PageHeader + compact tabs/cards |
+| EX-modal | P1 | View/form modal chrome | ViewModalShell + EntityForm | **this branch** | Tighter padding, title, ViewField |
 
 ## Hotfixes (can ship before full T1)
 

--- a/resources/js/components/common/EntityForm.tsx
+++ b/resources/js/components/common/EntityForm.tsx
@@ -99,10 +99,12 @@ export default function EntityForm<
                     className,
                 )}
             >
-                <div className="shrink-0 p-6 pb-2">
-                    <DialogHeader>
-                        <DialogTitle>{title}</DialogTitle>
-                        <DialogDescription>
+                <div className="shrink-0 px-4 pt-4 pb-1">
+                    <DialogHeader className="gap-1">
+                        <DialogTitle className="text-base leading-tight">
+                            {title}
+                        </DialogTitle>
+                        <DialogDescription className="text-xs">
                             {t('common.fill_details')}
                         </DialogDescription>
                     </DialogHeader>
@@ -112,13 +114,13 @@ export default function EntityForm<
                         onSubmit={form.handleSubmit(handleSubmit)}
                         className="flex min-h-0 flex-1 flex-col"
                     >
-                        <div className="min-h-0 flex-1 overflow-y-auto px-6">
-                            <div className="space-y-4 py-1 pb-6">
+                        <div className="min-h-0 flex-1 overflow-y-auto px-4">
+                            <div className="space-y-3 py-1 pb-4">
                                 {children}
                             </div>
                         </div>
-                        <div className="shrink-0 p-6 pt-2">
-                            <DialogFooter className="border-t pt-4">
+                        <div className="shrink-0 px-4 pt-1 pb-4">
+                            <DialogFooter className="border-t pt-3">
                                 <Button
                                     type="button"
                                     variant="outline"

--- a/resources/js/components/common/ViewField.tsx
+++ b/resources/js/components/common/ViewField.tsx
@@ -21,10 +21,10 @@ export function ViewField({
 }: Readonly<ViewFieldProps>) {
     return (
         <div className="grid gap-0.5">
-            <Label className="text-muted-foreground text-xs font-normal">
+            <Label className="text-xs font-normal text-muted-foreground">
                 {label}
             </Label>
-            <div className={cn('text-sm font-medium leading-snug', className)}>
+            <div className={cn('text-sm leading-snug font-medium', className)}>
                 {value || '-'}
             </div>
         </div>

--- a/resources/js/components/common/ViewField.tsx
+++ b/resources/js/components/common/ViewField.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
 import * as React from 'react';
 
 interface ViewFieldProps {
@@ -19,9 +20,11 @@ export function ViewField({
     className,
 }: Readonly<ViewFieldProps>) {
     return (
-        <div className="grid gap-1">
-            <Label className="text-muted-foreground">{label}</Label>
-            <div className={`text-sm font-medium ${className || ''}`}>
+        <div className="grid gap-0.5">
+            <Label className="text-muted-foreground text-xs font-normal">
+                {label}
+            </Label>
+            <div className={cn('text-sm font-medium leading-snug', className)}>
                 {value || '-'}
             </div>
         </div>

--- a/resources/js/components/common/ViewModalShell.tsx
+++ b/resources/js/components/common/ViewModalShell.tsx
@@ -11,6 +11,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
 
 interface ViewModalShellProps {
     open: boolean;
@@ -31,7 +32,7 @@ export function ViewModalShell({
     title,
     description,
     children,
-    contentClassName = 'sm:max-w-[425px]',
+    contentClassName,
     headerClassName,
     footerClassName,
     footer,
@@ -39,16 +40,25 @@ export function ViewModalShell({
 }: Readonly<ViewModalShellProps>) {
     return (
         <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-            <DialogContent className={contentClassName}>
-                <DialogHeader className={headerClassName}>
-                    <DialogTitle>{title}</DialogTitle>
-                    <DialogDescription>{description}</DialogDescription>
+            <DialogContent
+                className={cn(
+                    'gap-3 p-4 sm:max-w-lg',
+                    contentClassName,
+                )}
+            >
+                <DialogHeader className={cn('gap-1 pr-8', headerClassName)}>
+                    <DialogTitle className="text-base leading-tight">
+                        {title}
+                    </DialogTitle>
+                    <DialogDescription className="text-xs">
+                        {description}
+                    </DialogDescription>
                 </DialogHeader>
 
                 {children}
 
                 {!hideFooter && (
-                    <DialogFooter className={footerClassName}>
+                    <DialogFooter className={cn('pt-1', footerClassName)}>
                         {footer ?? (
                             <Button type="button" onClick={onClose}>
                                 Close

--- a/resources/js/components/common/ViewModalShell.tsx
+++ b/resources/js/components/common/ViewModalShell.tsx
@@ -41,10 +41,7 @@ export function ViewModalShell({
     return (
         <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
             <DialogContent
-                className={cn(
-                    'gap-3 p-4 sm:max-w-lg',
-                    contentClassName,
-                )}
+                className={cn('gap-3 p-4 sm:max-w-lg', contentClassName)}
             >
                 <DialogHeader className={cn('gap-1 pr-8', headerClassName)}>
                     <DialogTitle className="text-base leading-tight">

--- a/task.md
+++ b/task.md
@@ -1,46 +1,35 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-11  
-**Current milestone:** Visual audit — #98 merged; #99 rebased onto main  
-**Branch tip (this work):** `feat/va-asset-profile-chrome`  
-**main tip:** **#96** + **#97** + **#98**  
-**Open PRs:** [#99](https://github.com/gmedia/erp/pull/99) asset profile  
+**Last updated:** 2026-08-14  
+**Current milestone:** Visual audit — EX view/form modal chrome  
+**Branch tip (this work):** `feat/va-view-modal-chrome`  
+**main tip:** **#99** asset profile (`332526d1`)  
+**Open PRs:** this branch (pending create)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
 
 1. `task.md` (this)  
 2. `docs/visual-audit/BACKLOG.md`  
-3. `docs/visual-audit/FINDINGS.md`  
-4. `docs/visual-audit-plan.md`
+3. `docs/visual-audit/FINDINGS.md`
 
-## Done
+## Done on main
 
-- T1–T5 · Closeout #95 · Harness #97 · My Approvals **#96** · Capture auth **#98** — **on main**  
-- **Asset profile chrome** — this branch / **PR #99**  
-  - Gradient hero → `PageHeader`; compact tabs/cards; QR + EntityState* kept  
-  - `npm run types` clean  
+- T1–T5 · #95 · #97 · #96 My Approvals · #98 capture auth · #99 asset profile  
+- Selective re-smoke `/my-approvals,/asset-models,/dashboard` → **3 PASS**
 
-## Themes status
+## This branch
 
-| ID | Theme | Status |
-|----|-------|--------|
-| T1–T5 / Harness / EX-1 / EX-auth | shell + presets + My Approvals + capture | **merged** |
-| EX-asset-profile | Asset profile densify | **PR #99** (rebasing) |
+- Densify shared **ViewModalShell** + **ViewField** + **EntityForm** dialog chrome  
+- `npm run types` clean  
 
 ## Do not
 
-- Mass Wave 2 · commit `e2e/` · wait/poll CI · stack more work on this PR  
-
-## Recommended next
-
-1. Finish rebase → force-with-lease → MERGEABLE.  
-2. User merges **#99** when ready.  
-3. No mass Wave 2.
+- Mass Wave 2 · commit `e2e/` · wait on CI · >3 tools/turn  
 
 ## Continuation Prompt
 
 ```
-Read task.md. #98 merged. Finish #99 rebase/push if needed.
+Read task.md. Finish commit/PR for feat/va-view-modal-chrome if not open.
 Do not poll CI. Keep e2e/ untracked.
 ```


### PR DESCRIPTION
## What was done
- Densify shared **ViewModalShell** (tighter padding/gap, title `text-base`, description `text-xs`)
- Compact **ViewField** (xs labels, snug values)
- Compact **EntityForm** dialog chrome (header/body/footer padding)

## Files changed
- `resources/js/components/common/ViewModalShell.tsx`
- `resources/js/components/common/ViewField.tsx`
- `resources/js/components/common/EntityForm.tsx`
- `task.md`, `docs/visual-audit/BACKLOG.md`

## Verification
- [x] `npm run types`
- [ ] sail test — N/A (TSX chrome only)
- [ ] CI (do not wait)

## Next steps
- Merge when ready. No mass Wave 2. Keep `e2e/` untracked.