### PR TITLE
feat: label Compare vs Fiscal Year on financial reports (BS-01)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -51,7 +51,7 @@
 | ID | Pri | Item | Notes |
 |----|-----|------|-------|
 | PO-05 | P2 | Grand Total column visibility | Product/column config, not shell |
-| BS-01 | P2 | Compare “None” label opacity | Filter UX |
+| BS-01 | P2 | Compare “None” label opacity | **this branch** — labeled Fiscal Year / Compare; None muted |
 | SHELL-12 | P3 | Home stub vs financial dashboard | Product decision |
 
 ## Implementation rules

--- a/resources/js/components/reports/financial/FinancialReportPageShell.tsx
+++ b/resources/js/components/reports/financial/FinancialReportPageShell.tsx
@@ -301,12 +301,15 @@ export function FinancialReportPageShell({
                     meta={headerMeta}
                     actions={
                         <>
-                            <div className="w-full sm:w-[220px]">
+                            <div className="flex w-full flex-col gap-1 sm:w-[220px]">
+                                <span className="text-muted-foreground text-xs font-medium">
+                                    Fiscal Year
+                                </span>
                                 <Select
                                     value={String(selectedYearId)}
                                     onValueChange={onYearChange}
                                 >
-                                    <SelectTrigger>
+                                    <SelectTrigger aria-label="Fiscal Year">
                                         <SelectValue placeholder="Fiscal Year" />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -321,7 +324,10 @@ export function FinancialReportPageShell({
                                     </SelectContent>
                                 </Select>
                             </div>
-                            <div className="w-full sm:w-[220px]">
+                            <div className="flex w-full flex-col gap-1 sm:w-[220px]">
+                                <span className="text-muted-foreground text-xs font-medium">
+                                    Compare
+                                </span>
                                 <Select
                                     value={
                                         comparisonYearId
@@ -330,11 +336,21 @@ export function FinancialReportPageShell({
                                     }
                                     onValueChange={onComparisonChange}
                                 >
-                                    <SelectTrigger>
+                                    <SelectTrigger
+                                        aria-label="Compare fiscal year"
+                                        className={
+                                            comparisonYearId
+                                                ? undefined
+                                                : 'text-muted-foreground'
+                                        }
+                                    >
                                         <SelectValue placeholder="Compare With..." />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="none">
+                                        <SelectItem
+                                            value="none"
+                                            className="text-muted-foreground"
+                                        >
                                             None
                                         </SelectItem>
                                         {fiscalYears

--- a/resources/js/components/reports/financial/FinancialReportPageShell.tsx
+++ b/resources/js/components/reports/financial/FinancialReportPageShell.tsx
@@ -302,7 +302,7 @@ export function FinancialReportPageShell({
                     actions={
                         <>
                             <div className="flex w-full flex-col gap-1 sm:w-[220px]">
-                                <span className="text-muted-foreground text-xs font-medium">
+                                <span className="text-xs font-medium text-muted-foreground">
                                     Fiscal Year
                                 </span>
                                 <Select
@@ -325,7 +325,7 @@ export function FinancialReportPageShell({
                                 </Select>
                             </div>
                             <div className="flex w-full flex-col gap-1 sm:w-[220px]">
-                                <span className="text-muted-foreground text-xs font-medium">
+                                <span className="text-xs font-medium text-muted-foreground">
                                     Compare
                                 </span>
                                 <Select

--- a/task.md
+++ b/task.md
@@ -1,10 +1,9 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-14  
-**Current milestone:** Visual audit — EX view/form modal chrome  
-**Branch tip (this work):** `feat/va-view-modal-chrome`  
-**main tip:** **#99** asset profile (`332526d1`)  
-**Open PRs:** this branch (pending create)  
+**Last updated:** 2026-08-18  
+**Current milestone:** Visual audit residual **BS-01**  
+**Branch:** `feat/va-bs01-compare-label`  
+**Open PRs:** pending create  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -15,21 +14,21 @@
 
 ## Done on main
 
-- T1–T5 · #95 · #97 · #96 My Approvals · #98 capture auth · #99 asset profile  
-- Selective re-smoke `/my-approvals,/asset-models,/dashboard` → **3 PASS**
+- T1–T5 · #95 · #97 · #96–#100 EX themes  
+- Keep `e2e/` untracked
 
 ## This branch
 
-- Densify shared **ViewModalShell** + **ViewField** + **EntityForm** dialog chrome  
-- `npm run types` clean  
+- BS-01: visible **Fiscal Year** / **Compare** labels on `FinancialReportPageShell`
+- Compare **None** uses muted trigger + item
 
 ## Do not
 
-- Mass Wave 2 · commit `e2e/` · wait on CI · >3 tools/turn  
+- Mass Wave 2 · commit `e2e/` · wait on CI · >3 tools/turn
 
 ## Continuation Prompt
 
 ```
-Read task.md. Finish commit/PR for feat/va-view-modal-chrome if not open.
-Do not poll CI. Keep e2e/ untracked.
+Read task.md. Finish PR for feat/va-bs01-compare-label if not open.
+Do not mass Wave 2. Keep e2e/ untracked.
 ```


### PR DESCRIPTION
## What was done
- Visual audit **BS-01**: bare Compare select looked like a year; **None** was as opaque as FY names
- Added compact **Fiscal Year** / **Compare** labels on `FinancialReportPageShell`
- Muted Compare trigger + None item when no comparison year
- Shared by all comparison financial reports (balance sheet, P&L, cash flow, trial balance, comparative)

## Files changed
- `resources/js/components/reports/financial/FinancialReportPageShell.tsx`
- `docs/visual-audit/BACKLOG.md` — BS-01 this branch
- `task.md` — handoff

## Verification
- [ ] npm run types (optional)
- [ ] CI passing (do not wait)

## Next steps
- Merge when ready; residuals PO-05 / SHELL-12 still product-call