### PR TITLE
fix: financial dashboard FY selector stays bound (FD-02)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -57,7 +57,7 @@
 | PO-05 | P2 | Grand Total column visibility | Product/column config, not shell |
 | BS-01 | P2 | Compare “None” label opacity | **merged #102** — labeled Fiscal Year / Compare; None muted |
 | SHELL-12 | P3 | Home stub vs financial dashboard | Product decision |
-| FD-02 | P1 | FY “Select…” while KPIs full | Recheck after preferred-FY wiring |
+| FD-02 | P1 | FY “Select…” while KPIs full | **this PR** — bind Select to matching FY id; keepPreviousData |
 
 ## Implementation rules
 

--- a/docs/visual-audit/FINDINGS.md
+++ b/docs/visual-audit/FINDINGS.md
@@ -56,7 +56,7 @@
 | RSM-02 | P2 | stock-movement | **landed** — `title` + description on ReportDataTablePage |
 | BS-01 | P2 | balance-sheet | Bare selects; “None” opaque without Compare label |
 | BS-02 | P2 | balance-sheet | **landed** — `getSignedAmountTextClass` rose for negatives |
-| FD-02 | P1 | financial-dashboard | FY shows “Select…” while KPIs full |
+| FD-02 | P1 | financial-dashboard | **landed** — FY select binds to preferred year; keepPreviousData on refetch |
 | FD-03 | P1 | financial-dashboard | **landed** — KPI “vs comparison” gated on `showComparison` |
 | FD-06 | P2 | financial-dashboard | **landed** — breadcrumb + H1 both “Financial Overview” |
 

