### PR TITLE
docs: park visual-audit after FD-02 (#104)

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,9 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-18  
-**Current milestone:** Visual audit — FD-02 fiscal year selector  
-**Branch:** `fix/fd-02-fiscal-year-selector`  
-**Open PRs:** [#104](https://github.com/gmedia/erp/pull/104)  
+**Current milestone:** Visual audit — **parked** (shared shell + EX + FD-02 on main)  
+**Branch:** `main`  
+**Open PRs:** none for visual-audit  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -15,32 +15,32 @@
 ## Done on main
 
 - T1–T5 · #95 closeout · #97 harness presets  
-- #96–#100 EX · **#101** docs · **#102** BS-01 · **#103** FINDINGS landed  
+- #96–#100 EX · **#101** docs · **#102** BS-01 · **#103** FINDINGS  
+- **#104** FD-02 FY selector bind + `keepPreviousData`  
 - Keep `e2e/` untracked
 
 ## This session
 
-- FD-02 shipped as **PR #104** (do not wait on CI)
-- FY Select binds only when id exists in list; `keepPreviousData` on dashboard query
-- E2E: `#fiscal-year-select` must not show “Select fiscal year” after data load
-- FINDINGS/BACKLOG mark FD-02 as this PR
+- #104 squash-merged; local `main` pulled  
+- Visual-audit themes closed except product residuals
 
 ## Do not
 
 - Mass Wave 2 (85 leaves)  
 - Commit `e2e/`  
 - Wait on CI  
-- >3 tools/turn
+- >3 tools/turn  
+- Implement PO-05 or SHELL-12 without a product call
 
 ## Recommended next step
 
-1. After #104 is green: squash-merge, delete branch, `rtk git pull --ff-only` on main. Do not poll.  
-2. Residual only with product call: PO-05, SHELL-12.  
-3. Optional: `VISUAL_AUDIT_PRESET=exceptions` — do not commit PNGs.
+1. Product call: **PO-05** (Grand Total column), **SHELL-12** (home stub vs financial dashboard). If both no → visual-audit closed.  
+2. Optional AI work on `main`: one small Sonar wave (HIGH/BLOCKER or worst coverage) — separate MR, no FY selector.  
+3. Optional: `VISUAL_AUDIT_PRESET=exceptions` locally — do not commit PNGs.
 
 ## Continuation Prompt
 
 ```
-Read task.md. FD-02 is PR #104. Do not poll CI. Do not start mass Wave 2. Keep e2e/ untracked.
-If #104 is already merged, pull main. Residuals: PO-05, SHELL-12 only with product call.
+Read task.md. Visual audit is parked on main after #104. Do not start mass Wave 2. Keep e2e/ untracked.
+Residuals PO-05 / SHELL-12 only with product call. Next AI theme: Sonar on main if requested, else stop.
 ```


### PR DESCRIPTION
## What was done
- Point `task.md` at parked visual-audit on `main` after squash-merge of #104
- Next: product call for PO-05 / SHELL-12, or optional Sonar wave — not mass Wave 2

## Files changed
- `task.md` — milestone parked, #104 on main, residuals gated

## Verification
- [ ] docs only

## Next steps
- Squash-merge when convenient; do not wait on CI