### PR TITLE
feat: sticky Grand Total left of Actions (PO-05)

### DIFF
--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -54,7 +54,7 @@
 
 | ID | Pri | Item | Notes |
 |----|-----|------|-------|
-| PO-05 | P2 | Grand Total column visibility | **product: pin sticky left of Actions** — PO columns (+ invoice/bill siblings if same pattern) |
+| PO-05 | P2 | Grand Total column visibility | **in this MR** — sticky when `grand_total` is immediately left of Actions (PO, credit notes; not invoice/bill Amount Due) |
 | BS-01 | P2 | Compare “None” label opacity | **merged #102** — labeled Fiscal Year / Compare; None muted |
 | SHELL-12 | P3 | Home stub vs financial dashboard | **product: enrich `/dashboard`** — charts/widgets in placeholder; keep separate FD route/permission |
 | FD-02 | P1 | FY “Select…” while KPIs full | **merged #104** |

--- a/docs/visual-audit/FINDINGS.md
+++ b/docs/visual-audit/FINDINGS.md
@@ -49,7 +49,7 @@
 | EMP-03 | P1 | `/employees` | All status “Regular” solid black |
 | PO-01 | P1 | `/purchase-orders` | 8 statuses look identical; critical states don’t pop |
 | PO-04 | P2 | `/purchase-orders` | No Actions column visible |
-| PO-05 | P2 | `/purchase-orders` | **product:** pin Grand Total sticky (left of Actions) |
+| PO-05 | P2 | `/purchase-orders` | **in this MR** — sticky Grand Total immediately left of Actions |
 | ACC-01 | P1 | `/accounts` | Double title (breadcrumb + H1 same) |
 | ACC-02 | P1 | `/accounts` | Wrong sidebar active state |
 | RSM-01 | P1 | stock-movement | 2 rows + ~70% white void |