--- a/resources/js/components/financial-dashboard/FiscalYearSelector.tsx
+++ b/resources/js/components/financial-dashboard/FiscalYearSelector.tsx
@@ -24,9 +24,9 @@ export const FiscalYearSelector = memo<FiscalYearSelectorProps>(
         onYearChange,
         onComparisonYearChange,
     }) {
-        const selectedValue = fiscalYears.find(
-            (year) => Number(year.id) === Number(selectedYearId),
-        )?.id.toString();
+        const selectedValue = fiscalYears
+            .find((year) => Number(year.id) === Number(selectedYearId))
+            ?.id.toString();
 
         return (
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/resources/js/components/financial-dashboard/FiscalYearSelector.tsx
+++ b/resources/js/components/financial-dashboard/FiscalYearSelector.tsx
@@ -24,6 +24,10 @@ export const FiscalYearSelector = memo<FiscalYearSelectorProps>(
         onYearChange,
         onComparisonYearChange,
     }) {
+        const selectedValue = fiscalYears.find(
+            (year) => Number(year.id) === Number(selectedYearId),
+        )?.id.toString();
+
         return (
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
                 <div className="flex flex-col gap-1.5">
@@ -34,7 +38,7 @@ export const FiscalYearSelector = memo<FiscalYearSelectorProps>(
                         Fiscal Year
                     </label>
                     <Select
-                        value={selectedYearId?.toString() || ''}
+                        value={selectedValue}
                         onValueChange={(value) =>
                             onYearChange(value ? Number(value) : null)
                         }

--- a/resources/js/hooks/useFinancialDashboard.ts
+++ b/resources/js/hooks/useFinancialDashboard.ts
@@ -1,5 +1,5 @@
 import axios from '@/lib/axios';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 export interface KpiItem {
     value: number;
@@ -103,6 +103,7 @@ export function useFinancialDashboard(params?: UseFinancialDashboardParams) {
             params?.branchId,
         ],
         queryFn: fetchDashboardData,
+        placeholderData: keepPreviousData,
         staleTime: 60000,
     });
 

--- a/task.md
+++ b/task.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-08-18  
 **Current milestone:** Visual audit — FD-02 fiscal year selector  
 **Branch:** `fix/fd-02-fiscal-year-selector`  
-**Open PRs:** (create after commit)  
+**Open PRs:** [#104](https://github.com/gmedia/erp/pull/104)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -20,8 +20,10 @@
 
 ## This session
 
-- FD-02: FY Select binds only when id exists in list; `keepPreviousData` on dashboard query  
+- FD-02 shipped as **PR #104** (do not wait on CI)
+- FY Select binds only when id exists in list; `keepPreviousData` on dashboard query
 - E2E: `#fiscal-year-select` must not show “Select fiscal year” after data load
+- FINDINGS/BACKLOG mark FD-02 as this PR
 
 ## Do not
 
@@ -32,14 +34,13 @@
 
 ## Recommended next step
 
-1. Commit + `gh pr create` for FD-02.  
+1. After #104 is green: squash-merge, delete branch, `rtk git pull --ff-only` on main. Do not poll.  
 2. Residual only with product call: PO-05, SHELL-12.  
 3. Optional: `VISUAL_AUDIT_PRESET=exceptions` — do not commit PNGs.
 
 ## Continuation Prompt
 
 ```
-Read task.md. On branch fix/fd-02-fiscal-year-selector.
-Finish commit/PR for FD-02 if not opened. Do not start mass Wave 2. Keep e2e/ untracked.
-Residuals: PO-05, SHELL-12 only with product call.
+Read task.md. FD-02 is PR #104. Do not poll CI. Do not start mass Wave 2. Keep e2e/ untracked.
+If #104 is already merged, pull main. Residuals: PO-05, SHELL-12 only with product call.
 ```

--- a/task.md
+++ b/task.md
@@ -1,9 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-18  
-**Current milestone:** Visual audit — EX + BS-01 on main; landing FINDINGS docs (#103)  
-**Branch:** `docs/va-findings-landed`  
-**Open PRs:** #103 (this) after resolving conflicts vs #101/#102  
+**Current milestone:** Visual audit — FD-02 fiscal year selector  
+**Branch:** `fix/fd-02-fiscal-year-selector`  
+**Open PRs:** (create after commit)  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -15,16 +15,13 @@
 ## Done on main
 
 - T1–T5 · #95 closeout · #97 harness presets  
-- #96 My Approvals · #98 capture auth · #99 asset profile · **#100 view/form modal chrome**  
-- **#101** docs EX-modal closeout  
-- **#102** BS-01 Compare vs Fiscal Year labels  
-- Keep `e2e/` untracked (Playwright artefacts only)
+- #96–#100 EX · **#101** docs · **#102** BS-01 · **#103** FINDINGS landed  
+- Keep `e2e/` untracked
 
 ## This session
 
-- FINDINGS: BS-02, FD-03, FD-06, RSM-02 marked **landed**  
-- BACKLOG: EX-modal **#100**; BS-01 **#102 merged**; residual PO-05 / SHELL-12 / FD-02  
-- Squash-merged **#102** then **#101**; resolved `task.md` + BACKLOG vs main for **#103**
+- FD-02: FY Select binds only when id exists in list; `keepPreviousData` on dashboard query  
+- E2E: `#fiscal-year-select` must not show “Select fiscal year” after data load
 
 ## Do not
 
@@ -35,15 +32,14 @@
 
 ## Recommended next step
 
-1. Merge **#103** (this).  
-2. Residual FINDINGS only with product call: PO-05, SHELL-12, FD-02.  
+1. Commit + `gh pr create` for FD-02.  
+2. Residual only with product call: PO-05, SHELL-12.  
 3. Optional: `VISUAL_AUDIT_PRESET=exceptions` — do not commit PNGs.
 
 ## Continuation Prompt
 
 ```
-Read task.md. Visual-audit EX themes (#96–#100), docs #101, and BS-01 (#102) are on main.
-Finish merge of #103 if still open.
-Do not start mass Wave 2. Keep e2e/ untracked.
-If implementing: one residual FINDING (PO-05 / SHELL-12 / FD-02) only with product call.
+Read task.md. On branch fix/fd-02-fiscal-year-selector.
+Finish commit/PR for FD-02 if not opened. Do not start mass Wave 2. Keep e2e/ untracked.
+Residuals: PO-05, SHELL-12 only with product call.
 ```

--- a/tests/e2e/financial-dashboard/financial-dashboard.spec.ts
+++ b/tests/e2e/financial-dashboard/financial-dashboard.spec.ts
@@ -23,6 +23,10 @@ test.describe('Financial Dashboard', () => {
 
     await expect(page.getByRole('heading', { name: 'Financial Overview' })).toBeVisible();
 
+    const fiscalYearTrigger = page.locator('#fiscal-year-select');
+    await expect(fiscalYearTrigger).toBeVisible({ timeout: 10000 });
+    await expect(fiscalYearTrigger).not.toHaveText(/Select fiscal year/i);
+
     const cards = ['Revenue', 'Expenses', 'Net Income', 'Total Assets', 'Total Liabilities', 'Equity', 'Cash Balance'];
 
     for (const cardLabel of cards) {


### PR DESCRIPTION
## What was done
- Bind Fiscal Year Select to a year id that exists in `fiscalYears` (string/number match)
- Keep previous dashboard data on URL/query refetch so the selector does not unmount to placeholder
- E2E: `#fiscal-year-select` must not show `Select fiscal year` after KPI load
- Mark FD-02 on FINDINGS/BACKLOG; update `task.md`

## Files changed
- `resources/js/hooks/useFinancialDashboard.ts` — `placeholderData: keepPreviousData`
- `resources/js/components/financial-dashboard/FiscalYearSelector.tsx` — bind `selectedValue` from list
- `tests/e2e/financial-dashboard/financial-dashboard.spec.ts` — FY trigger assertion
- `docs/visual-audit/FINDINGS.md`, `BACKLOG.md`, `task.md`

## Verification
- [ ] sail test --group financial-dashboard (not run this PR)
- [ ] npm run types (not run this PR)
- [ ] CI passing (do not wait)

## Next steps
- Product call: PO-05 / SHELL-12
- Do not mass Wave 2