### PR TITLE
feat: enrich home dashboard widgets (SHELL-12)

### DIFF
--- a/docs/user-guide-dashboard.md
+++ b/docs/user-guide-dashboard.md
@@ -17,7 +17,7 @@ Permission: `dashboard`.
 
 | Menu | URL | Fungsi |
 |------|-----|--------|
-| Dashboard | `/dashboard` (root `/` mengarah ke sini) | Empat kartu total + area placeholder |
+| Dashboard | `/dashboard` (root `/` mengarah ke sini) | Empat kartu total + shortcut operasional + mix master data |
 
 ## 1. Mengakses Dashboard
 
@@ -38,9 +38,16 @@ Permission: `dashboard`.
 
 Angka diformat sesuai pengaturan regional aplikasi.
 
-## 3. Area Placeholder
+## 3. Widget Operasional
 
-Di bawah kartu, ada area konten placeholder (pola dekoratif). Ini **bukan** grafik keuangan. Untuk KPI keuangan, gunakan **Financial Dashboard**.
+Di bawah kartu ada dua panel:
+
+| Panel | Isi |
+|-------|-----|
+| Shortcuts | Deep-link ke My Approvals, Purchase Orders, dan Stock Monitor |
+| Master data mix | Bar relatif dari empat total yang sama (bukan KPI keuangan) |
+
+Untuk KPI keuangan, gunakan **Financial Dashboard**.
 
 ## 4. Sumber Data & Error
 

--- a/docs/visual-audit/BACKLOG.md
+++ b/docs/visual-audit/BACKLOG.md
@@ -1,6 +1,6 @@
 # Visual Audit — Backlog
 
-**Last updated:** 2026-08-18  
+**Last updated:** 2026-08-19  
 **Source:** multimodal-looker Wave 0–1  
 **Policy:** T1–T5 + EX themes on main. No **mass** Wave 2 (85 leaves). Prefer selective re-smoke via `VISUAL_AUDIT_PRESET` / `VISUAL_AUDIT_ROUTES`.
 
@@ -54,9 +54,9 @@
 
 | ID | Pri | Item | Notes |
 |----|-----|------|-------|
-| PO-05 | P2 | Grand Total column visibility | **in this MR** — sticky when `grand_total` is immediately left of Actions (PO, credit notes; not invoice/bill Amount Due) |
+| PO-05 | P2 | Grand Total column visibility | **merged #107** — sticky when `grand_total` is immediately left of Actions (PO, credit notes; not invoice/bill Amount Due) |
 | BS-01 | P2 | Compare “None” label opacity | **merged #102** — labeled Fiscal Year / Compare; None muted |
-| SHELL-12 | P3 | Home stub vs financial dashboard | **product: enrich `/dashboard`** — charts/widgets in placeholder; keep separate FD route/permission |
+| SHELL-12 | P3 | Home stub vs financial dashboard | **in this MR** — shortcuts + master-data mix; keep separate FD route/permission |
 | FD-02 | P1 | FY “Select…” while KPIs full | **merged #104** |
 
 ## Implementation rules

--- a/docs/visual-audit/FINDINGS.md
+++ b/docs/visual-audit/FINDINGS.md
@@ -36,7 +36,7 @@
 | SHELL-09 | P2 | Deep nav | Long nested lists; active child hard to see |
 | SHELL-10 | P2 | CRUD | Checkbox without bulk action UX |
 | SHELL-11 | P2 | DataTable | Pagination weak in empty footer zone |