--- a/resources/js/components/common/DataTableCore.tsx
+++ b/resources/js/components/common/DataTableCore.tsx
@@ -282,9 +282,7 @@ export function DataTable<T>({
         const actionsIndex = keys.lastIndexOf('actions');
         const grandTotalIndex = keys.indexOf('grand_total');
 
-        return (
-            actionsIndex > 0 && grandTotalIndex === actionsIndex - 1
-        );
+        return actionsIndex > 0 && grandTotalIndex === actionsIndex - 1;
     }, [columnsWithActions]);
 
     const table = useReactTable({
@@ -370,10 +368,7 @@ export function DataTable<T>({
                             key={`${rowKey}-${columnKey}`}
                             className={cn(
                                 'border-border',
-                                stickyCellClass(
-                                    columnKey,
-                                    hasStickyGrandTotal,
-                                ),
+                                stickyCellClass(columnKey, hasStickyGrandTotal),
                             )}
                         >
                             <Skeleton className="h-4 w-full bg-muted" />

--- a/resources/js/components/common/DataTableCore.tsx
+++ b/resources/js/components/common/DataTableCore.tsx
@@ -30,10 +30,40 @@ import { cn } from '@/lib/utils';
 import * as React from 'react';
 import type { FieldDescriptor } from './filters';
 
-const STICKY_ACTIONS_CELL =
-    'sticky right-0 z-10 bg-background shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.15)] dark:shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.45)]';
-const STICKY_ACTIONS_HEAD =
-    'sticky right-0 z-20 bg-muted shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.15)] dark:shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.45)]';
+const STICKY_EDGE_SHADOW =
+    'shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.15)] dark:shadow-[-6px_0_8px_-6px_rgba(0,0,0,0.45)]';
+const STICKY_ACTIONS_CELL = `sticky right-0 z-20 bg-background`;
+const STICKY_ACTIONS_HEAD = `sticky right-0 z-30 bg-muted`;
+const STICKY_GRAND_TOTAL_CELL = `sticky right-14 z-10 min-w-28 bg-background whitespace-nowrap ${STICKY_EDGE_SHADOW}`;
+const STICKY_GRAND_TOTAL_HEAD = `sticky right-14 z-20 min-w-28 bg-muted whitespace-nowrap ${STICKY_EDGE_SHADOW}`;
+
+function stickyCellClass(
+    columnId: string,
+    hasGrandTotal: boolean,
+): string | false {
+    if (columnId === 'actions') {
+        return cn(STICKY_ACTIONS_CELL, !hasGrandTotal && STICKY_EDGE_SHADOW);
+    }
+    if (columnId === 'grand_total' && hasGrandTotal) {
+        return STICKY_GRAND_TOTAL_CELL;
+    }
+
+    return false;
+}
+
+function stickyHeadClass(
+    columnId: string,
+    hasGrandTotal: boolean,
+): string | false {
+    if (columnId === 'actions') {
+        return cn(STICKY_ACTIONS_HEAD, !hasGrandTotal && STICKY_EDGE_SHADOW);
+    }
+    if (columnId === 'grand_total' && hasGrandTotal) {
+        return STICKY_GRAND_TOTAL_HEAD;
+    }
+
+    return false;
+}
 
 // Helper function to safely extract placeholder from filter fields
 function getPlaceholderFromFilterFields(
@@ -238,6 +268,25 @@ export function DataTable<T>({
         });
     }, [columns, onEdit, onDelete, onView, extraActionItems]);
 
+    const hasStickyGrandTotal = React.useMemo(() => {
+        const columnKey = (column: (typeof columnsWithActions)[number]) => {
+            if ('id' in column && column.id) {
+                return String(column.id);
+            }
+            if ('accessorKey' in column && column.accessorKey) {
+                return String(column.accessorKey);
+            }
+            return '';
+        };
+        const keys = columnsWithActions.map(columnKey);
+        const actionsIndex = keys.lastIndexOf('actions');
+        const grandTotalIndex = keys.indexOf('grand_total');
+
+        return (
+            actionsIndex > 0 && grandTotalIndex === actionsIndex - 1
+        );
+    }, [columnsWithActions]);
+
     const table = useReactTable({
         data,
         columns: columnsWithActions,
@@ -316,14 +365,15 @@ export function DataTable<T>({
                     } else if (typeof column.header === 'string') {
                         columnKey = column.header;
                     }
-                    const isActions = columnKey === 'actions';
-
                     return (
                         <TableCell
                             key={`${rowKey}-${columnKey}`}
                             className={cn(
                                 'border-border',
-                                isActions && STICKY_ACTIONS_CELL,
+                                stickyCellClass(
+                                    columnKey,
+                                    hasStickyGrandTotal,
+                                ),
                             )}
                         >
                             <Skeleton className="h-4 w-full bg-muted" />
@@ -340,13 +390,15 @@ export function DataTable<T>({
                 className="hover:bg-muted/50"
             >
                 {row.getVisibleCells().map((cell) => {
-                    const isActions = cell.column.id === 'actions';
                     return (
                         <TableCell
                             key={cell.id}
                             className={cn(
                                 'border-border px-2 py-1.5',
-                                isActions && STICKY_ACTIONS_CELL,
+                                stickyCellClass(
+                                    cell.column.id,
+                                    hasStickyGrandTotal,
+                                ),
                             )}
                         >
                             {flexRender(
@@ -435,15 +487,25 @@ export function DataTable<T>({
                         {table.getHeaderGroups().map((headerGroup) => (
                             <TableRow key={headerGroup.id}>
                                 {headerGroup.headers.map((header) => {
-                                    const isActions =
-                                        header.column.id === 'actions';
                                     return (
                                         <TableHead
                                             key={header.id}
+                                            data-sticky-column={
+                                                header.column.id ===
+                                                    'grand_total' &&
+                                                hasStickyGrandTotal
+                                                    ? 'grand_total'
+                                                    : header.column.id ===
+                                                        'actions'
+                                                      ? 'actions'
+                                                      : undefined
+                                            }
                                             className={cn(
                                                 'h-9 border-border px-2 py-1.5 text-xs select-none',
-                                                isActions &&
-                                                    STICKY_ACTIONS_HEAD,
+                                                stickyHeadClass(
+                                                    header.column.id,
+                                                    hasStickyGrandTotal,
+                                                ),
                                             )}
                                         >
                                             {header.isPlaceholder

--- a/tests/e2e/purchase-orders/purchase-order.spec.ts
+++ b/tests/e2e/purchase-orders/purchase-order.spec.ts
@@ -165,4 +165,23 @@ test.describe('Purchase Orders Module', () => {
         await expect(itemDialog.getByRole('combobox', { name: 'Product' })).toContainText(product.name);
         await expect(itemDialog.getByRole('combobox', { name: 'Unit' })).toContainText(unit.name);
     });
+
+    test('Grand Total header is sticky left of Actions', async ({ page }) => {
+        await page.goto('/purchase-orders');
+        await page.waitForResponse(
+            (response) =>
+                response.url().includes('/api/purchase-orders') &&
+                response.request().method() === 'GET',
+        );
+
+        const grandTotalHead = page.locator(
+            'thead [data-sticky-column="grand_total"]',
+        );
+        const actionsHead = page.locator('thead [data-sticky-column="actions"]');
+
+        await expect(grandTotalHead).toBeVisible();
+        await expect(actionsHead).toBeVisible();
+        await expect(grandTotalHead).toHaveCSS('position', 'sticky');
+        await expect(actionsHead).toHaveCSS('position', 'sticky');
+    });
 });


### PR DESCRIPTION
## What was done
- Pin Grand Total sticky immediately left of Actions when that is the column order (purchase orders, credit notes).
- Invoice/bill tables keep Amount Due between Grand Total and Actions, so Grand Total is not sticky there.
- E2E on `/purchase-orders` asserts both sticky columns.
- Visual-audit BACKLOG/FINDINGS marked for PO-05.

## Files changed
- `resources/js/components/common/DataTableCore.tsx` — sticky helpers, adjacency check, `right-14` offset
- `tests/e2e/purchase-orders/purchase-order.spec.ts` — sticky column assertions
- `docs/visual-audit/BACKLOG.md` / `FINDINGS.md` — PO-05 status

## Verification
- [ ] E2E purchase-orders (CI)
- [ ] Visual: Grand Total stays visible when scrolling horizontally on PO table

## Next steps
- SHELL-12 (home widget list) after this PR exists — separate MR

Do not wait for CI. One theme = one MR.