### PR TITLE
docs: close visual-audit EX-modal after #100

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -1,6 +1,6 @@
 # Visual Audit — Backlog
 
-**Last updated:** 2026-08-11  
+**Last updated:** 2026-08-18  
 **Source:** multimodal-looker Wave 0–1  
 **Policy:** T1–T5 + harness presets on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`, then exception surfaces only.
 
@@ -14,7 +14,7 @@
 | EX-1 | My Approvals inbox | **merged** (#96) |
 | EX-auth | Capture auth settle | **merged** (#98) |
 | EX-asset-profile | Asset profile chrome | **merged** (#99) |
-| EX-modal | View/form modal chrome | **this branch** |
+| EX-modal | View/form modal chrome | **merged** (#100) |
 
 ## Exception rows
 
@@ -23,7 +23,7 @@
 | EX-1 | P1 | My Approvals chrome | `/my-approvals` | **merged #96** | Densify inbox |
 | EX-auth | P1 | Capture auth settle | visual harness | **merged #98** | `requireDashboard` + re-login |
 | EX-asset-profile | P1 | Asset profile chrome | `/assets/:ulid` | **merged #99** | PageHeader + compact tabs/cards |
-| EX-modal | P1 | View/form modal chrome | ViewModalShell + EntityForm | **this branch** | Tighter padding, title, ViewField |
+| EX-modal | P1 | View/form modal chrome | ViewModalShell + EntityForm | **merged #100** | Tighter padding, title, ViewField |
 
 ## Hotfixes (can ship before full T1)
 
@@ -79,7 +79,6 @@ VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:8
 
 1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login` (fixed **#98 merged**).
 2. ~~Harness allowlist~~ **Done 2026-08-11:** `VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json` (**#97 merged**).
-3. ~~#96 / #98~~ **merged** on main.
-4. Finish **#99** rebase → MERGEABLE → merge when ready (no CI wait).
-5. Optional: selective capture of asset profile URL only; multimodal on Wave 0–1 PNGs.
-6. Optional residual FINDINGS (PO-05 / BS-01 / SHELL-12) only with product call — not mass Wave 2.
+3. ~~#96–#100~~ **merged** on main (My Approvals, capture auth, asset profile, view/form modal).
+4. Optional: `VISUAL_AUDIT_PRESET=exceptions` re-smoke — not full catalog.
+5. Optional residual FINDINGS (PO-05 / BS-01 / SHELL-12) only with product call — not mass Wave 2.

--- a/task.md
+++ b/task.md
@@ -1,10 +1,9 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-14  
-**Current milestone:** Visual audit — EX view/form modal chrome  
-**Branch tip (this work):** `feat/va-view-modal-chrome`  
-**main tip:** **#99** asset profile (`332526d1`)  
-**Open PRs:** this branch (pending create)  
+**Last updated:** 2026-08-18  
+**Current milestone:** Visual audit — EX themes closed; residuals only  
+**Branch:** `main` @ `2496a321` (**#100** merged)  
+**Open PRs:** none assigned  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -15,21 +14,38 @@
 
 ## Done on main
 
-- T1–T5 · #95 · #97 · #96 My Approvals · #98 capture auth · #99 asset profile  
-- Selective re-smoke `/my-approvals,/asset-models,/dashboard` → **3 PASS**
+- T1–T5 · #95 closeout · #97 harness presets  
+- #96 My Approvals · #98 capture auth · #99 asset profile · **#100 view/form modal chrome**  
+- Local: `main` ff-only to #100; squash-merged VA branches deleted  
+- Keep `e2e/` untracked (Playwright artefacts only)
 
-## This branch
+## This session (hygiene)
 
-- Densify shared **ViewModalShell** + **ViewField** + **EntityForm** dialog chrome  
-- `npm run types` clean  
+- Synced `main` after #100 merge  
+- Deleted local VA theme branches (T1–T5, EX-*, harness, t5 closeout)  
+- Did **not** commit `e2e/`
 
 ## Do not
 
-- Mass Wave 2 · commit `e2e/` · wait on CI · >3 tools/turn  
+- Mass Wave 2 (85 leaves)  
+- Commit `e2e/`  
+- Wait on CI  
+- >3 tools/turn
+
+## Recommended next step
+
+Pick **one** residual only if product asks:
+
+- PO-05 Grand Total column visibility (P2)  
+- BS-01 Compare “None” label opacity (P2)  
+- SHELL-12 Home stub vs financial dashboard (P3)
+
+Otherwise: selective re-smoke `VISUAL_AUDIT_PRESET=exceptions` (or named routes) — not full catalog.
 
 ## Continuation Prompt
 
 ```
-Read task.md. Finish commit/PR for feat/va-view-modal-chrome if not open.
-Do not poll CI. Keep e2e/ untracked.
+Read task.md. Visual-audit EX themes are on main (#96–#100).
+Do not start mass Wave 2. Keep e2e/ untracked.
+If implementing: one residual FINDING (PO-05 / BS-01 / SHELL-12) only with product call.
 ```


### PR DESCRIPTION
## What was done
- Synced local `main` to **#100** (`2496a321`)
- Deleted squash-merged local VA theme branches
- Marked EX-modal **merged #100** in BACKLOG
- Updated `task.md` next step: residuals only (no mass Wave 2)

## Files changed
- `task.md` — active handoff after #100
- `docs/visual-audit/BACKLOG.md` — EX-modal status + next agent action

## Verification
- [x] `e2e/` still untracked (Playwright artefacts)
- [ ] CI passing (do not wait)

## Next steps
- Optional: `VISUAL_AUDIT_PRESET=exceptions` re-smoke
- Residual FINDINGS only with product call (PO-05 / BS-01 / SHELL-12)