-| SHELL-12 | P3 | DASH vs FD | **product:** enrich `/dashboard` widgets; do not merge with financial dashboard |
+| SHELL-12 | P3 | DASH vs FD | **in this MR:** shortcuts + master-data mix; do not merge with financial dashboard |
 
 **Material shared-shell count:** 11 (≥3 threshold).
 

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -171,7 +171,7 @@ export default function Dashboard() {
             </div>
 
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <Card>
+                <Card data-testid="dashboard-shortcuts">
                     <CardHeader>
                         <CardTitle>Shortcuts</CardTitle>
                     </CardHeader>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,12 +1,20 @@
 import DashboardPageShell from '@/components/common/DashboardPageShell';
 import { KpiCard } from '@/components/common/KpiCard';
-import { Card, CardContent } from '@/components/ui/card';
-import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import axios from '@/lib/axios';
 import { type BreadcrumbItem } from '@/types';
 import { formatNumberByRegionalSettings } from '@/utils/number-format';
 import { useQuery } from '@tanstack/react-query';
-import { Boxes, Building2, Users, Warehouse } from 'lucide-react';
+import {
+    Boxes,
+    Building2,
+    ClipboardCheck,
+    PackageSearch,
+    ShoppingCart,
+    Users,
+    Warehouse,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -72,11 +80,61 @@ export default function Dashboard() {
         },
     ] as const;
 
+    const shortcuts = [
+        {
+            title: 'My Approvals',
+            href: '/my-approvals',
+            description: 'Review pending requests',
+            icon: ClipboardCheck,
+        },
+        {
+            title: 'Purchase Orders',
+            href: '/purchase-orders',
+            description: 'Open the PO list',
+            icon: ShoppingCart,
+        },
+        {
+            title: 'Stock Monitor',
+            href: '/stock-monitor',
+            description: 'On-hand quantity by warehouse',
+            icon: PackageSearch,
+        },
+    ] as const;
+
+    const composition = [
+        {
+            key: 'customers',
+            label: 'Customers',
+            value: totals.customers,
+            barClass: 'bg-blue-500',
+        },
+        {
+            key: 'employees',
+            label: 'Employees',
+            value: totals.employees,
+            barClass: 'bg-emerald-500',
+        },
+        {
+            key: 'suppliers',
+            label: 'Suppliers',
+            value: totals.suppliers,
+            barClass: 'bg-amber-500',
+        },
+        {
+            key: 'assets',
+            label: 'Assets',
+            value: totals.assets,
+            barClass: 'bg-indigo-500',
+        },
+    ] as const;
+
+    const maxComposition = Math.max(...composition.map((row) => row.value), 1);
+
     return (
         <DashboardPageShell
             title="Dashboard"
             heading="Dashboard"
-            description="At-a-glance entity counts across customers, people, suppliers, and assets."
+            description="At-a-glance entity counts, operational shortcuts, and master-data mix. Financial KPIs stay on Financial Overview."
             breadcrumbs={breadcrumbs}
             isLoading={isLoading}
             isError={isError}
@@ -112,15 +170,64 @@ export default function Dashboard() {
                       ))}
             </div>
 
