### PR TITLE
docs: mark landed visual-audit FINDINGS after #100

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -1,8 +1,8 @@
 # Visual Audit — Backlog
 
-**Last updated:** 2026-08-11  
+**Last updated:** 2026-08-18  
 **Source:** multimodal-looker Wave 0–1  
-**Policy:** T1–T5 + harness presets on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`, then exception surfaces only.
+**Policy:** T1–T5 + EX themes on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`.
 
 ## Themes
 
@@ -14,7 +14,7 @@
 | EX-1 | My Approvals inbox | **merged** (#96) |
 | EX-auth | Capture auth settle | **merged** (#98) |
 | EX-asset-profile | Asset profile chrome | **merged** (#99) |
-| EX-modal | View/form modal chrome | **this branch** |
+| EX-modal | View/form modal chrome | **merged** (#100) |
 
 ## Exception rows
 
@@ -23,7 +23,7 @@
 | EX-1 | P1 | My Approvals chrome | `/my-approvals` | **merged #96** | Densify inbox |
 | EX-auth | P1 | Capture auth settle | visual harness | **merged #98** | `requireDashboard` + re-login |
 | EX-asset-profile | P1 | Asset profile chrome | `/assets/:ulid` | **merged #99** | PageHeader + compact tabs/cards |
-| EX-modal | P1 | View/form modal chrome | ViewModalShell + EntityForm | **this branch** | Tighter padding, title, ViewField |
+| EX-modal | P1 | View/form modal chrome | ViewModalShell + EntityForm | **merged #100** | Tighter padding, title, ViewField |
 
 ## Hotfixes (can ship before full T1)
 
@@ -45,20 +45,25 @@
 | T3 | PR #92 — Page header contract |
 | T4 | PR #93 — Dashboard & KPI semantics |
 | T5 | PR #94 — Sparse & report density (SHELL-05; RSM-01) |
+| BS-02 | Signed amounts rose for negatives (`FinancialReportSection`) |
+| FD-03 | KPI vs-comparison hidden when Compare is None |
+| FD-06 | Breadcrumb + H1 both “Financial Overview” |
+| RSM-02 | Stock Movements page has title + description |
 
 ## Residual / optional (not shared-shell themes)
 
 | ID | Pri | Item | Notes |
 |----|-----|------|-------|
 | PO-05 | P2 | Grand Total column visibility | Product/column config, not shell |
-| BS-01 | P2 | Compare “None” label opacity | Filter UX |
+| BS-01 | P2 | Compare “None” label opacity | **#102** (open) — labeled Fiscal Year / Compare |
 | SHELL-12 | P3 | Home stub vs financial dashboard | Product decision |
+| FD-02 | P1 | FY “Select…” while KPIs full | Recheck after preferred-FY wiring |
 
 ## Implementation rules
 
 - One theme ≈ one `feat/*` or `fix/*` MR (AGENTS.md)
 - Prefer shared chrome over per-module hacks
-- Re-capture only **exception** surfaces later (modals, mobile, dark, My Approvals, asset profile) — not 85 leaves
+- Re-capture only **exception** surfaces later — not 85 leaves
 - PNGs stay gitignored; cite paths in MR description
 - Agents: **AGENTS.md Tool & Process Concurrency** (≤3 tools/turn; post-kill = 1 tool/turn)
 
@@ -77,9 +82,7 @@ VISUAL_AUDIT=1 VISUAL_AUDIT_PRESET=shells PLAYWRIGHT_BASE_URL=http://127.0.0.1:8
 
 ## Next agent action
 
-1. ~~Selective re-smoke~~ **Done 2026-08-10:** full catalog **84/85 PASS**; **FAIL** `/asset-models` → `/login` (fixed **#98 merged**).
-2. ~~Harness allowlist~~ **Done 2026-08-11:** `VISUAL_AUDIT_PRESET` + `docs/visual-audit/presets.json` (**#97 merged**).
-3. ~~#96 / #98~~ **merged** on main.
-4. Finish **#99** rebase → MERGEABLE → merge when ready (no CI wait).
-5. Optional: selective capture of asset profile URL only; multimodal on Wave 0–1 PNGs.
-6. Optional residual FINDINGS (PO-05 / BS-01 / SHELL-12) only with product call — not mass Wave 2.
+1. Merge **#101** (docs EX-modal closeout) and **#102** (BS-01) when CI green — do not poll.
+2. Keep `e2e/` untracked.
+3. Optional: `VISUAL_AUDIT_PRESET=exceptions` re-smoke — do not commit PNGs.
+4. PO-05 / SHELL-12 / FD-02 only with product call — not mass Wave 2.

--- a/docs/visual-audit/FINDINGS.md
+++ b/docs/visual-audit/FINDINGS.md
@@ -1,7 +1,7 @@
 # Visual Audit — Findings
 
 **Wave:** 0 + 1 (capture + multimodal vision)  
-**Last updated:** 2026-08-08  
+**Last updated:** 2026-08-18  
 **Reviewer:** multimodal-looker (`ses_02021a5c2ffeaD0HIIg6ymhnEW`)  
 **Viewport:** 1440×900  
 **Stop-rule (≥3 shared-shell):** **YES — freeze Wave 2 mass capture**
@@ -53,12 +53,12 @@
 | ACC-01 | P1 | `/accounts` | Double title (breadcrumb + H1 same) |
 | ACC-02 | P1 | `/accounts` | Wrong sidebar active state |
 | RSM-01 | P1 | stock-movement | 2 rows + ~70% white void |
-| RSM-02 | P2 | stock-movement | No H1 (unlike Balance Sheet) |
+| RSM-02 | P2 | stock-movement | **landed** — `title` + description on ReportDataTablePage |
 | BS-01 | P2 | balance-sheet | Bare selects; “None” opaque without Compare label |
-| BS-02 | P2 | balance-sheet | Negative amounts same black as positive |
+| BS-02 | P2 | balance-sheet | **landed** — `getSignedAmountTextClass` rose for negatives |
 | FD-02 | P1 | financial-dashboard | FY shows “Select…” while KPIs full |
-| FD-03 | P1 | financial-dashboard | “0.00% vs comparison” with Compare = None |
-| FD-06 | P2 | financial-dashboard | Breadcrumb “Financial Dashboard” vs H1 “Financial Overview” |
+| FD-03 | P1 | financial-dashboard | **landed** — KPI “vs comparison” gated on `showComparison` |
+| FD-06 | P2 | financial-dashboard | **landed** — breadcrumb + H1 both “Financial Overview” |
 
 Full multimodal narrative: session `ses_02021a5c2ffeaD0HIIg6ymhnEW`.
 

--- a/task.md
+++ b/task.md
@@ -1,10 +1,9 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-14  
-**Current milestone:** Visual audit — EX view/form modal chrome  
-**Branch tip (this work):** `feat/va-view-modal-chrome`  
-**main tip:** **#99** asset profile (`332526d1`)  
-**Open PRs:** this branch (pending create)  
+**Last updated:** 2026-08-18  
+**Current milestone:** Visual audit docs — mark landed FINDINGS  
+**Branch:** `docs/va-findings-landed`  
+**Open PRs:** #101 (docs EX-modal), #102 (BS-01) — do not poll CI  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -15,13 +14,13 @@
 
 ## Done on main
 
-- T1–T5 · #95 · #97 · #96 My Approvals · #98 capture auth · #99 asset profile  
-- Selective re-smoke `/my-approvals,/asset-models,/dashboard` → **3 PASS**
+- T1–T5 · #95 · #97 · #96–#100 EX themes  
+- Keep `e2e/` untracked
 
 ## This branch
 
-- Densify shared **ViewModalShell** + **ViewField** + **EntityForm** dialog chrome  
-- `npm run types` clean  
+- FINDINGS: BS-02, FD-03, FD-06, RSM-02 marked **landed**  
+- BACKLOG: EX-modal **#100**; residual list + next actions  
 
 ## Do not
 
@@ -30,6 +29,7 @@
 ## Continuation Prompt
 
 ```
-Read task.md. Finish commit/PR for feat/va-view-modal-chrome if not open.
-Do not poll CI. Keep e2e/ untracked.
+Read task.md. Finish PR for docs/va-findings-landed if not open.
+Merge #101/#102 when green without polling.
+Do not mass Wave 2. Keep e2e/ untracked.
 ```


### PR DESCRIPTION
## What was done
- Close FINDINGS that already landed in shared-shell / KPI work (no product code)
- Sync BACKLOG: EX-modal **merged #100**; residual list matches current code
- Handoff `task.md` for next session

## Files changed
- `docs/visual-audit/FINDINGS.md` — BS-02, FD-03, FD-06, RSM-02 **landed**
- `docs/visual-audit/BACKLOG.md` — EX-modal #100, next actions
- `task.md`

## Verification
- Docs only; do not wait on CI

## Next steps
- Merge #101 / #102 when green without polling
- PO-05 / SHELL-12 / FD-02 only with product call