### PR TITLE
docs: product call — sticky Grand Total, enrich home

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -54,10 +54,10 @@
 
 | ID | Pri | Item | Notes |
 |----|-----|------|-------|
-| PO-05 | P2 | Grand Total column visibility | Product/column config, not shell |
+| PO-05 | P2 | Grand Total column visibility | **product: pin sticky left of Actions** — PO columns (+ invoice/bill siblings if same pattern) |
 | BS-01 | P2 | Compare “None” label opacity | **merged #102** — labeled Fiscal Year / Compare; None muted |
-| SHELL-12 | P3 | Home stub vs financial dashboard | Product decision |
-| FD-02 | P1 | FY “Select…” while KPIs full | **this PR** — bind Select to matching FY id; keepPreviousData |
+| SHELL-12 | P3 | Home stub vs financial dashboard | **product: enrich `/dashboard`** — charts/widgets in placeholder; keep separate FD route/permission |
+| FD-02 | P1 | FY “Select…” while KPIs full | **merged #104** |
 
 ## Implementation rules
 

--- a/docs/visual-audit/FINDINGS.md
+++ b/docs/visual-audit/FINDINGS.md
@@ -36,7 +36,7 @@
 | SHELL-09 | P2 | Deep nav | Long nested lists; active child hard to see |
 | SHELL-10 | P2 | CRUD | Checkbox without bulk action UX |
 | SHELL-11 | P2 | DataTable | Pagination weak in empty footer zone |
-| SHELL-12 | P3 | DASH vs FD | Home stub vs rich financial dashboard |
+| SHELL-12 | P3 | DASH vs FD | **product:** enrich `/dashboard` widgets; do not merge with financial dashboard |
 
 **Material shared-shell count:** 11 (≥3 threshold).
 
@@ -49,7 +49,7 @@
 | EMP-03 | P1 | `/employees` | All status “Regular” solid black |
 | PO-01 | P1 | `/purchase-orders` | 8 statuses look identical; critical states don’t pop |
 | PO-04 | P2 | `/purchase-orders` | No Actions column visible |
-| PO-05 | P2 | `/purchase-orders` | Grand Total not in visible columns |
+| PO-05 | P2 | `/purchase-orders` | **product:** pin Grand Total sticky (left of Actions) |
 | ACC-01 | P1 | `/accounts` | Double title (breadcrumb + H1 same) |
 | ACC-02 | P1 | `/accounts` | Wrong sidebar active state |
 | RSM-01 | P1 | stock-movement | 2 rows + ~70% white void |

--- a/task.md
+++ b/task.md
@@ -1,9 +1,9 @@
 # task.md — Active Session Handoff
 
 **Last updated:** 2026-08-18  
-**Current milestone:** Visual audit — **parked** (shared shell + EX + FD-02 on main)  
+**Current milestone:** Visual residuals after product call — **PO-05 next**  
 **Branch:** `main`  
-**Open PRs:** none for visual-audit  
+**Open PRs:** none  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
 ## Read order
@@ -12,17 +12,15 @@
 2. `docs/visual-audit/BACKLOG.md`  
 3. `docs/visual-audit/FINDINGS.md`
 
+## Product call (2026-08-18)
+
+- **PO-05:** pin **Grand Total** sticky, immediately left of Actions. Scope: purchase orders; siblings (invoices/bills) if they share the column pattern.  
+- **SHELL-12 / DASH-01:** **enrich `/dashboard`** (charts/widgets in the placeholder). Keep `/financial-dashboard` and separate permissions. Do **not** redirect `/` to FD.
+
 ## Done on main
 
-- T1–T5 · #95 closeout · #97 harness presets  
-- #96–#100 EX · **#101** docs · **#102** BS-01 · **#103** FINDINGS  
-- **#104** FD-02 FY selector bind + `keepPreviousData`  
+- T1–T5 · EX · #101–#105 (incl. FD-02, parked handoff)  
 - Keep `e2e/` untracked
-
-## This session
-
-- #104 squash-merged; local `main` pulled  
-- Visual-audit themes closed except product residuals
 
 ## Do not
 
@@ -30,17 +28,17 @@
 - Commit `e2e/`  
 - Wait on CI  
 - >3 tools/turn  
-- Implement PO-05 or SHELL-12 without a product call
+- Merge home into financial dashboard
 
 ## Recommended next step
 
-1. Product call: **PO-05** (Grand Total column), **SHELL-12** (home stub vs financial dashboard). If both no → visual-audit closed.  
-2. Optional AI work on `main`: one small Sonar wave (HIGH/BLOCKER or worst coverage) — separate MR, no FY selector.  
+1. **PO-05 first** — one `feat/*` or `fix/*` MR: sticky money column left of Actions on PO table (then siblings).  
+2. **SHELL-12 second** — separate MR: home widgets (needs a short widget list: e.g. counts stay + 1–2 charts or deep-links). Do not start until PO-05 PR exists.  
 3. Optional: `VISUAL_AUDIT_PRESET=exceptions` locally — do not commit PNGs.
 
 ## Continuation Prompt
 
 ```
-Read task.md. Visual audit is parked on main after #104. Do not start mass Wave 2. Keep e2e/ untracked.
-Residuals PO-05 / SHELL-12 only with product call. Next AI theme: Sonar on main if requested, else stop.
+Read task.md. Product call done: PO-05 sticky Grand Total next; SHELL-12 enrich /dashboard after that.
+Do not mass Wave 2. Keep e2e/ untracked. One theme = one MR.
 ```


### PR DESCRIPTION
## What was done
- Product call: PO-05 = pin Grand Total sticky left of Actions
- SHELL-12 = enrich `/dashboard` widgets; keep financial dashboard separate
- Update BACKLOG, FINDINGS, task.md (PO-05 next MR)

## Files changed
- `docs/visual-audit/BACKLOG.md`
- `docs/visual-audit/FINDINGS.md`
- `task.md`

## Verification
- [ ] docs only

## Next steps
- Implement PO-05 in a separate feat/fix MR after this lands