-            <Card className="relative min-h-[40vh] overflow-hidden border-dashed">
-                <CardContent className="relative flex min-h-[40vh] items-center justify-center p-0">
-                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/15 dark:stroke-neutral-100/15" />
-                    <p className="relative z-10 max-w-sm px-6 text-center text-sm text-muted-foreground">
-                        More operational widgets will appear here. Use Financial
-                        Overview and module dashboards for detailed KPIs.
-                    </p>
-                </CardContent>
-            </Card>
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Shortcuts</CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid gap-2">
+                        {shortcuts.map((item) => (
+                            <Link
+                                key={item.href}
+                                to={item.href}
+                                className="flex items-start gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-accent"
+                            >
+                                <item.icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                                <span className="min-w-0">
+                                    <span className="block text-sm font-medium">
+                                        {item.title}
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                        {item.description}
+                                    </span>
+                                </span>
+                            </Link>
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Master data mix</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {composition.map((row) => (
+                            <div key={row.key} className="space-y-1">
+                                <div className="flex items-center justify-between text-sm">
+                                    <span>{row.label}</span>
+                                    <span className="tabular-nums text-muted-foreground">
+                                        {formatNumberByRegionalSettings(
+                                            row.value,
+                                        )}
+                                    </span>
+                                </div>
+                                <div className="h-2 overflow-hidden rounded-full bg-muted">
+                                    <div
+                                        className={`h-full rounded-full ${row.barClass}`}
+                                        style={{
+                                            width: `${(row.value / maxComposition) * 100}%`,
+                                        }}
+                                    />
+                                </div>
+                            </div>
+                        ))}
+                        <p className="text-xs text-muted-foreground">
+                            Operational counts only. Financial KPIs stay on
+                            Financial Overview.
+                        </p>
+                    </CardContent>
+                </Card>
+            </div>
         </DashboardPageShell>
     );
 }

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -205,7 +205,7 @@ export default function Dashboard() {
                             <div key={row.key} className="space-y-1">
                                 <div className="flex items-center justify-between text-sm">
                                     <span>{row.label}</span>
-                                    <span className="tabular-nums text-muted-foreground">
+                                    <span className="text-muted-foreground tabular-nums">
                                         {formatNumberByRegionalSettings(
                                             row.value,
                                         )}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -196,7 +196,7 @@ export default function Dashboard() {
                     </CardContent>
                 </Card>
 
-                <Card>
+                <Card data-testid="dashboard-mix">
                     <CardHeader>
                         <CardTitle>Master data mix</CardTitle>
                     </CardHeader>

--- a/task.md
+++ b/task.md
@@ -1,8 +1,8 @@
 # task.md — Active Session Handoff
 
-**Last updated:** 2026-08-18  
-**Current milestone:** Visual residuals after product call — **PO-05 next**  
-**Branch:** `main`  
+**Last updated:** 2026-08-19  
+**Current milestone:** Visual residuals after product call — **SHELL-12 next**  
+**Branch:** `main` @ `76ac5477` (#107 merged)  
 **Open PRs:** none  
 **Vision session:** multimodal-looker `ses_02021a5c2ffeaD0HIIg6ymhnEW`
 
@@ -14,12 +14,12 @@
 
 ## Product call (2026-08-18)
 
-- **PO-05:** pin **Grand Total** sticky, immediately left of Actions. Scope: purchase orders; siblings (invoices/bills) if they share the column pattern.  
+- **PO-05:** pin **Grand Total** sticky, immediately left of Actions. Landed **#107**.  
 - **SHELL-12 / DASH-01:** **enrich `/dashboard`** (charts/widgets in the placeholder). Keep `/financial-dashboard` and separate permissions. Do **not** redirect `/` to FD.
 
 ## Done on main
 
-- T1–T5 · EX · #101–#105 (incl. FD-02, parked handoff)  
+- T1–T5 · EX · #101–#107 (incl. FD-02, park, product call, PO-05)  
 - Keep `e2e/` untracked
 
 ## Do not
@@ -28,17 +28,17 @@
 - Commit `e2e/`  
 - Wait on CI  
 - >3 tools/turn  
-- Merge home into financial dashboard
+- Merge home into financial dashboard  
+- Redirect `/` to FD
 
 ## Recommended next step
 
-1. **PO-05 first** — one `feat/*` or `fix/*` MR: sticky money column left of Actions on PO table (then siblings).  
-2. **SHELL-12 second** — separate MR: home widgets (needs a short widget list: e.g. counts stay + 1–2 charts or deep-links). Do not start until PO-05 PR exists.  
-3. Optional: `VISUAL_AUDIT_PRESET=exceptions` locally — do not commit PNGs.
+1. **SHELL-12** — one `feat/*` MR from `main`: home widgets. Confirm widget list before coding. Default proposal: keep 4 count cards + fill placeholder with 1–2 charts and/or deep-links (not a copy of financial dashboard).  
+2. Optional: `VISUAL_AUDIT_PRESET=exceptions` locally — do not commit PNGs.
 
 ## Continuation Prompt
 
 ```
-Read task.md. Product call done: PO-05 sticky Grand Total next; SHELL-12 enrich /dashboard after that.
-Do not mass Wave 2. Keep e2e/ untracked. One theme = one MR.
+Read task.md. #107 merged. Next: SHELL-12 enrich /dashboard (separate MR). Confirm widget list first.
+Do not mass Wave 2. Keep e2e/ untracked. One theme = one MR. Do not wait CI. Do not redirect / to FD.
 ```

--- a/tests/e2e/dashboards/dashboard-totals.spec.ts
+++ b/tests/e2e/dashboards/dashboard-totals.spec.ts
@@ -83,4 +83,29 @@ test.describe('Dashboard', () => {
 
     await expect(page).toHaveTitle(/Dashboard/, { timeout: 10000 });
   });
+
+  test('dashboard shows operational shortcuts and mix widget', async ({
+    page,
+  }) => {
+    await login(page, undefined, undefined, { requireDashboard: false });
+
+    await page.goto('/dashboard');
+    await page.waitForResponse(
+      (r) => r.url().includes('/api/dashboard') && r.status() < 400,
+    );
+
+    await expect(
+      page.getByRole('link', { name: /My Approvals/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /Purchase Orders/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /Stock Monitor/ }),
+    ).toBeVisible();
+    await expect(page.getByText('Master data mix')).toBeVisible();
+    await expect(
+      page.getByText(/Financial KPIs stay on Financial Overview/),
+    ).toBeVisible();
+  });
 });

--- a/tests/e2e/dashboards/dashboard-totals.spec.ts
+++ b/tests/e2e/dashboards/dashboard-totals.spec.ts
@@ -94,14 +94,15 @@ test.describe('Dashboard', () => {
       (r) => r.url().includes('/api/dashboard') && r.status() < 400,
     );
 
+    const shortcuts = page.getByTestId('dashboard-shortcuts');
     await expect(
-      page.getByRole('link', { name: /My Approvals/ }),
+      shortcuts.getByRole('link', { name: 'My Approvals' }),
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: /Purchase Orders/ }),
+      shortcuts.getByRole('link', { name: 'Purchase Orders' }),
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: /Stock Monitor/ }),
+      shortcuts.getByRole('link', { name: 'Stock Monitor' }),
     ).toBeVisible();
     await expect(page.getByText('Master data mix')).toBeVisible();
     await expect(

--- a/tests/e2e/dashboards/dashboard-totals.spec.ts
+++ b/tests/e2e/dashboards/dashboard-totals.spec.ts
@@ -104,9 +104,13 @@ test.describe('Dashboard', () => {
     await expect(
       shortcuts.getByRole('link', { name: 'Stock Monitor' }),
     ).toBeVisible();
-    await expect(page.getByText('Master data mix')).toBeVisible();
+    const mix = page.getByTestId('dashboard-mix');
+    await expect(mix.getByText('Master data mix')).toBeVisible();
     await expect(
-      page.getByText(/Financial KPIs stay on Financial Overview/),
+      mix.getByText(
+        'Operational counts only. Financial KPIs stay on Financial Overview.',
+        { exact: true },
+      ),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## What was done
- Replaced the home dashboard placeholder with operational shortcuts (My Approvals, Purchase Orders, Stock Monitor) and a master-data mix chart from existing totals.
- Four count cards unchanged. Financial dashboard route and permission stay separate. No redirect of `/` to FD.

## Files changed
- `resources/js/pages/dashboard.tsx` — shortcuts + mix widgets
- `tests/e2e/dashboards/dashboard-totals.spec.ts` — widget assertions
- `docs/user-guide-dashboard.md` — widget section
- `docs/visual-audit/BACKLOG.md` / `FINDINGS.md` — SHELL-12 status
- `task.md` — handoff

## Verification
- [ ] E2E dashboards (CI)
- [ ] Visual: `/dashboard` no longer shows empty dashed placeholder

## Next steps
- Optional visual-audit exceptions locally — do not commit PNGs

Do not wait for CI. One theme = one MR.